### PR TITLE
Setup arch linux

### DIFF
--- a/tools/dev/setup-qemu.sh
+++ b/tools/dev/setup-qemu.sh
@@ -25,7 +25,7 @@
 #
 
 # QEMU.
-export QEMU_VERSION=3.0.0-rc3
+export QEMU_VERSION=2.12.0
 
 # Set working directory.
 export CURDIR=`pwd`
@@ -36,19 +36,13 @@ cd $WORKDIR
 # Retrieve the number of processor cores
 num_cores=`grep -c ^processor /proc/cpuinfo`
 
-# Get qemu.
+# Get bochs.
 wget "http://wiki.qemu-project.org/download/qemu-$QEMU_VERSION.tar.bz2"
 
 # Get required packages.
-DIST=$(uname -rv)
-if [[ ${DIST,,} = *"ubuntu"* || ${DIST,,} = *"debian"* ]]; then
-	apt-get install libglib2.0-dev zlib1g-dev \
-		libtool libsdl2-dev libpixman-1-dev dh-autoreconf -y
-elif [[ ${DIST,,} = *"arch"* ]]; then
-	pacman -S glibz2 zlib libtool sdl2 pixman autoconf --needed
-fi
+apt-get install libglib2.0-dev zlib1g-dev libtool libsdl2-dev libpixman-1-dev dh-autoreconf -y
 
-# Build qemu
+# Build Bochs
 tar -xjvf qemu-$QEMU_VERSION.tar.bz2
 cd qemu-$QEMU_VERSION
 ./configure --target-list=i386-softmmu,or1k-softmmu,or1k-linux-user --enable-sdl

--- a/tools/dev/setup-qemu.sh
+++ b/tools/dev/setup-qemu.sh
@@ -25,7 +25,7 @@
 #
 
 # QEMU.
-export QEMU_VERSION=2.12.0
+export QEMU_VERSION=3.0.0-rc3
 
 # Set working directory.
 export CURDIR=`pwd`
@@ -36,13 +36,19 @@ cd $WORKDIR
 # Retrieve the number of processor cores
 num_cores=`grep -c ^processor /proc/cpuinfo`
 
-# Get bochs.
+# Get qemu.
 wget "http://wiki.qemu-project.org/download/qemu-$QEMU_VERSION.tar.bz2"
 
 # Get required packages.
-apt-get install libglib2.0-dev zlib1g-dev libtool libsdl2-dev libpixman-1-dev dh-autoreconf -y
+DIST=$(uname -rv)
+if [[ ${DIST,,} = *"ubuntu"* || ${DIST,,} = *"debian"* ]]; then
+	apt-get install libglib2.0-dev zlib1g-dev \
+		libtool libsdl2-dev libpixman-1-dev dh-autoreconf -y
+elif [[ ${DIST,,} = *"arch"* ]]; then
+	pacman -S glibz2 zlib libtool sdl2 pixman autoconf --needed
+fi
 
-# Build Bochs
+# Build qemu
 tar -xjvf qemu-$QEMU_VERSION.tar.bz2
 cd qemu-$QEMU_VERSION
 ./configure --target-list=i386-softmmu,or1k-softmmu,or1k-linux-user --enable-sdl

--- a/tools/dev/setup-qemu.sh
+++ b/tools/dev/setup-qemu.sh
@@ -36,13 +36,24 @@ cd $WORKDIR
 # Retrieve the number of processor cores
 num_cores=`grep -c ^processor /proc/cpuinfo`
 
-# Get bochs.
+# Get qemu.
 wget "http://wiki.qemu-project.org/download/qemu-$QEMU_VERSION.tar.bz2"
 
-# Get required packages.
-apt-get install libglib2.0-dev zlib1g-dev libtool libsdl2-dev libpixman-1-dev dh-autoreconf -y
+DIST=$(uname -rv)
 
-# Build Bochs
+case ${DIST,,} in
+    *"ubuntu"*|*"debian"*)
+	apt-get install libglib2.0-dev zlib1g-dev \
+		libtool libsdl2-dev libpixman-1-dev dh-autoreconf -y
+        ;;
+    *"arch"*)
+        pacman -S glibz2 zlib libtool sdl2 pixman autoconf --needed
+        ;;
+    *)
+        echo "Warning: your distro is not officially supported or tested by us"
+esac
+
+# Build qemu
 tar -xjvf qemu-$QEMU_VERSION.tar.bz2
 cd qemu-$QEMU_VERSION
 ./configure --target-list=i386-softmmu,or1k-softmmu,or1k-linux-user --enable-sdl

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -22,8 +22,13 @@
 # Get required packages.
 DIST=$(uname -rv)
 
-if [[ ${DIST,,} = *"ubuntu"* || ${DIST,,} = *"debian"* ]]; then
-	apt-get install g++ ddd genisoimage texinfo flex bison libncurses5-dev -y
-elif [[ ${DIST,,} = *"arch"* ]]; then
-	pacman -S gcc cdrtools texinfo flex bison ncurses --needed
-fi
+case ${DIST,,} in
+    *"ubuntu"*|*"debian"*)
+        apt-get install g++ ddd genisoimage texinfo flex bison libncurses5-dev -y
+        ;;
+    *"arch"*)
+        pacman -S gcc cdrtools texinfo flex bison ncurses --needed
+        ;;
+    *)
+        echo "Warning: your distro is not officially supported or tested by us"
+esac

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -20,4 +20,10 @@
 #
 
 # Get required packages.
-apt-get install g++ ddd genisoimage texinfo flex bison libncurses5-dev -y
+DIST=$(uname -rv)
+
+if [[ ${DIST,,} = *"ubuntu"* || ${DIST,,} = *"debian"* ]]; then
+	apt-get install g++ ddd genisoimage texinfo flex bison libncurses5-dev -y
+elif [[ ${DIST,,} = *"arch"* ]]; then
+	pacman -S gcc cdrtools texinfo flex bison ncurses --needed
+fi


### PR DESCRIPTION
**Changes**

- Modified `<setup-toolchain.sh>` and `<setup-qemu.sh>` to work properly on both debian-based or arch-based systems.
- Updated qemu version.