### PR TITLE
C Library Support for sleep() ad alarm()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It relies on the Homebrew package manager (https://brew.sh), to get
 the necessary UNIX-like packages to build Nanvix.
 
 The general flow for building Nanvix on macOS from the root directory
-is as follows :
+is as follows:
 
 ```sh
 bash tools/dev/setup-toolchain.sh
@@ -57,13 +57,8 @@ make image
 
 Unlike the Linux-like systems procedure, this flow does not build
 bochs from source. Instead, it installs the bochs package using brew.
-As this package does not comme with gdb-stubs support, one last step
-will be to **remove** the following line from the
-`tools/run/bochsrc.txt.pl` file :
-
-```
-gdbstub: enabled=#GDBSTUB_ENABLED#, port=1234
-```
+As this package does not come with gdb-stubs support, you cannot run
+Nanvix with `--debug` option (see details below).
 
 ## Running
 
@@ -72,6 +67,9 @@ To run Nanvix, type the following command at the root directory:
 ```sh
 bash tools/run/run.sh
 ```
+
+The script above accepts some optional parameters to configure bochs.
+Please, run `bash tools/run/run.sh --help` for more details.
 
 ## License and Maintainers
 

--- a/include/nanvix/pm.h
+++ b/include/nanvix/pm.h
@@ -213,8 +213,14 @@
 	EXTERN int issig(void);
 	EXTERN void pm_init(void);
 	EXTERN void sched(struct process *);
+
+#ifdef __NANVIX_KERNEL__
+
 	EXTERN void sleep(struct process **, int);
-	EXTERN void sndsig(struct process *, int);
+	
+#endif /* __NANVIX_KERNEL__ */
+
+    EXTERN void sndsig(struct process *, int);
 	EXTERN void wakeup(struct process **);
 	EXTERN void yield(void);
 	

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -190,7 +190,16 @@
 	extern int setuid(pid_t uid);
 	
 	extern pid_t setpgrp(void);
+
+#ifndef __NANVIX_KERNEL__
+
+    /*
+     * Puts the current process to sleep.
+     */
+    extern unsigned sleep(unsigned seconds);
 	
+#endif /* __NANVIX_KERNEL__ */
+
 	/*
 	 * Schedules file system updates.
 	 */

--- a/src/kernel/makefile
+++ b/src/kernel/makefile
@@ -51,6 +51,8 @@ OBJ = $(ASM_SRC:.S=.o) \
 # Executable file.
 EXEC = kernel
 
+CFLAGS += -D __NANVIX_KERNEL__
+
 # Linker configuration options.
 export LDFLAGS = -T arch/$(ARCH)/link.ld
 

--- a/src/lib/libc/unistd/alarm.c
+++ b/src/lib/libc/unistd/alarm.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 
+ * This file is part of Nanvix.
+ * 
+ * Nanvix is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Nanvix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Nanvix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <nanvix/syscall.h>
+#include <errno.h>
+
+/*
+ * Configures an alarm to happen at specified time.
+ */
+unsigned alarm(unsigned seconds)
+{
+    unsigned ret;
+
+	__asm__ volatile (
+		"int $0x80"
+		: "=a" (ret)
+		: "0" (NR_alarm),
+          "b" (seconds)
+	);
+
+    /* Time left on old alarm */
+    return ret;
+}

--- a/src/lib/libc/unistd/sleep.c
+++ b/src/lib/libc/unistd/sleep.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 
+ * This file is part of Nanvix.
+ * 
+ * Nanvix is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Nanvix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Nanvix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdlib.h>
+
+/* Signal received */
+volatile int sig_received = SIGALRM;
+
+/* Update signal */
+static void handle_alarm(int signo)
+{
+   sig_received = signo;
+}
+
+/*
+ * Puts the current process to sleep.
+ */
+unsigned sleep(unsigned seconds)
+{
+    alarm(seconds);
+    signal(SIGALRM, handle_alarm);   
+
+    pause();
+    
+    if (sig_received != SIGALRM)
+        return -1;
+
+    return 0;
+}

--- a/src/ubin/makefile
+++ b/src/ubin/makefile
@@ -42,10 +42,11 @@
 .PHONY: ps
 .PHONY: clear
 .PHONY: nim
+.PHONY: sleep
 
 # Builds everything.
 all: cat chgrp chmod chown cp echo kill ln login ls mv nice pwd rm stat sync \
-	 touch tsh ps clear nim
+	 touch tsh ps clear nim sleep
 
 # Builds cat.
 cat: 
@@ -139,6 +140,11 @@ clear:
 nim: 
 	$(CC) $(CFLAGS) $(LDFLAGS) nim/*.c -o $(UBINDIR)/nim $(LIBDIR)/libc.a
 
+# Builds sleep.
+sleep: 
+	$(CC) $(CFLAGS) $(LDFLAGS) -D TESTE sleep/*.c -o $(UBINDIR)/sleep $(LIBDIR)/libc.a
+
+
 # Clean compilation files.
 clean:
 	@rm -f $(UBINDIR)/cat
@@ -164,3 +170,4 @@ clean:
 	@rm -f $(UBINDIR)/ps
 	@rm -f $(UBINDIR)/clear
 	@rm -f $(UBINDIR)/nim
+	@rm -f $(UBINDIR)/sleep

--- a/src/ubin/sleep/sleep.c
+++ b/src/ubin/sleep/sleep.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 
+ * This file is part of Nanvix.
+ * 
+ * Nanvix is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Nanvix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Nanvix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Software versioning. */
+#define VERSION_MAJOR 1 /* Major version. */
+#define VERSION_MINOR 0 /* Minor version. */
+
+/* Seconds to sleep */
+static unsigned seconds;
+
+/*
+ * Prints program version and exits.
+ */
+static void version(void)
+{
+	printf("sleep (Nanvix Coreutils) %d.%d\n\n", VERSION_MAJOR, VERSION_MINOR);
+	printf("Copyright(C) 2011-2014 Pedro H. Penna\n");
+	printf("This is free software under the "); 
+	printf("GNU General Public License Version 3.\n");
+	printf("There is NO WARRANTY, to the extent permitted by law.\n\n");
+	
+	exit(EXIT_SUCCESS);
+}
+
+/*
+ * Prints program usage and exits.
+ */
+static void usage(void)
+{
+	printf("Usage: sleep [seconds]\n\n");
+	printf("Brief: Puts current process to sleep.\n\n");
+	printf("Options:\n");
+	printf("      --help    Display this information and exit\n");
+	printf("      --version Display program version and exit\n");
+	
+	exit(EXIT_SUCCESS);
+}
+
+/*
+ * Gets program arguments.
+ */
+static void getargs(int argc, char *const argv[])
+{
+	int i;            /* Loop index.            */
+	char *arg;        /* Working argument.      */
+	
+    int seconds_read; /* Seconds actually read. */
+
+    if (argc != 2)
+    {
+        usage();
+    }
+
+	/* Get program arguments. */
+	for (i = 1; i < argc; i++)
+	{
+		arg = argv[i];
+		
+		/* Display help information. */
+		if (!strcmp(arg, "--help")) {
+			usage();
+	    }	
+		/* Display program version. */
+		else if (!strcmp(arg, "--version")) {
+			version();
+        }
+		/* Get directory name. */
+		else {
+			if ((seconds_read = atoi(arg)) <= 0)
+                usage();
+            seconds = (unsigned) seconds_read; 
+        }
+	}
+}
+
+/*
+ * Puts current process to sleep.
+ */
+int main(int argc, char *const argv[])
+{
+    getargs(argc, argv);
+
+    sleep(seconds);
+
+    return (EXIT_SUCCESS);
+}

--- a/tools/run/bochsrc.txt.tpl
+++ b/tools/run/bochsrc.txt.tpl
@@ -4,11 +4,11 @@ vgaromimage: file="/usr/local/share/bochs/VGABIOS-lgpl-latest"
 boot: cdrom
 log: bochsout.txt
 mouse: enabled=0
-clock: #RT_ENABLED#
-display_library: term
+clock: #CLOCK#
+display_library: #DISPLAY#
 magic_break: enabled=1
 ata0: enabled=1, ioaddr1=0x1f0, ioaddr2=0x3f0, irq=14
 ata1: enabled=1, ioaddr1=0x170, ioaddr2=0x370, irq=15
 ata0-master: type=disk, path=hdd.img, mode=flat, cylinders=130, heads=16, spt=63
 ata0-slave: type=cdrom, path=nanvix.iso, status=inserted
-gdbstub: enabled=#GDBSTUB_ENABLED#, port=1234
+#GDBSTUB#

--- a/tools/run/bochsrc.txt.tpl
+++ b/tools/run/bochsrc.txt.tpl
@@ -4,7 +4,7 @@ vgaromimage: file="/usr/local/share/bochs/VGABIOS-lgpl-latest"
 boot: cdrom
 log: bochsout.txt
 mouse: enabled=0
-clock: sync=none, time0=utc
+clock: #RT_ENABLED#
 display_library: term
 magic_break: enabled=1
 ata0: enabled=1, ioaddr1=0x1f0, ioaddr2=0x3f0, irq=14

--- a/tools/run/run.sh
+++ b/tools/run/run.sh
@@ -19,7 +19,6 @@
 
 # NOTES:
 #   - This script should work in any Linux distribution.
-#   - You should run this script with superuser privileges.
 
 VERSION_MAJOR=1
 VERSION_MINOR=0
@@ -29,7 +28,7 @@ RT=false
 
 version()
 {
-    echo "run (Nanvix tools) $VERSION_MAJOR.$VERSION_MINOR\n"
+    echo "run (Nanvix tools) $VERSION_MAJOR.$VERSION_MINOR"
     echo "Copyright(C) 2011-2014 Pedro H. Penna"
     echo "This is free software under the GNU General Public License Version 3."
     echo "There is NO WARRANTY, to the extent permitted by law."
@@ -37,11 +36,13 @@ version()
 
 usage()
 {
-    echo "Usage: run\n"
-    echo "Brief: Runs nanvix inside bochs.\n"
+    echo "Usage: run"
+    echo "Brief: Runs nanvix inside bochs."
     echo "Options:"
-    echo "      --help    Display this information and exit"
-    echo "      --version Display program version and exit"
+    echo "      --help       Display this information and exit"
+    echo "      --version    Display program version and exit"
+    echo "      --debug      Enables GDB support"
+    echo "      --real-time  Enables real-time clock support"
 }
 
 debug()
@@ -54,18 +55,19 @@ real_time()
     RT=true
 }
 
-update_bosch()
+update_bochs()
 {
+    cat $BOCHS_CONFIG.tpl > $BOCHS_CONFIG
     if [ "$DEBUG" = true ]; then
-        sed 's/#GDBSTUB_ENABLED#/1/' $BOCHS_CONFIG.tpl > $BOCHS_CONFIG
+        sed -i '' -e 's/#GDBSTUB_ENABLED#/1/' $BOCHS_CONFIG
     else
-        sed 's/#GDBSTUB_ENABLED#/0/' $BOCHS_CONFIG.tpl > $BOCHS_CONFIG
+        sed -i '' -e 's/#GDBSTUB_ENABLED#/0/' $BOCHS_CONFIG
     fi;
 
     if [ "$RT" = true ]; then
-        sed -i 's/#RT_ENABLED#/sync=realtime, time0=local, rtc_sync=0/' $BOCHS_CONFIG
+        sed -i '' -e 's/#RT_ENABLED#/sync=realtime, time0=local, rtc_sync=0/' $BOCHS_CONFIG
     else
-        sed -i 's/#RT_ENABLED#/sync=none, time0=utc/' $BOCHS_CONFIG
+        sed -i '' -e 's/#RT_ENABLED#/sync=none, time0=utc/' $BOCHS_CONFIG
     fi;
 }
 
@@ -96,6 +98,6 @@ while [ "$1" != "" ]; do
     shift
 done
 
-update_bosch
+update_bochs
 
 bochs -q -f tools/run/bochsrc.txt

--- a/tools/run/run.sh
+++ b/tools/run/run.sh
@@ -20,13 +20,82 @@
 # NOTES:
 #   - This script should work in any Linux distribution.
 #   - You should run this script with superuser privileges.
-#
 
-DEBUG=$1
-FILE="tools/run/bochsrc.txt"
-if [ "$DEBUG" == "--debug" ]; then
-    sed 's/#GDBSTUB_ENABLED#/1/' $FILE.tpl > $FILE
-else
-    sed 's/#GDBSTUB_ENABLED#/0/' $FILE.tpl > $FILE
-fi;
+VERSION_MAJOR=1
+VERSION_MINOR=0
+BOCHS_CONFIG="tools/run/bochsrc.txt"
+DEBUG=false
+RT=false
+
+version()
+{
+    echo "run (Nanvix tools) $VERSION_MAJOR.$VERSION_MINOR\n"
+    echo "Copyright(C) 2011-2014 Pedro H. Penna"
+    echo "This is free software under the GNU General Public License Version 3."
+    echo "There is NO WARRANTY, to the extent permitted by law."
+}
+
+usage()
+{
+    echo "Usage: run\n"
+    echo "Brief: Runs nanvix inside bochs.\n"
+    echo "Options:"
+    echo "      --help    Display this information and exit"
+    echo "      --version Display program version and exit"
+}
+
+debug()
+{
+    DEBUG=true
+}
+    
+real_time()
+{
+    RT=true
+}
+
+update_bosch()
+{
+    if [ "$DEBUG" = true ]; then
+        sed 's/#GDBSTUB_ENABLED#/1/' $BOCHS_CONFIG.tpl > $BOCHS_CONFIG
+    else
+        sed 's/#GDBSTUB_ENABLED#/0/' $BOCHS_CONFIG.tpl > $BOCHS_CONFIG
+    fi;
+
+    if [ "$RT" = true ]; then
+        sed -i 's/#RT_ENABLED#/sync=realtime, time0=local, rtc_sync=0/' $BOCHS_CONFIG
+    else
+        sed -i 's/#RT_ENABLED#/sync=none, time0=utc/' $BOCHS_CONFIG
+    fi;
+}
+
+while [ "$1" != "" ]; do
+    PARAM=`echo $1 | awk -F= '{print $1}'`
+    VALUE=`echo $1 | awk -F= '{print $2}'`
+    case $PARAM in
+        -h | --help)
+            usage
+            exit
+            ;;
+        -v | --version)
+            version
+            exit
+            ;;
+        -d | --debug | --gdb)
+            debug
+            ;;
+        -rt | --real-time)
+            real_time
+            ;;
+        *)
+            echo "ERROR: unknown parameter \"$PARAM\""
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+update_bosch
+
 bochs -q -f tools/run/bochsrc.txt

--- a/tools/run/run.sh
+++ b/tools/run/run.sh
@@ -25,6 +25,7 @@ VERSION_MINOR=0
 BOCHS_CONFIG="tools/run/bochsrc.txt"
 DEBUG=false
 RT=false
+SDL=false
 
 version()
 {
@@ -41,33 +42,45 @@ usage()
     echo "Options:"
     echo "      --help       Display this information and exit"
     echo "      --version    Display program version and exit"
-    echo "      --debug      Enables GDB support"
-    echo "      --real-time  Enables real-time clock support"
+    echo "      --debug      Enables GDB support (default=false)"
+    echo "      --real-time  Enables real-time clock support (default=false)"
+    echo "      --sdl        Uses sdl2 display library (default=term)"
 }
 
 debug()
 {
     DEBUG=true
 }
-    
+
 real_time()
 {
     RT=true
+}
+
+sdl()
+{
+    SDL=true
 }
 
 update_bochs()
 {
     cat $BOCHS_CONFIG.tpl > $BOCHS_CONFIG
     if [ "$DEBUG" = true ]; then
-        sed -i '' -e 's/#GDBSTUB_ENABLED#/1/' $BOCHS_CONFIG
+        sed -i '' -e 's/#GDBSTUB#/gdbstub: enabled=1, port=1234/' $BOCHS_CONFIG
     else
-        sed -i '' -e 's/#GDBSTUB_ENABLED#/0/' $BOCHS_CONFIG
+        sed -i '' -e 's/#GDBSTUB#//' $BOCHS_CONFIG
     fi;
 
     if [ "$RT" = true ]; then
-        sed -i '' -e 's/#RT_ENABLED#/sync=realtime, time0=local, rtc_sync=0/' $BOCHS_CONFIG
+        sed -i '' -e 's/#CLOCK#/sync=realtime, time0=local, rtc_sync=0/' $BOCHS_CONFIG
     else
-        sed -i '' -e 's/#RT_ENABLED#/sync=none, time0=utc/' $BOCHS_CONFIG
+        sed -i '' -e 's/#CLOCK#/sync=none, time0=utc/' $BOCHS_CONFIG
+    fi;
+
+    if [ "$SDL" = true ]; then
+        sed -i '' -e 's/#DISPLAY#/sdl2/' $BOCHS_CONFIG
+    else
+        sed -i '' -e 's/#DISPLAY#/term/' $BOCHS_CONFIG
     fi;
 }
 
@@ -88,6 +101,9 @@ while [ "$1" != "" ]; do
             ;;
         -rt | --real-time)
             real_time
+            ;;
+        -s  | --sdl)
+            sdl
             ;;
         *)
             echo "ERROR: unknown parameter \"$PARAM\""


### PR DESCRIPTION
  This PR is an expansion to nanvix's libc and bosch configuration
  scheme (mainly to bochs run script). Altough it includes a user
  binary (namely, sleep), it merely serves the purpose of ilustrate
  sleep's functionallity and shouldn't be included in default user
  software-package. The following sections describe what has been
  changed by this PR in detail.

  Please note that if you're seeing this then the commit is still
  a WIP (Work In Progress). Please refer to the Pull Request thread
  for up-to-date discussion on changes proposed here.

  * Changes to libc:

      This changes were the inital objective of the PR, however, as
      explained in [bochs configuration], the need for a more versatile
      run-script was also found.

      - alarm.c (new):

          This file represents libc's wrapper to the sys_alarm syscall
          as specified by unistd.h. The wrapper does not contain any
          extra return logic, it only forwards the return of sys_alarm.
          That's the case because kernel/sys/alarm.c already implements
          all of it according to:

          [RETURN VALUE] http://pubs.opengroup.org/onlinepubs/009695399/
                functions/alarm.html

          [lines 42-45] https://github.com/nanvix/nanvix/blob/master/src/
                kernel/sys/alarm.c

      - sleep.c (new):

          This file makes part of libc but it isn't a syscall-wrapper.
          Sleep is implementing by setting up an alarm (the same as
          described above) and then registering a signal_handler with a
          call to signal (using the libc wrapper). In contrast to
          linux's libc, this implementation of sleep doesn't return the
          unslept time in case of another signal (this should probably
          be changed before the merge).

          [RETURN VALUE] https://pubs.opengroup.org/onlinepubs/009695399/
                functions/sleep.html

  * Changes to user binaries:

      - sleep (new):

          Simple user binary,

                usage: sleep [seconds]

          Puts the current process to sleep for [seconds] seconds. Even
          though it was written as driver program, it should be
          following all the usual nanvix conventions (style-guides,
          usage, version, argparsing, etc...).

  * Changes to headers:

      As discussed in nanvix's teaching channel on slack, there was a
      problem regarding kernel namespace pollution. The work-around to
      this problem was to add include guards on unistd.h and pm.h
      wrapping the sleep declaration so there is only one defined at a
      given moment. (pm.h's during kernel compilation and unistd.h's
      during the compilation of libc).

      - nanvix/pm.h (modified):

          #ifdef __NANVIX_KERNEL__

          #define sleep (kernel's)

          #endif

      - unistd.h (modified):

          #ifndef __NANVIX_KERNEL__

          #define sleep (libc's)

          #endif

  * Changes to makefiles:

      As explained in [Changes to headers], the work-around for the
      kernel namespace pollution problem (sleep being defined both
      inside pm.h and unistd.h) was to include guard sleep's declaration
      in a way to make the includes mutually exclusive. Moreover, the
      makefile under ubin has been changed to account for the sleep user
      binary.

      - kernel/makefile:

        Now the kernel needs to be compiled with an extra define:

            CFLAGS += -D __NANVIX_KERNEL__

      - ubin/makefile:

        Add sleep rule, target in clean and all, marked as PHONY.

  * Changes to bochs configuration:

      As speculated and now confirmed, bochs's timer isn't real time,
      resulting in grotesque time discrepancies such as running (user
      binary):

          sleep 200 (seconds)

      And it taking only ~6 seconds to complete:

      [BOCHS CLOCK TIKING SUPER FAST] https://stackoverflow.com/questions/
                45845736/emulated-environments-hardware-clock-ticking-a-lot-
                faster-than-18-2-times-per

      [BOCHS TIMER IS NOT REAL TIME] https://wiki.osdev.org/Bochs

      After some web-browsing and some tweaking of bochs parameters,
      it's now capable of running in a state somewhat close to real time
      so that nanvix users do not notice the difference.

      To facilitate further bochs management, the run script was changed
      a bit.

      - run/run.sh:

        The run script now iterates over all script parameters, exitting
        in case of a help/version/unknown flag. Otherwise, the script
        builds a set of config values, DEBUG and RT (Real Time) as of
        now to be latter used by the update_boch function in the seddin'
        of bochsrc.txt.tpl. The set of flags could easily be expanded
        but the way in which they are evaluated (sed calls) should
        probably be modified with code reusability in mind.

      - run/bochs.txt.tpl:

        Added a #RT_ENABLED# marker to be replaced by sed on the line
        that configures clock.

Author: Alek Frohlich, Date: 31/08/2019.