### PR TITLE
i386, bug fix: restoring ecx register after calling processor_reload

### DIFF
--- a/src/kernel/arch/x86/utilities.S
+++ b/src/kernel/arch/x86/utilities.S
@@ -230,7 +230,9 @@ switch_to:
 	movl PROC_KESP(%ecx), %esp
 	frstor PROC_FSS(%ecx)
 
+	push %ecx
 	call processor_reload
+	pop %ecx
 	
 	btrl $PROC_NEW, PROC_FLAGS(%ecx)
 	jc fork_return


### PR DESCRIPTION
This PR fixes #185, since the `ECX` register is a scratch register and the function `processor_reload` can use it, and so, overwriting the current value.

Note that I'm not saving the `EAX` register here, because the PR #191 doesn't use it anymore.