### PR TITLE
or1k, bug fix: issue #222, cannot create semaphores

### DIFF
--- a/include/nanvix/syscall.h
+++ b/include/nanvix/syscall.h
@@ -292,7 +292,7 @@
 	EXTERN int sys_mkfs(const char *, const char *, int);
 
 	/* Creates or opens a semaphore */
-	EXTERN int sys_semopen(const char* name, int oflag, ...);
+	EXTERN int sys_semopen(const char* name, int oflag, mode_t mode, int value);
 
 	/* Closes a semaphore */
 	EXTERN int sys_semclose(int idx);

--- a/src/kernel/sys/semopen.c
+++ b/src/kernel/sys/semopen.c
@@ -1,5 +1,4 @@
 #include <fcntl.h>
-#include <stdarg.h>
 #include <sys/sem.h>
 #include <nanvix/klib.h>
 #include <nanvix/fs.h>
@@ -37,11 +36,8 @@ int add_table(int value, const char* semname, int idx, struct inode* seminode)
 /* TODO for error detection :
  *			ENOSPC : There is insufficient space on a storage device for the creation of the new named semaphore.
  */
-PUBLIC int sys_semopen(const char* name, int oflag, ...)
+PUBLIC int sys_semopen(const char* name, int oflag, mode_t mode, int value)
 {
-	mode_t mode;
-	int value;
-	va_list arg;				/* Variable argument */
 	int i, freeslot, semid;
 	struct inode *inode;
 	freeslot = -1;
@@ -57,12 +53,6 @@ PUBLIC int sys_semopen(const char* name, int oflag, ...)
 			/* Both O_CREAT and O_EXCL flags set */
 			if (oflag & O_EXCL)
 				return (-EEXIST);
-			
-			/* Semaphore creation if it does not exist */
-			va_start(arg, oflag);
-			mode = va_arg(arg, mode_t);
-			value = va_arg(arg, int);
-			va_end(arg);
 
 			/* Value greater than maximum */
 			if (!SEM_VALID_VALUE(value))


### PR DESCRIPTION
The kernel shouldn't use var_args between syscall entry-point and the handler, because it's highly arch dependent, furthermore, the kernel only accepts 4 registers as syscall parameters, so var_args doesn't make sense here. This PR solves the issue #222.