### PR TITLE
increasing initrd image size

### DIFF
--- a/include/nanvix/config.h
+++ b/include/nanvix/config.h
@@ -42,7 +42,7 @@
 	#define PROC_MAX                    64 /**< Maximum number of process.         */
 	#define PROC_SIZE_MAX  (MEMORY_SIZE/8) /**< Maximum process size.              */
 	#define RAMDISK_SIZE          0x400000 /**< RAM disks size.                    */
-	#define INITRD_SIZE           0x140000 /**< Init RAM disk size.                */
+	#define INITRD_SIZE           0x300000 /**< Init RAM disk size.                */
 	#define NR_INODES                 1024 /**< Number of in-core inodes.          */
 	#define NR_SUPERBLOCKS               4 /**< Number of in-core super blocks.    */
 	#define ROOT_DEV                0x0001 /**< Root device number.                */

--- a/tools/build/build-img.sh
+++ b/tools/build/build-img.sh
@@ -159,8 +159,8 @@ else
 	copy_files hdd.img
 
 	# Build initrd image.
-	dd if=/dev/zero of=initrd.img bs=1024 count=1152
-	format initrd.img 1152 512
+	dd if=/dev/zero of=initrd.img bs=1024 count=3000
+	format initrd.img 3000 512
 	copy_files initrd.img
 	initrdsize=`stat -c %s initrd.img`
 	maxsize=`grep "INITRD_SIZE" include/nanvix/config.h | cut -d" " -f 13`


### PR DESCRIPTION
Initrd image size increased to 3M to avoid an overflow.

[https://github.com/nanvix/nanvix/issues/215](url)