### PR TITLE
Add support for Arch on setup-toolchain and setup-bochs scripts

### DIFF
--- a/tools/dev/setup-bochs.sh
+++ b/tools/dev/setup-bochs.sh
@@ -32,8 +32,23 @@ cd $WORKDIR
 export CFLAGS="-pipe -O3"
 export CXXFLAGS="-pipe -O3"
 
+
 # Get required packages.
-apt-get install -y libncurses5-dev
+DIST=$(uname -rv)
+
+case ${DIST,,} in
+    *"ubuntu"*|*"debian"*)
+        apt-get install -y libncurses5-dev
+        ;;
+    *"arch"*)
+        pacman -S ncurses --needed --noconfirm
+        ;;
+    *)
+        echo "Warning: your distro is not officially supported or tested by us"
+esac
+
+
+# Get required packages.
 
 # Get bochs.
 wget --no-check-certificate "http://sourceforge.net/projects/bochs/files/bochs/2.6.9/bochs-2.6.9.tar.gz"

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -36,7 +36,18 @@ wget --no-check-certificate "http://ftp.gnu.org/gnu/binutils/$BINUTILS_TAR"
 wget --no-check-certificate "http://ftp.gnu.org/gnu/gcc/$GCC_PACKAGE/$GCC_TAR"
 
 # Get required packages.
-apt-get install -y g++ doxygen genisoimage gdb xz-utils make
+DIST=$(uname -rv)
+
+case ${DIST,,} in
+    *"ubuntu"*|*"debian"*)
+        apt-get install -y g++ doxygen genisoimage gdb xz-utils make
+        ;;
+    *"arch"*)
+        pacman -S gcc doxygen cdrtools gdb xz make --needed --noconfirm
+        ;;
+    *)
+        echo "Warning: your distro is not officially supported or tested by us"
+esac
 
 # Export variables.
 export PREFIX=/usr/local/cross


### PR DESCRIPTION
Hey. 

As I'm now an Arch user (well..Antergos, but it's based on Arch anyway)...I wanted to add support to run Nanvix on arch-based distros... and so I ported #248 from the `dev` branch to the `master` branch.

Please note that all the Ubuntu/Debian code is the same, and I adapted the code that runs on Arch to maintain the same order of the packages, so it's easier to maintain.

By the way, this is a feature commonly requested by students because a few students seem to prefer Arch, so this PR fixes that problem too.. and according to my tests everything runs fine even after this PR (well, at least on the Arch side)

Thank you!