### PR TITLE
Update qemu.sh

### DIFF
--- a/tools/dev/setup/qemu.sh
+++ b/tools/dev/setup/qemu.sh
@@ -23,7 +23,7 @@ function setup_qemu
 {
     local TARGET="$1-softmmu"
     local PREFIX=$2/qemu
-    local VERSION=8.0.0
+    local VERSION=8.1.1
 
     pushd $PWD
 


### PR DESCRIPTION
## Descrição do problema

A versão 8.0.0 do QEMU possui um erro relacionado aos keymaps para o idioma árabe, gerando erros de compilação ao rodar o arquivo qemu.sh em um ambiente com Arch Linux. Isso impedia a concretização da instalação do QEMU e consequentemente o não era possível utilizar o Nanvix.

```
[1810/2783] Generating pc-bios/keymaps/ar with a custom command
FAILED: pc-bios/keymaps/ar 
/home/samuelcorocha/Documents/PUC/5P/Sistemas-Operacionais/tp-nanvix/build-qemu/qemu-8.0.0/build/qemu-keymap -f pc-bios/keymaps/ar -l ar
xkbcommon: ERROR: Couldn't find file "symbols/ar" in include paths
xkbcommon: ERROR: 1 include paths searched:
xkbcommon: ERROR: 	/usr/share/X11/xkb
xkbcommon: ERROR: 3 include paths could not be added:
xkbcommon: ERROR: 	/root/.config/xkb
xkbcommon: ERROR: 	/root/.xkb
xkbcommon: ERROR: 	/etc/xkb
xkbcommon: ERROR: Abandoning symbols file "(unnamed)"
xkbcommon: ERROR: Failed to compile xkb_symbols
xkbcommon: ERROR: Failed to compile keymap
ninja: build stopped: subcommand failed.
make[1]: *** [Makefile:165: run-ninja] Error 1
make[1]: Leaving directory '/home/samuelcorocha/Documents/PUC/5P/Sistemas-Operacionais/tp-nanvix/build-qemu/qemu-8.0.0/build'
make: *** [GNUmakefile:11: all] Error 2
changing dir to build for make "install"...
make[1]: Entering directory '/home/samuelcorocha/Documents/PUC/5P/Sistemas-Operacionais/tp-nanvix/build-qemu/qemu-8.0.0/build'
[1/992] Generating qemu-version.h with a custom command (wrapped by meson to capture output)
[2/976] Generating pc-bios/keymaps/ar with a custom command
FAILED: pc-bios/keymaps/ar 
/home/samuelcorocha/Documents/PUC/5P/Sistemas-Operacionais/tp-nanvix/build-qemu/qemu-8.0.0/build/qemu-keymap -f pc-bios/keymaps/ar -l ar
xkbcommon: ERROR: Couldn't find file "symbols/ar" in include paths
xkbcommon: ERROR: 1 include paths searched:
xkbcommon: ERROR: 	/usr/share/X11/xkb
xkbcommon: ERROR: 3 include paths could not be added:
xkbcommon: ERROR: 	/root/.config/xkb
xkbcommon: ERROR: 	/root/.xkb
xkbcommon: ERROR: 	/etc/xkb
xkbcommon: ERROR: Abandoning symbols file "(unnamed)"
xkbcommon: ERROR: Failed to compile xkb_symbols
xkbcommon: ERROR: Failed to compile keymap
ninja: build stopped: subcommand failed.
make[1]: *** [Makefile:165: run-ninja] Error 1
make[1]: Leaving directory '/home/samuelcorocha/Documents/PUC/5P/Sistemas-Operacionais/tp-nanvix/build-qemu/qemu-8.0.0/build'
make: *** [GNUmakefile:11: install] Error 2
/home/samuelcorocha/Documents/PUC/5P/Sistemas-Operacionais/tp-nanvix
```

## Solução proposta

Alterar a versão do QEMU de 8.0.0 para 8.1.1.

## Evidências de que a solução funciona corretamente

Uma versão mais atualizada do QEMU corrige esse erro, acrescentado a pasta `(symbols/ara)`. O código da solução foi executado em um ambiente de teste e não apresentou erros, possibilitando o uso normal do sistema.

## Mudanças no código

A versão do QEMU foi alterada para 8.1.1. Na function setup_qemu, foi alterado da seguinte forma:

`local VERSION=8.0.0` para `local VERSION=8.1.1`