### PR TITLE
i386, bug fix: when in crtpgdir(), changing EBP only when IDLE

### DIFF
--- a/src/kernel/mm/paging.c
+++ b/src/kernel/mm/paging.c
@@ -317,7 +317,7 @@ PUBLIC int crtpgdir(struct process *proc)
 	
 	/* Adjust stack pointers. */
 	proc->kesp = (curr_proc->kesp -(dword_t)curr_proc->kstack)+(dword_t)kstack;
-	if (KERNEL_WAS_RUNNING(curr_proc))
+	if (curr_proc == IDLE)
 	{
 		s1 = (struct intstack *) curr_proc->kesp;
 		s2 = (struct intstack *) proc->kesp;	


### PR DESCRIPTION
Since the only time that we need to change the base pointer register is when the IDLE process is creating the INIT process, we just need to check if the current process is IDLE. Therefore, this fixes #188.