### PR TITLE
Random function added to the kernel

### DIFF
--- a/include/nanvix/klib.h
+++ b/include/nanvix/klib.h
@@ -290,5 +290,11 @@
 	 * @brief No operation.
 	 */
 	#define noop()
+
+	/**
+	 * @name Random Functions
+	 */
+	EXTERN int krand(void);
+	EXTERN void ksrand(unsigned);
 	
 #endif /* NANVIX_KLIB_H_ */

--- a/src/kernel/lib/krand.c
+++ b/src/kernel/lib/krand.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 
+ * This file is part of Nanvix.
+ * 
+ * Nanvix is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Nanvix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Nanvix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Copyright (c) 1990 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *
+ * @brief krand() implementation.
+ */
+
+#include "krand.h"
+
+/**
+ * @brief Generates a pseudo-random number.
+ *
+ * @returns A pseudo-random integer.
+ */
+int krand(void)
+{
+	_next = (_next * 1103515245) + 12345;
+	return ((_next >> 16) & 0x7fff);
+}

--- a/src/kernel/lib/krand.h
+++ b/src/kernel/lib/krand.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 
+ * This file is part of Nanvix.
+ * 
+ * Nanvix is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Nanvix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Nanvix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file
+ *
+ * @brief Definitions for ksrand() and krand().
+ */
+#ifndef _KRAND_H_
+#define _KRAND_H_
+
+	/* Forward definitions. */
+	extern unsigned _next;
+
+#endif /* _KRAND_H_ */

--- a/src/kernel/lib/ksrand.c
+++ b/src/kernel/lib/ksrand.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 
+ * This file is part of Nanvix.
+ * 
+ * Nanvix is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Nanvix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Nanvix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file
+ *
+ * @brief ksrand() implementation.
+ */
+
+#include "krand.h"
+
+/**
+ * @brief Next pseudo-random number if the sequence.
+ */
+unsigned _next = 1;
+
+/**
+ * @brief Sets seed value for pseudo-random number generator.
+ *
+ * @param seed Pseudo-random number sequence's seed value. 
+ */
+void ksrand(unsigned seed)
+{
+	_next = seed;
+}


### PR DESCRIPTION
Foram adicionadas à biblioteca do kernel "klib" as seguintes funções:
    - krand()
    - ksrand()

Ambas originadas das funções rand() e srand() da biblioteca "stdlib".