### PR TITLE
Supporting Manjaro

### DIFF
--- a/tools/dev/setup-bochs.sh
+++ b/tools/dev/setup-bochs.sh
@@ -40,7 +40,7 @@ case ${DIST,,} in
     *"ubuntu"*|*"debian"*)
         apt-get install -y libncurses5-dev
         ;;
-    *"arch"*)
+    *"arch"*|*"manjaro"*)
         pacman -S ncurses --needed --noconfirm
         ;;
     *)

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -57,7 +57,7 @@ case ${DIST,,} in
     *"ubuntu"*|*"debian"*)
         apt-get install -y g++ doxygen genisoimage gdb xz-utils make
         ;;
-    *"arch"*)
+    *"arch"*|*"manjaro"*)
         pacman -S gcc doxygen cdrtools gdb xz make --needed --noconfirm
         ;;
     *)


### PR DESCRIPTION
This allows to run Nanvix setup scripts (`toolchain` and `bochs`) on **Manjaro**. As an arch-based distribuition that uses pacman, it's possible to support