### PR TITLE
Script for Arch Linux distribution

### DIFF
--- a/tools/dev/setup/arch.sh
+++ b/tools/dev/setup/arch.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright(c) 2011-2023 The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# If you are using Arch Linux distribution use this script.
+
+# Update system and install required packages.
+pacman -Syu --noconfirm \
+	bison               \
+	base-devel          \
+	clang               \
+	doxygen             \
+	flex                \
+	gcc                 \
+	gdb                 \
+	cdrtools            \
+	graphviz            \
+	grub                \
+	ncurses             \
+	glibmm-2.68         \
+	gmp                 \
+	pixman              \
+	sdl2                \
+	make                \
+	mtools              \
+	ninja               \
+	pkgconf             \
+	texinfo             \
+	libisoburn          \
+	xz                  \


### PR DESCRIPTION
This is a script for Arch Linux distribution.

It upgrade all Pacman packages and install the required packages to compile the tools and run Nanvix.
The script was tested on Arch and Manjaro 23.1.0 Vulcan.