### PR TITLE
Fixed missing curr_proc->errno updates at dev.c file.

### DIFF
--- a/src/kernel/dev/dev.c
+++ b/src/kernel/dev/dev.c
@@ -62,11 +62,11 @@ PUBLIC int cdev_register(unsigned major, const struct cdev *dev)
 {
 	/* Invalid major number? */
 	if (major >= NR_CHRDEV)
-		return (-EINVAL);
+		return (curr_proc->errno = -EINVAL);
 	
 	/* Device already registered? */
 	if ((major == NULL_MAJOR) || (cdevsw[major] != NULL))
-		return (-EBUSY);
+		return (curr_proc->errno = -EBUSY);
 	
 	/* Register character device. */
 	cdevsw[major] = dev;
@@ -91,11 +91,11 @@ PUBLIC ssize_t cdev_write(dev_t dev, const void *buf, size_t n)
 	
 	/* Invalid device. */
 	if (cdevsw[MAJOR(dev)] == NULL)
-		return (-EINVAL);
+		return (curr_proc->errno = -EINVAL);
 	
 	/* Operation not supported. */
 	if (cdevsw[MAJOR(dev)]->write == NULL)
-		return (-ENOTSUP);
+		return (curr_proc->errno = -ENOTSUP);
 	
 	return (cdevsw[MAJOR(dev)]->write(MINOR(dev), buf, n));
 }
@@ -118,11 +118,11 @@ PUBLIC ssize_t cdev_read(dev_t dev, void *buf, size_t n)
 	
 	/* Invalid device. */
 	if (cdevsw[MAJOR(dev)] == NULL)
-		return (-EINVAL);
+		return (curr_proc->errno = -EINVAL);
 	
 	/* Operation not supported. */
 	if (cdevsw[MAJOR(dev)]->read == NULL)
-		return (-ENOTSUP);
+		return (curr_proc->errno = -ENOTSUP);
 	
 	return (cdevsw[MAJOR(dev)]->read(MINOR(dev), buf, n));
 }
@@ -138,11 +138,11 @@ PUBLIC int cdev_open(dev_t dev)
 	
 	/* Invalid device. */
 	if (cdevsw[MAJOR(dev)] == NULL)
-		return (-EINVAL);
+		return (curr_proc->errno = -EINVAL);
 	
 	/* Operation not supported. */
 	if (cdevsw[MAJOR(dev)]->open == NULL)
-		return (-ENOTSUP);
+		return (curr_proc->errno = -ENOTSUP);
 		
 	return (cdevsw[MAJOR(dev)]->open(MINOR(dev)));
 }
@@ -154,15 +154,15 @@ PUBLIC int cdev_ioctl(dev_t dev, unsigned cmd, unsigned arg)
 {	
 	/* Null device. */
 	if (MAJOR(dev) == NULL_MAJOR)
-		return (-ENODEV);
+		return (curr_proc->errno = -ENODEV);
 	
 	/* Invalid device. */
 	if (cdevsw[MAJOR(dev)] == NULL)
-		return (-EINVAL);
+		return (curr_proc->errno = -EINVAL);
 	
 	/* Operation not supported. */
 	if (cdevsw[MAJOR(dev)]->ioctl == NULL)
-		return (-ENOTSUP);
+		return (curr_proc->errno = -ENOTSUP);
 		
 	return (cdevsw[MAJOR(dev)]->ioctl(MINOR(dev), cmd, arg));
 }
@@ -183,11 +183,11 @@ PUBLIC int cdev_close(dev_t dev)
 		
 	/* Invalid device. */
 	if (cdevsw[MAJOR(dev)] == NULL)
-		return (-EINVAL);
+		return (curr_proc->errno = -EINVAL);
 	
 	/* Operation not supported. */
 	if (cdevsw[MAJOR(dev)]->close == NULL)
-		return (-ENOTSUP);
+		return (curr_proc->errno = -ENOTSUP);
 		
 	return (cdevsw[MAJOR(dev)]->close(MINOR(dev)));
 }
@@ -295,11 +295,11 @@ PUBLIC int bdev_register(unsigned major, const struct bdev *dev)
 {
 	/* Invalid major number? */
 	if (major >= NR_BLKDEV)
-		return (-EINVAL);
+		return (curr_proc->errno = -EINVAL);
 	
 	/* Device already registered? */
 	if (bdevsw[major] != NULL)
-		return (-EBUSY);
+		return (curr_proc->errno = -EBUSY);
 	
 	/* Register block device. */
 	bdevsw[major] = dev;
@@ -321,11 +321,11 @@ PUBLIC ssize_t bdev_write(dev_t dev, const char *buf, size_t n, off_t off)
 {
 	/* Invalid device. */
 	if (bdevsw[MAJOR(dev)] == NULL)
-		return (-EINVAL);
+		return (curr_proc->errno = -EINVAL);
 	
 	/* Operation not supported. */
 	if (bdevsw[MAJOR(dev)]->write == NULL)
-		return (-ENOTSUP);
+		return (curr_proc->errno = -ENOTSUP);
 	
 	return (bdevsw[MAJOR(dev)]->write(MINOR(dev), buf, n, off));
 }
@@ -344,11 +344,11 @@ PUBLIC ssize_t bdev_read(dev_t dev, char *buf, size_t n, off_t off)
 {
 	/* Invalid device. */
 	if (bdevsw[MAJOR(dev)] == NULL)
-		return (-EINVAL);
+		return (curr_proc->errno = -EINVAL);
 		
 	/* Operation not supported. */
 	if (bdevsw[MAJOR(dev)]->read == NULL)
-		return (-ENOTSUP);
+		return (curr_proc->errno = -ENOTSUP);
 	
 	return (bdevsw[MAJOR(dev)]->read(MINOR(dev), buf, n, off));
 }


### PR DESCRIPTION
**Changes**

* `dev.c`: Modified file to set *curr_proc->errno* properly in every moment that an error is found.