### PR TITLE
Update setup-toolchain.sh

### DIFF
--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -36,7 +36,7 @@ wget --no-check-certificate "http://ftp.gnu.org/gnu/binutils/$BINUTILS_TAR"
 wget --no-check-certificate "http://ftp.gnu.org/gnu/gcc/$GCC_PACKAGE/$GCC_TAR"
 
 # Get required packages.
-apt-get install -y g++ doxygen genisoimage gdb xz-utils
+apt-get install -y g++ doxygen genisoimage gdb xz-utils make
 
 # Export variables.
 export PREFIX=/usr/local/cross

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -36,7 +36,7 @@ wget --no-check-certificate "http://ftp.gnu.org/gnu/binutils/$BINUTILS_TAR"
 wget --no-check-certificate "http://ftp.gnu.org/gnu/gcc/$GCC_PACKAGE/$GCC_TAR"
 
 # Get required packages.
-apt-get install -y g++ doxygen genisoimage gdb
+apt-get install -y g++ doxygen genisoimage gdb xz-utils
 
 # Export variables.
 export PREFIX=/usr/local/cross


### PR DESCRIPTION
The xz-utils and make packages may not be installed in some distros, so it is not possible to decompress binutils and gcc and compile them. This patch adds the packages xz-utils and make to the required packages.