### PR TITLE
[vfsd] hostfs-aware chdir

### DIFF
--- a/src/daemons/vfsd/src/assembler.rs
+++ b/src/daemons/vfsd/src/assembler.rs
@@ -243,7 +243,9 @@ fn dispatch_assembled_request(
         },
         SystemCallMessageHeader::ChangeDirectoryRequestPart => {
             match ChangeDirectoryRequest::from_parts(parts) {
-                Ok(req) => handler::handle_chdir(source, req),
+                // Returns `None` when forwarded to hostfsd (response deferred to IKC completion).
+                Ok(req) => handler::handle_chdir_with_hostfs(source_pid, source, req, pending)
+                    .unwrap_or_default(),
                 Err(e) => {
                     ::syslog::error!("dispatch: chdir from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -47,8 +47,10 @@ use ::sys::{
         ThreadIdentifier,
     },
 };
+use ::sysapi::fcntl::atflags::AT_FDCWD;
 use ::syscall::{
     unistd::message::{
+        ChangeDirectoryRequest,
         CloseRequest,
         Dup2Request,
         Dup2Response,
@@ -446,6 +448,52 @@ pub(crate) fn handle_fstatat_with_hostfs(
     Some(super::long::handle_fstatat(source, request))
 }
 
+/// hostfs-aware `chdir`.
+///
+/// For a target under the hostfs mount, forwards a path-based stat to hostfsd and
+/// defers (returns `None`); the completion (`complete_chdir`) sets the cwd when the
+/// target is a directory and returns `ENOTDIR` otherwise. Non-hostfs targets fall
+/// through to the local VFS handler, which validates against the FAT mount table.
+pub(crate) fn handle_chdir_with_hostfs(
+    source_pid: ProcessIdentifier,
+    source: ThreadIdentifier,
+    request: ChangeDirectoryRequest,
+    pending: &mut PendingQueue,
+) -> Option<Vec<Message>> {
+    let resolved = match vfs_resolve_path(AT_FDCWD, &request.path) {
+        Some(p) => p,
+        None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
+    };
+
+    if hostfs::is_hostfs_path(&resolved) {
+        if !pending.has_capacity() {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        let op_id = pending.alloc_op_id();
+        match hostfs::send_pathstat_request(&resolved, op_id) {
+            Ok(()) => {
+                if pending
+                    .insert(
+                        op_id,
+                        PendingOp {
+                            source_tid: source,
+                            source_pid,
+                            kind: PendingOpKind::Chdir { path: resolved },
+                        },
+                    )
+                    .is_err()
+                {
+                    return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+                }
+                return None;
+            },
+            Err(e) => return Some(vec![build_error(source, e)]),
+        }
+    }
+
+    Some(handle_chdir(source, request))
+}
+
 pub(crate) fn handle_read_with_hostfs(
     source_pid: ProcessIdentifier,
     source_tid: ThreadIdentifier,
@@ -599,10 +647,13 @@ use ::syscall::{
         SymbolicLinkAtRequest,
     },
 };
+use ::vfs::fd::vfs_resolve_path;
 use alloc::{
     vec,
     vec::Vec,
 };
+
+use super::long::handle_chdir;
 
 /// Handles getdents with hostfs awareness.
 ///

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -20,10 +20,16 @@ extern crate alloc;
 
 use crate::error::{
     build_error,
+    fat32_to_error_code,
     send_response,
 };
-use ::alloc::collections::BTreeMap;
+use ::alloc::{
+    collections::BTreeMap,
+    string::String,
+};
 use ::hostfs_api::{
+    file_kind,
+    LstatResponse,
     OperationId,
     OperationIdAllocator,
 };
@@ -38,6 +44,8 @@ use ::sys::{
         ThreadIdentifier,
     },
 };
+use ::syscall::unistd::message::ChangeDirectoryResponse;
+use ::vfs::fd::vfs_set_cwd;
 
 //==================================================================================================
 // Pending Operation Descriptor
@@ -97,6 +105,12 @@ pub(crate) enum PendingOpKind {
     /// Path-based stat that follows the final symbolic link (default `stat(2)` semantics).
     /// Shares the `lstat` response wire format and completion path.
     PathStat,
+    /// chdir onto a hostfs path — a path-based stat whose completion commits the cwd
+    /// when the target is a directory (else `ENOTDIR`). Reuses the `PathStat` wire form.
+    Chdir {
+        /// Absolute hostfs path to become the cwd once confirmed to be a directory.
+        path: String,
+    },
     /// getdents — directory listing over hostfs.
     ///
     /// hostfsd returns one entry per IKC round-trip, so a single guest `getdents`
@@ -346,6 +360,7 @@ pub(crate) fn complete_pending_op(
         },
         PendingOpKind::Lstat => complete_lstat(pending.source_tid, response_payload),
         PendingOpKind::PathStat => complete_lstat(pending.source_tid, response_payload),
+        PendingOpKind::Chdir { path } => complete_chdir(pending.source_tid, response_payload, path),
         PendingOpKind::Getdents { .. } => {
             // Getdents sweeps are driven entirely by the main event loop, which keeps
             // the op buffered across round-trips and finalizes it via `finish_getdents`.
@@ -678,6 +693,7 @@ fn validate_response_header(kind: &PendingOpKind, payload: &[u8; Message::PAYLOA
             | (PendingOpKind::Readlink { .. }, SystemCallMessageHeader::HostFsReadlinkResponse)
             | (PendingOpKind::Lstat, SystemCallMessageHeader::HostFsLstatResponse)
             | (PendingOpKind::PathStat, SystemCallMessageHeader::HostFsPathStatResponse)
+            | (PendingOpKind::Chdir { .. }, SystemCallMessageHeader::HostFsPathStatResponse)
             | (PendingOpKind::Getdents { .. }, SystemCallMessageHeader::HostFsReadDirResponse)
     )
 }
@@ -1163,4 +1179,41 @@ fn complete_lstat(source_tid: ThreadIdentifier, response_payload: &[u8; Message:
             send_response(&build_error(source_tid, ErrorCode::IoErr));
         },
     }
+}
+
+/// Completes a deferred hostfs `chdir`: the pending path-stat has returned, so
+/// commit the cwd when the target is a directory, else surface `ENOTDIR`.
+fn complete_chdir(
+    source_tid: ThreadIdentifier,
+    response_payload: &[u8; Message::PAYLOAD_SIZE],
+    path: String,
+) {
+    let resp: LstatResponse = match LstatResponse::decode(response_payload) {
+        Some(r) => r,
+        None => {
+            ::syslog::error!("complete_chdir: failed to decode response");
+            send_response(&build_error(source_tid, ErrorCode::IoErr));
+            return;
+        },
+    };
+
+    if resp.status < 0 {
+        send_response(&build_error(source_tid, hostfs_error_to_code(resp.status)));
+        return;
+    }
+
+    if resp.kind != file_kind::DIRECTORY {
+        send_response(&build_error(source_tid, ErrorCode::InvalidDirectory));
+        return;
+    }
+
+    if let Err(e) = vfs_set_cwd(&path) {
+        send_response(&build_error(source_tid, fat32_to_error_code(&e)));
+        return;
+    }
+    send_response(&ChangeDirectoryResponse::build(
+        source_tid,
+        ProcessIdentifier::VFSD,
+        MessageType::Ipc,
+    ));
 }

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -1495,6 +1495,24 @@ pub fn vfs_chdir(path: &str) -> Result<(), Fat32Error> {
     Ok(())
 }
 
+/// Commits the current working directory to a hostfs path, bypassing local
+/// mount-table validation but still enforcing an absolute, normalized cwd.
+///
+/// Unlike [`vfs_chdir`], this performs NO existence/type check: vfsd uses it to
+/// finalize a chdir onto a hostfs path after hostfsd has confirmed the target is
+/// a directory (hostfs paths live outside the local FAT mount table, so
+/// [`vfs_chdir`] would reject them). `path` is normalized here so the stored cwd
+/// keeps the same absolute, canonical form as every other code path; a relative
+/// or malformed `path` is rejected with [`Fat32Error::InvalidPath`].
+pub fn vfs_set_cwd(path: &str) -> Result<(), Fat32Error> {
+    if !path.starts_with('/') {
+        return Err(Fat32Error::InvalidPath);
+    }
+    let normalized: String = filesystem::normalize(&current_cwd(), path)?;
+    set_current_cwd(normalized);
+    Ok(())
+}
+
 /// Changes the current working directory to the directory referenced by a VFS FD.
 ///
 /// Only works on directory handles. Returns an error for file handles.

--- a/src/tests/integration/test-c-file/chdir.c
+++ b/src/tests/integration/test-c-file/chdir.c
@@ -19,6 +19,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -70,6 +71,33 @@ void test_chdir(void)
     assert(getcwd(new_cwd, sizeof(new_cwd)) != NULL);
     assert(strcmp(new_cwd, original_cwd) == 0);
     assert(unlink(filename) == 0);
+
+    // Cross-mount coverage over hostfs (mounted at /mnt by test_umask()): chdir
+    // must forward to hostfsd, succeed onto a directory, and reject a file with
+    // ENOTDIR.
+    if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
+        const char *hostdir = "/mnt/testdir_chdir";
+        const char *hostfile = "/mnt/testfile_chdir";
+
+        // chdir() onto a hostfs directory succeeds and updates the cwd.
+        assert(mkdir(hostdir, S_IRUSR | S_IWUSR | S_IXUSR) == 0);
+        assert(chdir(hostdir) == 0);
+        assert(getcwd(new_cwd, sizeof(new_cwd)) != NULL);
+        assert(strcmp(new_cwd, hostdir) == 0);
+        assert(chdir(original_cwd) == 0);
+        assert(unlinkat(AT_FDCWD, hostdir, AT_REMOVEDIR) == 0);
+
+        // chdir() onto a hostfs file fails with ENOTDIR and leaves the cwd intact.
+        fd = open(hostfile, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+        assert(fd >= 0);
+        assert(close(fd) == 0);
+        errno = 0;
+        assert(chdir(hostfile) != 0);
+        assert(errno == ENOTDIR);
+        assert(getcwd(new_cwd, sizeof(new_cwd)) != NULL);
+        assert(strcmp(new_cwd, original_cwd) == 0);
+        assert(unlink(hostfile) == 0);
+    }
 
     // Clean up.
     assert(unlinkat(AT_FDCWD, dirname, AT_REMOVEDIR) == 0);


### PR DESCRIPTION
This commit enables hostfs aware chdir.

Closes #3033.
Follow-up to #3032.