### PR TITLE
First Travis-CI implementation (Equivalent to #147 but for dev branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: C
+
+services:
+  - docker
+
+before_install:
+- docker build -t turbolay/launchnanvix --build-arg BRANCH=$TRAVIS_BRANCH .
+
+script:
+- docker run turbolay/launchnanvix /bin/sh -c "cd /root/nanvix; make nanvix > /dev/null"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# compilenv is a pre-compiled docker image containing all binaries dependancies for nanvix
+FROM turbolay/nanvix:compilenv
+
+MAINTAINER turbolay "https://github.com/turbolay"
+
+# Setting up ENV variable for checkout on updated branch
+ARG BRANCH=local
+ENV BRANCH ${BRANCH}
+
+# Pull & checkout to last updated branch of nanvix
+RUN git clone --branch=$BRANCH https://github.com/nanvix/nanvix.git /root/nanvix
+
+# Command below would be a better implementation than ENV variable but it's always returning "master" on Docker
+# RUN git checkout $(git branch --sort=-committerdate | grep '*' | awk -F " " '{print $2}')
+
+# Make port 4567 listenable for Travis-CI
+EXPOSE 4567


### PR DESCRIPTION
Travis-CI will now tries to compil lastest updated branch of nanvix at every push. It works through 2 Docker images, one already compiled on Docker Hub and the other is getting built using Dockerfile on this repo.