### PR TITLE
A secure way of configuring bochs in tool/runs/run.sh (works on any version of MacOS and Linux)

### DIFF
--- a/tools/run/bochsrc.txt.tpl
+++ b/tools/run/bochsrc.txt.tpl
@@ -4,11 +4,8 @@ vgaromimage: file="/usr/local/share/bochs/VGABIOS-lgpl-latest"
 boot: cdrom
 log: bochsout.txt
 mouse: enabled=0
-clock: #CLOCK#
-display_library: #DISPLAY#
 magic_break: enabled=1
 ata0: enabled=1, ioaddr1=0x1f0, ioaddr2=0x3f0, irq=14
 ata1: enabled=1, ioaddr1=0x170, ioaddr2=0x370, irq=15
 ata0-master: type=disk, path=hdd.img, mode=flat, cylinders=130, heads=16, spt=63
 ata0-slave: type=cdrom, path=nanvix.iso, status=inserted
-#GDBSTUB#

--- a/tools/run/run.sh
+++ b/tools/run/run.sh
@@ -62,25 +62,23 @@ sdl()
     SDL=true
 }
 
-update_bochs()
+config_bochs()
 {
     cat $BOCHS_CONFIG.tpl > $BOCHS_CONFIG
     if [ "$DEBUG" = true ]; then
-        sed -i '' -e 's/#GDBSTUB#/gdbstub: enabled=1, port=1234/' $BOCHS_CONFIG
-    else
-        sed -i '' -e 's/#GDBSTUB#//' $BOCHS_CONFIG
+        echo "gdbstub: enabled=1, port=1234/" >> $BOCHS_CONFIG
     fi;
 
     if [ "$RT" = true ]; then
-        sed -i '' -e 's/#CLOCK#/sync=realtime, time0=local, rtc_sync=0/' $BOCHS_CONFIG
+        echo "clock: sync=realtime, time0=local, rtc_sync=0" >> $BOCHS_CONFIG
     else
-        sed -i '' -e 's/#CLOCK#/sync=none, time0=utc/' $BOCHS_CONFIG
+        echo "clock: sync=none, time0=utc" >> $BOCHS_CONFIG
     fi;
 
     if [ "$SDL" = true ]; then
-        sed -i '' -e 's/#DISPLAY#/sdl2/' $BOCHS_CONFIG
+        echo "display_library: sdl2" >> $BOCHS_CONFIG
     else
-        sed -i '' -e 's/#DISPLAY#/term/' $BOCHS_CONFIG
+        echo "display_library: term" >> $BOCHS_CONFIG
     fi;
 }
 
@@ -114,6 +112,6 @@ while [ "$1" != "" ]; do
     shift
 done
 
-update_bochs
+config_bochs
 
 bochs -q -f tools/run/bochsrc.txt


### PR DESCRIPTION
In this commit, I changed the way we configure bochs in tools/run/run.sh. Instead of using sed, which has several implementations and some of them do not allow -i option, I now add some config lines directly in tools/run/bochsrc.txt using echo in tools/run/run.sh. This solution will work on any version of MacOS and Linux.