### PR TITLE
Fix gdb building error

### DIFF
--- a/tools/dev/arch/setup-toolchain-i386.sh
+++ b/tools/dev/arch/setup-toolchain-i386.sh
@@ -60,7 +60,7 @@ git clean -f -d
 # Build GDB.
 cd $WORKDIR
 cd gdb*/
-./configure --target=$TARGET --prefix=$PREFIX --with-auto-load-safe-path=/
+./configure --target=$TARGET --prefix=$PREFIX --with-auto-load-safe-path=/ --with-guile=no
 make -j$num_cores
 make install
 git checkout .

--- a/tools/dev/arch/setup-toolchain-or1k.sh
+++ b/tools/dev/arch/setup-toolchain-or1k.sh
@@ -36,7 +36,7 @@ fi
 
 # Build binutils and GDB.
 cd binutils*/
-./configure --target=$TARGET --prefix=$PREFIX --disable-nls --disable-sim --with-auto-load-safe-path=/ --enable-tui
+./configure --target=$TARGET --prefix=$PREFIX --disable-nls --disable-sim --with-auto-load-safe-path=/ --enable-tui --with-guile=no
 make -j$num_cores all
 make install
 git checkout .


### PR DESCRIPTION
Regarding the issue #220 

Related bug issue : [https://sourceware.org/bugzilla/show_bug.cgi?id=21104](url)

Fix : avoid the usage of guile for gdb in our toolchains (flag passed to configure script)