### PR TITLE
Update the Build Procedure to Support macOS Hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
-# Nanvix [![Build Status](https://travis-ci.org/nanvix/nanvix.svg?branch=master)](https://travis-ci.org/nanvix/nanvix) [![Join us on Slack!](https://img.shields.io/badge/chat-on%20Slack-e01563.svg)](https://join.slack.com/t/nanvix/shared_invite/enQtMzY2Nzg5OTQ4NTAyLTAxMmYwOGQ0ZmU2NDg2NTJiMWU1OWVkMWJhMWY4NzMzY2E1NTIyMjNiOTVlZDFmOTcyMmM2NDljMTAzOGI1NGY)  
+# Nanvix [![Build Status](https://travis-ci.org/nanvix/nanvix.svg?branch=master)](https://travis-ci.org/nanvix/nanvix) [![Join us on Slack!](https://img.shields.io/badge/chat-on%20Slack-e01563.svg)](https://join.slack.com/t/nanvix/shared_invite/enQtMzY2Nzg5OTQ4NTAyLTAxMmYwOGQ0ZmU2NDg2NTJiMWU1OWVkMWJhMWY4NzMzY2E1NTIyMjNiOTVlZDFmOTcyMmM2NDljMTAzOGI1NGY)
 
 ## What Is Nanvix
 
