### PR TITLE
Clean up process state when threads exit

### DIFF
--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -348,16 +348,30 @@ impl ProcessDaemon {
             match ::sys::kcall::ipc::__kcall_recv() {
                 Ok(message) => {
                     ::syslog::info!("received message from={:?}", { message.source });
+                    let source_pid: ProcessIdentifier = { message.source }.pid;
                     match message.message_type {
-                        MessageType::Exception => unreachable!("should not receive exceptions"),
+                        MessageType::Exception => {
+                            ::syslog::warn!("received unexpected exception message, ignoring");
+                        },
                         MessageType::Ipc => {
                             if let Err(e) = self.handle_ipc_message(message) {
                                 ::syslog::error!("failed to handle IPC message (error={:?})", e);
                             }
                         },
-                        MessageType::Interrupt => unreachable!("should not receive interrupts"),
-                        MessageType::Ikc => unreachable!("should not receive IKC messages"),
+                        MessageType::Interrupt => {
+                            ::syslog::warn!("received unexpected interrupt message, ignoring");
+                        },
+                        MessageType::Ikc => {
+                            ::syslog::warn!("received unexpected IKC message, ignoring");
+                        },
                         MessageType::ProcessTerminationEvent => {
+                            if source_pid != ProcessIdentifier::KERNEL {
+                                ::syslog::warn!(
+                                    "dropping forged process termination event (source={:?})",
+                                    source_pid
+                                );
+                                continue;
+                            }
                             match self.handle_process_termination_event(message) {
                                 Ok(Some(status)) => return status,
                                 Ok(None) => continue,
@@ -374,6 +388,13 @@ impl ProcessDaemon {
                             continue;
                         },
                         MessageType::ProcessCreationEvent => {
+                            if source_pid != ProcessIdentifier::KERNEL {
+                                ::syslog::warn!(
+                                    "dropping forged process creation event (source={:?})",
+                                    source_pid
+                                );
+                                continue;
+                            }
                             if let Err(e) = self.handle_process_creation_event(message) {
                                 ::syslog::error!(
                                     "failed to handle process creation event (error={:?})",
@@ -870,6 +891,13 @@ impl ProcessDaemon {
         } else {
             false
         }
+    }
+
+    /// Removes every blocked wait owned by one exiting thread.
+    fn handle_thread_exit(&mut self, caller: ProcessIdentifier, tid: ThreadIdentifier) {
+        self.blocked.retain(|waiter| {
+            waiter.waiter != caller || waiter.response_context.receiver.tid != tid
+        });
     }
 
     /// Wakes a parent blocked in `waitpid()` that is waiting for `child` (a child of `parent`) and
@@ -1581,6 +1609,9 @@ impl ProcessDaemon {
                         self.handle_wait_cancel(caller, sender.tid, request.request_id());
                     let reply: Message = message::wait_cancel_response(caller, cancelled)?;
                     response_context.send(reply)?;
+                },
+                ProcessManagementMessageHeader::ThreadExit => {
+                    self.handle_thread_exit(caller, sender.tid);
                 },
                 ProcessManagementMessageHeader::Kill => {
                     let message: KillMessage = KillMessage::from_bytes(message.payload);
@@ -2345,6 +2376,15 @@ impl ProcessDaemon {
             match ::sys::kcall::ipc::__kcall_recv() {
                 Ok(message) => {
                     if message.message_type == MessageType::ProcessTerminationEvent {
+                        let source_pid: ProcessIdentifier = { message.source }.pid;
+                        if source_pid != ProcessIdentifier::KERNEL {
+                            ::syslog::warn!(
+                                "dropping forged process termination event during shutdown \
+                                 (source={:?})",
+                                source_pid
+                            );
+                            continue;
+                        }
                         // Deserialize process identifier.
                         let pid: ProcessIdentifier = ProcessIdentifier::from(i32::from_le_bytes(
                             message.payload[0..4].try_into().unwrap(),
@@ -2647,6 +2687,30 @@ mod tests {
         assert!(daemon.handle_wait_cancel(parent, first_tid, first_id));
         assert_eq!(daemon.blocked.len(), 1);
         assert_eq!(daemon.blocked[0].response_context.request_id, second_id);
+    }
+
+    #[test]
+    fn thread_exit_removes_only_exiting_threads_waiters() {
+        let parent: ProcessIdentifier = ProcessIdentifier::from(10);
+        let exiting_tid: ThreadIdentifier = ThreadIdentifier::from(20);
+        let surviving_tid: ThreadIdentifier = ThreadIdentifier::from(21);
+        let mut daemon: ManuallyDrop<ProcessDaemon> =
+            process_daemon(&[(parent, Some(process_identity(1000)))]);
+        for (tid, request_id) in [
+            (exiting_tid, RequestIdentifier::from_raw(100)),
+            (surviving_tid, RequestIdentifier::from_raw(101)),
+        ] {
+            daemon.blocked.push(BlockedWaiter {
+                waiter: parent,
+                selector: WaitSelector::Any,
+                response_context: ResponseContext::new(MessageSender::new(parent, tid), request_id),
+            });
+        }
+
+        daemon.handle_thread_exit(parent, exiting_tid);
+
+        assert_eq!(daemon.blocked.len(), 1);
+        assert_eq!(daemon.blocked[0].response_context.receiver.tid, surviving_tid);
     }
 
     #[test]

--- a/src/libs/proc/src/lib.rs
+++ b/src/libs/proc/src/lib.rs
@@ -51,6 +51,7 @@ pub use message::{
     signup_response,
     terminal_access_request,
     terminal_signal_request,
+    thread_exit_notification,
     wait_cancel_request,
     wait_cancel_response,
     wait_request,

--- a/src/libs/proc/src/message/mod.rs
+++ b/src/libs/proc/src/message/mod.rs
@@ -125,6 +125,8 @@ pub enum ProcessManagementMessageHeader {
     WaitCancel = 21,
     /// Reports whether a blocked wait request was cancelled before completion.
     WaitCancelResponse = 22,
+    /// Notifies the process daemon that the calling thread is exiting.
+    ThreadExit = 23,
 }
 
 impl TryFrom<u8> for ProcessManagementMessageHeader {
@@ -154,6 +156,7 @@ impl TryFrom<u8> for ProcessManagementMessageHeader {
             20 => Ok(ProcessManagementMessageHeader::TerminalAccess),
             21 => Ok(ProcessManagementMessageHeader::WaitCancel),
             22 => Ok(ProcessManagementMessageHeader::WaitCancelResponse),
+            23 => Ok(ProcessManagementMessageHeader::ThreadExit),
             _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid process management message")),
         }
     }
@@ -184,6 +187,7 @@ impl From<&ProcessManagementMessageHeader> for u8 {
             ProcessManagementMessageHeader::TerminalAccess => 20,
             ProcessManagementMessageHeader::WaitCancel => 21,
             ProcessManagementMessageHeader::WaitCancelResponse => 22,
+            ProcessManagementMessageHeader::ThreadExit => 23,
         }
     }
 }

--- a/src/libs/proc/src/message/process_exit.rs
+++ b/src/libs/proc/src/message/process_exit.rs
@@ -142,3 +142,20 @@ pub fn process_exit_request(pid: ProcessIdentifier) -> Result<Message, Error> {
 
     Ok(ipc_message)
 }
+
+/// Builds a fire-and-forget notification that the calling thread is exiting.
+pub fn thread_exit_notification() -> Message {
+    let process_message: ProcessManagementMessage = ProcessManagementMessage::new(
+        ProcessManagementMessageHeader::ThreadExit,
+        [0u8; ProcessManagementMessage::PAYLOAD_SIZE],
+    );
+    let system_message: SystemMessage =
+        SystemMessage::new(SystemMessageHeader::ProcessManagement, process_message.into_bytes());
+    Message::new(
+        MessageSender::KERNEL,
+        MessageReceiver::new(ProcessIdentifier::PROCD, ThreadIdentifier::NONE),
+        MessageType::Ipc,
+        None,
+        system_message.into_bytes(),
+    )
+}

--- a/src/libs/sysalloc/src/allocator.rs
+++ b/src/libs/sysalloc/src/allocator.rs
@@ -463,6 +463,9 @@ pub fn cleanup() -> Result<(), Error> {
 /// This is the number of bytes currently backed by physical pages. It increases when the OOM
 /// handler grows the heap via `mmap` and decreases when `try_reclaim` shrinks it via `munmap`.
 pub fn heap_committed_size() -> usize {
+    let Ok(_signal_mask): Result<SignalMaskGuard, Error> = SignalMaskGuard::acquire() else {
+        return 0;
+    };
     let locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
     match locked_heap.as_ref() {
         Some(heap) => heap.oom_handler.heap.size(),
@@ -472,6 +475,9 @@ pub fn heap_committed_size() -> usize {
 
 /// Returns the maximum capacity of the heap in bytes.
 pub fn heap_capacity() -> usize {
+    let Ok(_signal_mask): Result<SignalMaskGuard, Error> = SignalMaskGuard::acquire() else {
+        return 0;
+    };
     let locked_heap: MutexGuard<'_, Option<Talc<NanvixOomHandler>>> = HEAP.lock();
     match locked_heap.as_ref() {
         Some(heap) => heap.oom_handler.heap.capacity(),

--- a/src/libs/syscall/src/pthread/syscall/mod.rs
+++ b/src/libs/syscall/src/pthread/syscall/mod.rs
@@ -110,6 +110,21 @@ struct ThreadStartArgs {
 // Standalone Functions
 //==================================================================================================
 
+fn notify_thread_exit() {
+    match ::sys::kcall::pm::getpid() {
+        Ok(pid) if i32::from(pid) > ::sys::pm::ProcessIdentifier::VFSD_RAW => {
+            let notification: ::sys::ipc::Message = ::proc::thread_exit_notification();
+            if let Err(error) = ::sys::kcall::ipc::__kcall_send(&notification) {
+                ::syslog::warn!("failed to notify process daemon of thread exit (error={error:?})");
+            }
+        },
+        Ok(_) => {},
+        Err(error) => {
+            ::syslog::warn!("failed to query process id during thread exit (error={error:?})");
+        },
+    }
+}
+
 extern "C" fn pthread_start(arg: usize) -> usize {
     let start_args: Box<ThreadStartArgs> = unsafe { Box::from_raw(arg as *mut ThreadStartArgs) };
     let retval: usize = (start_args.func)(start_args.arg);
@@ -121,6 +136,8 @@ extern "C" fn pthread_start(arg: usize) -> usize {
     if let Err(error) = ::sysalloc::tda::cleanup() {
         ::syslog::warn!("pthread_start(): failed to cleanup thread data area ({error:?})");
     }
+
+    notify_thread_exit();
 
     retval
 }
@@ -275,6 +292,8 @@ pub fn pthread_exit(retval: usize) -> Result<!, Error> {
         // Log warning and continue exiting, as we are about to terminate the thread anyway.
         ::syslog::warn!("pthread_exit(): failed to cleanup thread data area ({error:?})");
     }
+
+    notify_thread_exit();
 
     __kcall_exit_thread(retval)
 }


### PR DESCRIPTION
## Summary

- notify `procd` when a pthread exits
- remove blocked waits owned by the exact exiting thread
- accept process creation and termination events only from the kernel
- log and ignore unexpected process-daemon message types instead of panicking

## Validation

- `./z build -- test`

## Stack

Draft 2 of 3. Depends on #3035 and targets its head branch so this PR shows only the lifecycle cleanup.