### PR TITLE
Toolchain submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "doc"]
 	path = doc
 	url = https://github.com/nanvix/documentation
+[submodule "tools/dev/toolchain/i386"]
+	path = tools/dev/toolchain/i386
+	url = https://github.com/nanvix/toolchain
+	branch = master

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -43,7 +43,7 @@ sh -c "echo 'export TARGET=$TARGET' > /etc/profile.d/var.sh"
 sh -c "echo 'export PATH=$PATH:$PREFIX/bin' >> /etc/profile.d/var.sh"
 
 # Build binutils.
-cd binutils-2.25/
+cd binutils*/
 ./configure --target=$TARGET --prefix=$PREFIX --disable-nls
 make -j$num_cores all
 make install
@@ -52,7 +52,7 @@ git clean -f -d
 
 # Build GCC.
 cd $WORKDIR
-cd gcc-5.3.0/
+cd gcc*/
 ./contrib/download_prerequisites
 ./configure --target=$TARGET --prefix=$PREFIX --disable-nls --enable-languages=c --without-headers
 make -j$num_cores all-gcc
@@ -62,7 +62,7 @@ git clean -f -d
 
 # Build GDB.
 cd $WORKDIR
-cd gdb-7.11/
+cd gdb*/
 ./configure --target=$TARGET --prefix=$PREFIX --with-auto-load-safe-path=/
 make -j$num_cores
 make install

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -54,7 +54,9 @@ git clean -f -d
 cd $WORKDIR
 cd gcc*/
 ./contrib/download_prerequisites
-./configure --target=$TARGET --prefix=$PREFIX --disable-nls --enable-languages=c --without-headers
+mkdir build
+cd build
+../configure --target=$TARGET --prefix=$PREFIX --disable-nls --enable-languages=c --without-headers
 make -j$num_cores all-gcc
 make install-gcc
 git checkout .

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -21,7 +21,7 @@
 
 # Set working directory.
 export CURDIR=`pwd`
-export WORKDIR=$CURDIR/toolchain/i386
+export WORKDIR=$CURDIR/tools/dev/toolchain/i386
 cd $WORKDIR
 
 # Retrieve the number of processor cores

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -21,56 +21,56 @@
 
 # Set working directory.
 export CURDIR=`pwd`
-export WORKDIR=$CURDIR/nanvix-toolchain
-mkdir -p $WORKDIR
+export WORKDIR=$CURDIR/toolchain/i386
 cd $WORKDIR
 
 # Retrieve the number of processor cores
 num_cores=`grep -c ^processor /proc/cpuinfo`
 
 # Get binutils, GDB and GCC.
-wget "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.bz2"
-wget "http://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
-wget "http://ftp.gnu.org/gnu/gdb/gdb-7.11.tar.xz"
+if [ ! "$(ls -A $WORKDIR)" ]; then
+	git submodule update --init .
+fi
 
 # Get required packages.
 apt-get install g++
 apt-get install ddd
 
 # Export variables.
-export PREFIX=/usr/local/cross
+export PREFIX=$WORKDIR/bin
 export TARGET=i386-elf
 sh -c "echo 'export TARGET=$TARGET' > /etc/profile.d/var.sh"
 sh -c "echo 'export PATH=$PATH:$PREFIX/bin' >> /etc/profile.d/var.sh"
 
 # Build binutils.
-tar -xjvf binutils-2.25.tar.bz2
 cd binutils-2.25/
 ./configure --target=$TARGET --prefix=$PREFIX --disable-nls
 make -j$num_cores all
 make install
+git checkout .
+git clean -f -d
 
 # Build GCC.
 cd $WORKDIR
-tar -xjvf gcc-5.3.0.tar.bz2
 cd gcc-5.3.0/
 ./contrib/download_prerequisites
 ./configure --target=$TARGET --prefix=$PREFIX --disable-nls --enable-languages=c --without-headers
 make -j$num_cores all-gcc
 make install-gcc
+git checkout .
+git clean -f -d
 
 # Build GDB.
 cd $WORKDIR
-tar -Jxf gdb-7.11.tar.xz
 cd gdb-7.11/
 ./configure --target=$TARGET --prefix=$PREFIX --with-auto-load-safe-path=/
 make -j$num_cores
 make install
+git checkout .
+git clean -f -d
 
 # Install genisoimage.
 apt-get install genisoimage
 
-# Cleans files.
-cd $WORKDIR
-cd ..
-rm -R -f $WORKDIR
+# Back to the current folder
+cd $CURDIR


### PR DESCRIPTION
This PR uses the "toolchain" repository as a submodule, this way, we can manage better the toolchain used and not have to deal with another servers, like gnu.org for instance.

Besides that, this makes the tools more integrated with the system once we have the 'Nanvix' organization, all the stuff related to Nanvix can be bind here in some way.

The submodule 'i386' points to the master branch in 'toolchain' repository, so we can pull Intel or OpenRISC toolchain only when needed.

--

Even so, there are some things that I would like to point:
* This approach works fine only if the user get the source by cloning from github, not from a zip file.
* Since we are using submodule we can't get rid the source files after installing toolchain, otherwise, git client will complaim that we have local changes.
* The submodule size will always grow at every change we made and the total size will be larger than current toolchain size (i.e: gcc/gdb/binutils + history).