### PR TITLE
Printing clock ticks since initialization in kernel logs - branch dbg-mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,10 +45,8 @@ nanvix-iso/*
 # C Tags
 tags
 
-# ISO Images
+# Images
 nanvix.iso
-nanvix-iso/*
-
 *.img
 
 # Exceptions.

--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -231,6 +231,7 @@
 	 * @name Formated Output Functions
 	 */
 	/**@{*/
+	PUBLIC int itoa(char *str, unsigned num, int base); 
 	EXTERN int kvsprintf(char *, const char *, va_list);
 	EXTERN void chkout(dev_t);
 	EXTERN void kprintf(const char *, ...);

--- a/src/kernel/dev/klog/klog.c
+++ b/src/kernel/dev/klog/klog.c
@@ -20,16 +20,18 @@
 
 #include <nanvix/config.h>
 #include <nanvix/const.h>
+#include <nanvix/debug.h>
 #include <nanvix/dev.h>
 #include <nanvix/klib.h>
-#include <nanvix/debug.h>
-#include <sys/types.h>
+#include <nanvix/syscall.h> 
+#include <sys/types.h>  
 
 /* Error checking. */
 #if KLOG_SIZE > KBUFFER_SIZE
 	#error "KLOG_SIZE must be smaller than or equal to KBUFFER_SIZE"
 #endif
 
+#define TL_CONST 3 
 /**
  * @brief Kernel log.
  */
@@ -79,6 +81,50 @@ PRIVATE const char *print_code(const char *buffer, int *n, int *head, int *tail,
 	return skip_code(buffer,n);
 }
 
+/** 
+ * @brief Add clock ticks to klog.buffer 
+ *  
+ * @param head, tail    Pointers on buffer head and tail 
+ * @param char_printed  Number of chaf added to buffer for log_level (0 or (TL_CONST + size of int returned by sys_gticks())) 
+ */ 
+PRIVATE void print_ticks(int *head, int *tail, int *char_printed) 
+{ 
+  /* loop variables */ 
+  int i,j; 
+ 
+  /* temporary buffers */ 
+  char string_ticks[sizeof(int)*8 + 1] = ""; 
+  char string_ticks_const[TL_CONST + 1] = " - "; 
+  char buffer[sizeof(int)*8 + TL_CONST + 1]; 
+ 
+  /* compute clock ticks */ 
+  int ticks_lenght = itoa(string_ticks,(unsigned)sys_gticks(),'d'); 
+ 
+  /* put ticks in temporary buffer */ 
+  for(j=0;j<ticks_lenght;j++) 
+  { 
+    buffer[j] = string_ticks[j]; 
+  } 
+ 
+  /* put esthetic in temporary buffer */ 
+  for(i=0;i<TL_CONST;i++) 
+  { 
+    buffer[i + ticks_lenght] = string_ticks_const[i]; 
+  } 
+ 
+  /* Copy data to ring buffer */ 
+  for (i=0;i<(ticks_lenght + TL_CONST);i++) 
+  { 
+    klog.buffer[*tail] = buffer[i]; 
+    *tail = (*tail + 1)&(KLOG_SIZE - 1); 
+     
+    if (*tail == *head) 
+      *head = *head + 1; 
+  } 
+  /* number of characters added to buffer for ticks printing */ 
+  *char_printed =+ (ticks_lenght + TL_CONST); 
+} 
+
 
 /**
  * @brief Writes to kernel log.
@@ -106,6 +152,10 @@ PUBLIC ssize_t klog_write(unsigned minor, const char *buffer, size_t n)
 
 	/* If there is a log_level code, add it in buffer and skip it */
 	p = print_code(buffer,&lenght,&head,&tail,&char_printed);
+
+	  /* if a code had been printed, then clock ticks since initialization are printed too */ 
+     if (char_printed) 
+        print_ticks(&head,&tail,&char_printed); 
 	
 	/* Copy data to ring buffer. */
 	while (lenght-- > 0)

--- a/src/kernel/lib/kvsprintf.c
+++ b/src/kernel/lib/kvsprintf.c
@@ -29,7 +29,7 @@
  * 
  * @returns The length of the output string.
  */
-PRIVATE int itoa(char *str, unsigned num, int base)
+PUBLIC int itoa(char *str, unsigned num, int base)
 {
 	char *b = str;
 	char *p, *p1, *p2;

--- a/src/kernel/sys/ps.c
+++ b/src/kernel/sys/ps.c
@@ -20,44 +20,11 @@
 #include <nanvix/klib.h>
 #include <nanvix/pm.h>
 
-void reverse(char* s)
-{
-	int i, j;
-	char c;
-
-	for (i = 0, j = kstrlen(s)-1; i<j; i++, j--)
-	{
-		c = s[i];
-		s[i] = s[j];
-		s[j] = c;
-	}
-}
-
-void itoa(int n, char* s)
-{
-	int i, sign;
-
-	if ((sign = n) < 0) 
-		n = -n;
-
-	i = 0;
-	do
-	{
-		s[i++] = n % 10 + '0';
-	} while ((n /= 10) > 0);
-
-	if (sign < 0)
-		s[i++] = '-';
-	
-	s[i] = '\0';
-	reverse(s);
-}
-
 void prepareValue(int value, char* s, int padding)
 {
 	int i,len,size;
 
-	itoa(value, s);
+    itoa(s,value,'d'); 
 	len = padding - kstrlen(s);
 
 	size = kstrlen(s);


### PR DESCRIPTION
Useful for debug.
It's only printed when a log_level is specified. That way it's not printed in early boot console.
Whenever klog_write is called with a specified log_level, sys_gticks() is called and the result is printed

To do so, itoa() has to be swapped as a public method, now defined in klib and kvsprintf.

Also little fixes, .gitignore contained a duplicate on this branch and a log_level was printed in the boot console