### PR TITLE
[kernel] E: Alloc usable frames conservatively

### DIFF
--- a/kernel/src/klib/bitmap.rs
+++ b/kernel/src/klib/bitmap.rs
@@ -297,6 +297,24 @@ impl Bitmap {
 
         Ok((word, bit))
     }
+
+
+    ///
+    /// # Description
+    ///
+    /// Fill with value 1 all the bitmap.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, `Ok(())` is returned. Upon failure, an error is returned instead.
+    ///
+    pub fn fill_bitmap(&mut self) -> Result<(), Error> {
+        for word in self.bits.iter_mut() {
+            *word |= u8::MAX;
+        }
+        self.usage = self.number_of_bits;
+        Ok(())
+    }
 }
 
 //==================================================================================================

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -87,18 +87,26 @@ fn parse_memory_regions(
     while let Some(region) = memory_regions.pop_front() {
         if region.typ() == MemoryRegionType::Reserved || region.typ() == MemoryRegionType::Mmio {
             if PhysicalAddress::from_virtual_address(region.start()).is_ok() {
-                if region.typ() != MemoryRegionType::Usable {
-                    if let Ok(region) =
-                        TruncatedMemoryRegion::from_virtual_memory_region(region.clone())
-                    {
-                        physical_memory_regions.push_back(region);
-                    }
+                if let Ok(region) =
+                    TruncatedMemoryRegion::from_virtual_memory_region(region.clone())
+                {
+                    physical_memory_regions.push_back(region);
                 }
                 virtual_memory_regions
                     .push_back(TruncatedMemoryRegion::from_memory_region(region)?);
             } else {
                 other_virtual_memory_regions
                     .push_back(TruncatedMemoryRegion::from_memory_region(region)?);
+            }
+        } else {
+            if region.typ() == MemoryRegionType::Usable {
+                if PhysicalAddress::from_virtual_address(region.start()).is_ok() {
+                    if let Ok(region) =
+                        TruncatedMemoryRegion::from_virtual_memory_region(region.clone())
+                    {
+                        physical_memory_regions.push_back(region);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
This PR implements new functions to manipulate frame allocation and allow allocates usable frames conservatively, i.e., just memory marked as usable will be, all the rest, including untracked memorys are reserved.