### PR TITLE
libm added to sbin and ubin build

### DIFF
--- a/src/lib/makefile
+++ b/src/lib/makefile
@@ -29,7 +29,7 @@ export CFLAGS += -Wno-error=parentheses
 .PHONY: libm
 
 # Builds everything.
-all: libc
+all: libc libm
 
 # Builds C library.
 libc:

--- a/src/sbin/makefile
+++ b/src/sbin/makefile
@@ -22,7 +22,7 @@
 # Toolchain configuration.
 export CFLAGS  += -Os
 export LDFLAGS += -Wl,-e,_start
-export LIBS = $(LIBDIR)/libc.a -lgcc
+export LIBS = $(LIBDIR)/libc.a -lgcc $(LIBDIR)/libm.a
 
 # Resolves conflicts
 .PHONY: foobar

--- a/src/ubin/makefile
+++ b/src/ubin/makefile
@@ -21,7 +21,7 @@
 # Toolchain configuration.
 export CFLAGS  += -Os -D_POSIX_C_SOURCE
 export LDFLAGS += -Wl,-e,_start
-export LIBS = $(LIBDIR)/libc.a -lgcc
+export LIBS = $(LIBDIR)/libc.a -lgcc $(LIBDIR)/libm.a
 
 # Conflicts.
 .PHONY: cat


### PR DESCRIPTION
Regarding issue #213.
Only adding **libm** to the makefile target and adding **lm** to the linker was needed. The port was already done.