### PR TITLE
Add Check Before Switching to New Process

### DIFF
--- a/src/kernel/pm/sched.c
+++ b/src/kernel/pm/sched.c
@@ -116,5 +116,6 @@ PUBLIC void yield(void)
 	next->priority = PRIO_USER;
 	next->state = PROC_RUNNING;
 	next->counter = PROC_QUANTUM;
-	switch_to(next);
+	if (curr_proc != next)
+		switch_to(next);
 }


### PR DESCRIPTION
# Description

This change prevents any unneeded context switch by checking if the current process is equal to next.