### PR TITLE
Printing clock ticks since initialization in kernel logs

### DIFF
--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -231,6 +231,7 @@
 	 */
 	/**@{*/
 	EXTERN int kvsprintf(char *, const char *, va_list);
+	PUBLIC int itoa(char *str, unsigned num, int base);
 	EXTERN void chkout(dev_t);
 	EXTERN void kprintf(const char *, ...);
 	/**@}*/

--- a/src/kernel/lib/kvsprintf.c
+++ b/src/kernel/lib/kvsprintf.c
@@ -29,7 +29,7 @@
  * 
  * @returns The length of the output string.
  */
-PRIVATE int itoa(char *str, unsigned num, int base)
+PUBLIC int itoa(char *str, unsigned num, int base)
 {
 	char *b = str;
 	char *p, *p1, *p2;

--- a/src/kernel/sys/ps.c
+++ b/src/kernel/sys/ps.c
@@ -20,44 +20,11 @@
 #include <nanvix/klib.h>
 #include <nanvix/pm.h>
 
-void reverse(char* s)
-{
-	int i, j;
-	char c;
-
-	for (i = 0, j = kstrlen(s)-1; i<j; i++, j--)
-	{
-		c = s[i];
-		s[i] = s[j];
-		s[j] = c;
-	}
-}
-
-void itoa(int n, char* s)
-{
-	int i, sign;
-
-	if ((sign = n) < 0) 
-		n = -n;
-
-	i = 0;
-	do
-	{
-		s[i++] = n % 10 + '0';
-	} while ((n /= 10) > 0);
-
-	if (sign < 0)
-		s[i++] = '-';
-	
-	s[i] = '\0';
-	reverse(s);
-}
-
 void prepareValue(int value, char* s, int padding)
 {
 	int i,len,size;
 
-	itoa(value, s);
+	itoa(s,value,'d');
 	len = padding - kstrlen(s);
 
 	size = kstrlen(s);

--- a/tools/dev/setup-docker.sh
+++ b/tools/dev/setup-docker.sh
@@ -1,0 +1,55 @@
+# 
+# Copyright(C)  2011-2017 Pedro H. Penna   <pedrohenriquepenna@gmail.com>
+#               2016-2017 Davidson Francis <davidsondfgl@gmail.com>
+#               2016-2017 Subhra Sarkar    <rurtle.coder@gmail.com>
+#
+# This file is part of Nanvix.
+#
+# Nanvix is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Nanvix is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Nanvix.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Set working directory.
+export CURDIR=`pwd`
+export WORKDIR=$CURDIR/nanvix-toolchain
+mkdir -p $WORKDIR
+cd $WORKDIR
+
+# Retrieve the number of processor cores
+num_cores=`grep -c ^processor /proc/cpuinfo`
+
+# Get binutils, GDB and GCC.
+wget "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.bz2"
+
+
+# Export variables.
+export PREFIX=/usr/local/cross
+export TARGET=i386-elf
+sh -c "echo 'export TARGET=$TARGET' > /etc/profile.d/var.sh"
+sh -c "echo 'export PATH=$PATH:$PREFIX/bin' >> /etc/profile.d/var.sh"
+
+# Build binutils.
+tar -xjvf binutils-2.25.tar.bz2
+cd binutils-2.25/
+./configure --target=$TARGET --prefix=$PREFIX --disable-nls
+make -j$num_cores all
+make install
+
+
+# Install genisoimage.
+apt-get install genisoimage
+
+# Cleans files.
+cd $WORKDIR
+cd ..
+rm -R -f $WORKDIR


### PR DESCRIPTION
Useful for debug.
It's only printed when a log_level is specified. That way it's not printed in early boot console.
Whenever klog_write is called with a specified log_level, sys_gticks() is called and the result is printed

To do so, itoa() has to be swapped as a public method, now defined in klib and kvsprintf.