-Nanvix is a Unix-like operating system written by [Pedro H. Penna](https://github.com/ppenna) for 
-educational purposes. It is designed to be simple and small, but also 
+Nanvix is a Unix-like operating system written by [Pedro H. Penna](https://github.com/ppenna) for
+educational purposes. It is designed to be simple and small, but also
 modern and fully featured.
-	
+
 ## What Hardware Is Required?
 
-Nanvix targets 32-bit x86-based PCs and only requires a floppy or 
-CD-ROM drive and 16 MB of RAM. You can run it either in a real PC 
+Nanvix targets 32-bit x86-based PCs and only requires a floppy or
+CD-ROM drive and 16 MB of RAM. You can run it either in a real PC
 or in a virtual machine, using a Live System's Image.
-	
+
 ## Building
 
-In order to build Nanvix, you will need a Linux like programming 
+### Linux-like systems
+In order to build Nanvix, you will need a Linux like programming
 environment, the x86 GCC compiler and the x86 GNU binutils.
 
-If you are running a Debian-based Linux distribution, like Ubuntu, 
+If you are running a Debian-based Linux distribution, like Ubuntu,
 you can simply run the following commands at the root directory:
 
 ```sh
@@ -28,7 +29,7 @@ sudo reboot now
 ```
 
 When done, you can build Nanvix by typing, at the root directory:
-	
+
 ```sh
 make nanvix
 ```
@@ -39,6 +40,31 @@ Or you can build a Live System's Image by typing, at the same directory:
 make image
 ```
 
+### macOS
+
+The support of Nanvix on macOS is still experimental.
+It relies on the Homebrew package manager (https://brew.sh), to get
+the necessary UNIX-like packages to build Nanvix.
+
+The general flow for building Nanvix on macOS from the root directory
+is as follows :
+
+```sh
+bash tools/dev/setup-toolchain.sh
+make TARGET=i386-elf nanvix
+make image
+```
+
+Unlike the Linux-like systems procedure, this flow does not build
+bochs from source. Instead, it installs the bochs package using brew.
+As this package does not comme with gdb-stubs support, one last step
+will be to **remove** the following line from the
+`tools/run/bochsrc.txt.pl` file :
+
+```
+gdbstub: enabled=#GDBSTUB_ENABLED#, port=1234
+```
+
 ## Running
 
 To run Nanvix, type the following command at the root directory:
@@ -46,8 +72,9 @@ To run Nanvix, type the following command at the root directory:
 ```sh
 bash tools/run/run.sh
 ```
+
 ## License and Maintainers
 
-Nanvix is a free software that is under the GPL V3 license and is 
-maintained by Pedro H. Penna. Any questions or suggestions send him an 
+Nanvix is a free software that is under the GPL V3 license and is
+maintained by Pedro H. Penna. Any questions or suggestions send him an
 email: <pedrohenriquepenna@gmail.com>

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -23,7 +23,9 @@
 	#include <sys/types.h>
 	
 	/* File types. */
-	#define S_IFMT  00170000
+    #ifndef __APPLE__
+	    #define S_IFMT  00170000
+    #endif /* __APPLE__ */
 	#define S_IFREG  0100000
 	#define S_IFBLK  0060000
 	#define S_IFDIR  0040000
@@ -37,24 +39,26 @@
 	#define S_ISFIFO(m)	(((m) & S_IFMT) == S_IFIFO) /* FIFO special file?  */
 
 	/* Mode bits. */
-	#define S_IRWXU  0700 /* Read, write, execute/search by owner.     */
-	#define S_IRUSR  0400 /* Read permission, owner.                   */
-	#define S_IWUSR  0200 /* Write permission, owner.                  */
-	#define S_IXUSR  0100 /* Execute/search permission, owner.         */
-	#define S_IRWXG   070 /* Read, write, execute/search by group.     */
-	#define S_IRGRP   040 /* Read permission, group.                   */
-	#define S_IWGRP   020 /* Write permission, group.                  */
-	#define S_IXGRP   010 /* Execute/search permission, group.         */
-	#define S_IRWXO    07 /* Read, write, execute/search by others.    */
-	#define S_IROTH    04 /* Read permission, others.                  */
-	#define S_IWOTH    02 /* Write permission, others.                 */
-	#define S_IXOTH    01 /* Execute/search permission, others.        */
-	#define S_ISUID 04000 /* Set-user-ID on execution.                 */
-	#define S_ISGID 02000 /* Set-group-ID on execution.                */
-	#define S_ISVTX 01000 /* On directories, restricted deletion flag. */
+    #ifndef __APPLE__
+        #define S_IRWXU  0700 /* Read, write, execute/search by owner.     */
+        #define S_IRUSR  0400 /* Read permission, owner.                   */
+        #define S_IWUSR  0200 /* Write permission, owner.                  */
+        #define S_IXUSR  0100 /* Execute/search permission, owner.         */
+        #define S_IRWXG   070 /* Read, write, execute/search by group.     */
+        #define S_IRGRP   040 /* Read permission, group.                   */
+        #define S_IWGRP   020 /* Write permission, group.                  */
+        #define S_IXGRP   010 /* Execute/search permission, group.         */
+        #define S_IRWXO    07 /* Read, write, execute/search by others.    */
+        #define S_IROTH    04 /* Read permission, others.                  */
+        #define S_IWOTH    02 /* Write permission, others.                 */
+        #define S_IXOTH    01 /* Execute/search permission, others.        */
+        #define S_ISUID 04000 /* Set-user-ID on execution.                 */
+        #define S_ISGID 02000 /* Set-group-ID on execution.                */
+        #define S_ISVTX 01000 /* On directories, restricted deletion flag. */
+    #endif /* __APPLE__ */
 
 #ifndef _ASM_FILE_
-	
+
 	/*
 	 * File status.
 	 */
@@ -73,17 +77,17 @@
 		time_t st_mtime;  /* Time of last data modification.                */
 		time_t st_ctime;  /* Time of last status change.                    */
 	};
-	
+
 	/*
 	 * Changes permissions of a file.
 	 */
 	extern int chmod(const char *path, mode_t mode);
-	
+
 	/*
 	 * Gets file status.
 	 */
 	extern int stat(const char *path, struct stat *buf);
-	
+
 	/*
 	 * Sets and gets the file mode creation mask.
 	 */

--- a/makefile
+++ b/makefile
@@ -79,7 +79,7 @@ documentation:
 # Builds tools.
 tools:
 	mkdir -p $(BINDIR)
-	cd $(TOOLSDIR) && $(MAKE) all
+	cd $(TOOLSDIR)/build && bash ./build-tools.sh
 
 # Cleans compilation files.
 clean:

--- a/tools/build/build-tools.sh
+++ b/tools/build/build-tools.sh
@@ -1,5 +1,5 @@
-# 
-# Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com> 
+#
+# Copyright(C) 2011-2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
 #
 # This file is part of Nanvix.
 #
@@ -17,19 +17,19 @@
 # along with Nanvix.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Toolchain configuration.
-CFLAGS    = -I $(INCDIR)/nanvix -DKERNEL_HASH=$(KEY)
-CFLAGS   += -std=c99 -pedantic-errors -fextended-identifiers
-CFLAGS   += -Wall -Wextra -Werror
-CFLAGS   += -D NDEBUG
+#! /bin/bash
 
-# Builds everything.
-all: useradd
+if [ "x$(uname -rv | grep Darwin)" == "x" ];
+then
+    cc=gcc
+else
+    # macOS compatibility stuff. Ok, that's ugly.
+    cc=$(find /usr/local/Cellar/gcc/*/bin -name "gcc-*" | grep -v ranlib | grep -v nm | grep -v "\-ar\-")
+    if [ "x$cc" == "x" ];
+    then
+        echo "Couldn't find gcc. Please run 'brew install gcc' and try again."
+        exit 1
+    fi
+fi
 
-# Builds cp.minix.
-useradd: useradd.c
-	$(CC) $(CFLAGS) $^ -o $(BINDIR)/$@
-
-# Cleans compilation files.
-clean:
-	@rm -f $(BINDIR)/useradd
+cd .. && make CC=$cc

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -17,6 +17,21 @@
 # along with Nanvix.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# macOS support
+if [ "x$(uname -rv | grep Darwin)" != "x" ];
+then
+    if [ "x$(which brew)" == "x" ];
+    then
+        echo "We only support macOS platforms that use homebrew."
+        echo "Please install homebrew (https://brew.sh/) and try again."
+        exit 1
+    fi
+
+    # Install macOS dependencies
+    brew install binutils bochs cdrtools doxygen gcc gnu-sed i386-elf-gcc
+    exit 0
+fi
+
 # Set working directory.
 export CURDIR=`pwd`
 export WORKDIR=$CURDIR/nanvix-toolchain

--- a/tools/minix/makefile
+++ b/tools/minix/makefile
@@ -17,9 +17,6 @@
 # along with Nanvix.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Toolchain
-CC = gcc
-
 # Toolchain configuration.
 CFLAGS    = -I $(INCDIR)/fs
 CFLAGS   += -std=c99 -pedantic-errors -fextended-identifiers


### PR DESCRIPTION
This allows building the educational version of Nanvix on macOS.

The main changes concern the `build-img.sh` script, as it intensively uses standard tools (`strip`, `sed`, ...) coming from either the `binutils` package or the OS itself, that macOS also provides, but with little differences that prevent from using them "as is" (macOS inherited a bunch of UNIX tools from BSD).

The workaround is to install standard (GNU/UNIX) versions of these tools using `brew`, and refer to these standard versions in the `build-img.sh` script.

Also note that, unlike the usual build procedure for Nanvix, the macOS build flow does not compile `binutils`, `gcc` and `bochs` from source, but take the standard `brew` packages instead. This eases the building procedure a lot, but prevent from connecting `gdb` to `bochs` (the default `bochs` package provided by `brew` is not configured with gdb-stubs support). This certainly could be fixed by editing the `bochs` brew formulae to pass the `--enable-gdb-stubs` option to `configure`, but it remains to be tested.