### PR TITLE
First Travis-CI implementation using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: C
+
+services:
+  - docker
+
+before_install:
+- docker build -t turbolay/launchnanvix --build-arg BRANCH=$TRAVIS_BRANCH .
+
+script:
+- docker run turbolay/launchnanvix /bin/sh -c "cd /root/nanvix; make nanvix > /dev/null"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# compilenv is a pre-compiled docker image containing all binaries dependancies for nanvix
+FROM turbolay/nanvix:compilenv
+
+MAINTAINER turbolay "https://github.com/turbolay"
+
+# Setting up ENV variable for checkout on updated branch
+ARG BRANCH=local
+ENV BRANCH ${BRANCH}
+
+# Pull & checkout to last updated branch of nanvix
+RUN git clone --branch=$BRANCH https://github.com/nanvix/nanvix.git /root/nanvix
+
+# Command below would be a better implementation than ENV variable but it's always returning "master" on Docker
+# RUN git checkout $(git branch --sort=-committerdate | grep '*' | awk -F " " '{print $2}')
+
+# Make port 4567 listenable for Travis-CI
+EXPOSE 4567


### PR DESCRIPTION
Travis-CI implementation, working like that:
- A compiled image containing all binaries is stored on Docker hub: https://hub.docker.com/r/turbolay/nanvix/tags/
- At each push, the file .travis.yml will be triggered
- This will build the Docker Image specified in the file Docker using as base environment the first compiled image (by pulling it), which by the end tries to compile nanvix

If compilation is a success (resp. failure), travis-ci will return a success (resp. failure)

A Travis-CI account needs now to be set-up by the organisation.