### PR TITLE
i386, bug fix: no need to manually manipulate the flags

### DIFF
--- a/src/kernel/arch/x86/utilities.S
+++ b/src/kernel/arch/x86/utilities.S
@@ -247,8 +247,6 @@ switch_to:
  * Returns from fork.
  */
 fork_return:
-	notl %eax
-	andl %eax, PROC_FLAGS(%ecx)
 	movl $0, EAX(%esp)
 	jmp leave
 


### PR DESCRIPTION
This PR fixes #186, since the `BRTL` instruction already does the job.