### PR TITLE
Enable Bochs safe optimizations on master

### DIFF
--- a/tools/dev/setup-bochs.sh
+++ b/tools/dev/setup-bochs.sh
@@ -42,7 +42,7 @@ wget --no-check-certificate "http://sourceforge.net/projects/bochs/files/bochs/2
 tar -xvf bochs-2.6.9.tar.gz
 cd bochs-2.6.9/
 patch < $CURDIR/tools/dev/gdbstub.patch
-./configure --with-term --enable-gdb-stub
+./configure --with-term --enable-gdb-stub --enable-all-optimizations
 sed -i '/^\<LIBS\>/ s/$/ -lpthread/' Makefile
 make all
 make install


### PR DESCRIPTION
Reading [this page on Bochs documentation](http://bochs.sourceforge.net/doc/docbook/user/compiling.html), I found a flag that, according to Bochs changelog, enable some optimizations with improvements between 10% and 15% on performance.

This flag enables, according to Bochs developers, **only safe optimizations**, so it should not be a problem for nanvix itself.

I executed a few tests here but did not found a big improvement yet, probably the fact that I'm running  three bochs instances executing nanvix on my machine does not help. :smile: 

Please note that with this flag an error is shown about handlers chaining being not compatible with gdb stub. I do not know why this is flagged as an error, because Bochs itself compiles normally and the gdb integration works normally..Probably it should be flagged as a warning, but okay, it's safe to ignore anyway. :stuck_out_tongue: 