### PR TITLE
Add bash shebang to run setup scripts with others shells

### DIFF
--- a/tools/dev/setup-bochs.sh
+++ b/tools/dev/setup-bochs.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
 #

--- a/tools/dev/setup-toolchain.sh
+++ b/tools/dev/setup-toolchain.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Copyright(C) 2011-2016 Pedro H. Penna <pedrohenriquepenna@gmail.com>
 #


### PR DESCRIPTION
Some shells like zsh do not support the `${DIST,,}` directive used in the setup script. By adding the shebang at the top of the scripts, it specifies that they will only be executed by bash.

Instead of running `sudo bash tools/dev/setup-toolchain.sh`, we can simply use `sudo ./tools/dev/setup-toolchain.sh`
