### PR TITLE
Printing clock ticks since initialization in kernel logs - branch master

### DIFF
--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -231,6 +231,7 @@
 	 */
 	/**@{*/
 	EXTERN int kvsprintf(char *, const char *, va_list);
+	PUBLIC int itoa(char *str, unsigned num, int base);
 	EXTERN void chkout(dev_t);
 	EXTERN void kprintf(const char *, ...);
 	/**@}*/

--- a/src/kernel/lib/kvsprintf.c
+++ b/src/kernel/lib/kvsprintf.c
@@ -29,7 +29,7 @@
  * 
  * @returns The length of the output string.
  */
-PRIVATE int itoa(char *str, unsigned num, int base)
+PUBLIC int itoa(char *str, unsigned num, int base)
 {
 	char *b = str;
 	char *p, *p1, *p2;

--- a/src/kernel/sys/ps.c
+++ b/src/kernel/sys/ps.c
@@ -20,44 +20,11 @@
 #include <nanvix/klib.h>
 #include <nanvix/pm.h>
 
-void reverse(char* s)
-{
-	int i, j;
-	char c;
-
-	for (i = 0, j = kstrlen(s)-1; i<j; i++, j--)
-	{
-		c = s[i];
-		s[i] = s[j];
-		s[j] = c;
-	}
-}
-
-void itoa(int n, char* s)
-{
-	int i, sign;
-
-	if ((sign = n) < 0) 
-		n = -n;
-
-	i = 0;
-	do
-	{
-		s[i++] = n % 10 + '0';
-	} while ((n /= 10) > 0);
-
-	if (sign < 0)
-		s[i++] = '-';
-	
-	s[i] = '\0';
-	reverse(s);
-}
-
 void prepareValue(int value, char* s, int padding)
 {
 	int i,len,size;
 
-	itoa(value, s);
+	itoa(s,value,'d');
 	len = padding - kstrlen(s);
 
 	size = kstrlen(s);


### PR DESCRIPTION
Useful for debug.
It's only printed when a log_level is specified. That way it's not printed in early boot console.
Whenever klog_write is called with a specified log_level, sys_gticks() is called and the result is printed

To do so, itoa() has to be swapped as a public method, now defined in klib and kvsprintf.