### PR TITLE
add flag '--no-check-certificate' to wget calls 

### DIFF
--- a/tools/dev/setup-bochs.sh
+++ b/tools/dev/setup-bochs.sh
@@ -36,7 +36,7 @@ export CXXFLAGS=-pipe
 apt-get install -y libncurses5-dev
 
 # Get bochs.
-wget "http://sourceforge.net/projects/bochs/files/bochs/2.6.9/bochs-2.6.9.tar.gz"
+wget --no-check-certificate "http://sourceforge.net/projects/bochs/files/bochs/2.6.9/bochs-2.6.9.tar.gz"
 
 # Build Bochs
 tar -xvf bochs-2.6.9.tar.gz

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -24,8 +24,8 @@ mkdir -p $WORKDIR
 cd $WORKDIR
 
 # Get binutils and GCC.
-wget "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.bz2"
-wget "http://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
+wget --no-check-certificate "http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.bz2"
+wget --no-check-certificate "http://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
 
 # Get required packages.
 apt-get install -y g++ doxygen genisoimage gdb


### PR DESCRIPTION
So we can avoid problems with local invalid certificates - which happened today on a class using nanvix. :)

