### PR TITLE
[kernel] Harden IPC mailbox lifecycle

### DIFF
--- a/src/kernel/src/ipc/mbx/mailbox.rs
+++ b/src/kernel/src/ipc/mbx/mailbox.rs
@@ -96,4 +96,46 @@ impl Mailbox {
 
         None
     }
+
+    ///
+    /// # Description
+    ///
+    /// Removes every buffered message addressed exactly to a thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `tid`: Identifier of the thread whose messages should be removed.
+    ///
+    /// # Returns
+    ///
+    /// The number of messages removed from the mailbox.
+    ///
+    pub fn purge_thread(&mut self, tid: ThreadIdentifier) -> usize {
+        let mut retained: LinkedList<Message> = LinkedList::new();
+        let mut removed: usize = 0;
+        while let Some(message) = self.buffer.pop_front() {
+            if { message.destination }.tid == tid {
+                removed += 1;
+            } else {
+                retained.push_back(message);
+            }
+        }
+        self.buffer = retained;
+        removed
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Removes every buffered message.
+    ///
+    /// # Returns
+    ///
+    /// The number of messages removed from the mailbox.
+    ///
+    pub fn purge_all(&mut self) -> usize {
+        let removed: usize = self.buffer.len();
+        self.buffer.clear();
+        removed
+    }
 }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -3816,6 +3816,18 @@ impl ProcessManager {
             } else {
                 self.find_process_by_tid(receiver.tid)?
             };
+            if matches!(&process, ProcessRefMut::Zombie(_)) {
+                let reason: &str = "cannot post a message to a zombie process";
+                warn!("{reason} (receiver={receiver:?})");
+                return Err(Error::new(ErrorCode::NoSuchEntry, reason));
+            }
+            if !receiver.tid.is_none()
+                && matches!(process.find_thread_mut(receiver.tid), Some(ThreadRefMut::Zombie(_)))
+            {
+                let reason: &str = "cannot post a message to a zombie thread";
+                warn!("{reason} (receiver={receiver:?})");
+                return Err(Error::new(ErrorCode::NoSuchEntry, reason));
+            }
             process.state_mut().post_message(message);
         }
         self.note_message_posted()?;

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -2113,7 +2113,7 @@ impl ProcessManager {
         // Check the running thread's kernel stack guard watermark before switching away.
         self.check_running_stack_guard();
 
-        let running_process: RunningProcess = self.take_running();
+        let mut running_process: RunningProcess = self.take_running();
         trace!(
             "pid={:?}, tid={:?}, status={status:?}",
             running_process.state().pid(),
@@ -2124,6 +2124,9 @@ impl ProcessManager {
         if running_process.state().pid() == ProcessIdentifier::KERNEL {
             panic!("kernel process cannot exit");
         }
+
+        let purged_messages: usize = running_process.state_mut().purge_messages();
+        self.note_messages_purged(purged_messages);
 
         // Clean up any pending rendezvous entries for this process and wake up counterpart
         // threads that would otherwise block forever.
@@ -2201,7 +2204,8 @@ impl ProcessManager {
         // Check the running thread's kernel stack guard watermark before switching away.
         self.check_running_stack_guard();
 
-        let running_process: RunningProcess = self.take_running();
+        let mut running_process: RunningProcess = self.take_running();
+        let exiting_tid: ThreadIdentifier = running_process.get_tid();
 
         trace!(
             "pid={:?}, tid={:?}, status={:?}",
@@ -2214,6 +2218,11 @@ impl ProcessManager {
         if running_process.state().pid() == ProcessIdentifier::KERNEL {
             panic!("kernel process cannot exit (status={status:?})");
         }
+
+        let purged_messages: usize = running_process
+            .state_mut()
+            .purge_thread_messages(exiting_tid);
+        self.note_messages_purged(purged_messages);
 
         // Terminate the calling thread and schedule another thread to run.
         let (join_cond, previous_context): (Condvar, *mut ContextInformation) =
@@ -2237,11 +2246,13 @@ impl ProcessManager {
                     (join_cond, previous_context)
                 },
                 // The calling process has only zombie threads left, put it in the list of zombies processes.
-                (Err(Err((join_cond, zombie_process, previous_context))), deferred_zombie) => {
+                (Err(Err((join_cond, mut zombie_process, previous_context))), deferred_zombie) => {
                     debug_assert!(
                         deferred_zombie.is_none(),
                         "deferred zombie must be None when no other threads remain"
                     );
+                    let purged_messages: usize = zombie_process.state_mut().purge_messages();
+                    self.note_messages_purged(purged_messages);
                     self.zombies.push_back(zombie_process);
                     (join_cond, previous_context)
                 },
@@ -3010,6 +3021,21 @@ impl ProcessManager {
                     ErrorCode::InvalidArgument,
                     "number of buffered messages underflowed",
                 ))
+            },
+        }
+    }
+
+    /// Removes purged messages from the global buffered-message count.
+    fn note_messages_purged(&mut self, purged_messages: usize) {
+        match self.number_buffered_messages.checked_sub(purged_messages) {
+            Some(n) => self.number_buffered_messages = n,
+            None => {
+                error!(
+                    "number of buffered messages underflowed while purging (buffered={}, \
+                     purged={})",
+                    self.number_buffered_messages, purged_messages
+                );
+                self.number_buffered_messages = 0;
             },
         }
     }

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -493,6 +493,16 @@ impl ProcessState {
         self.mailbox.receive(tid)
     }
 
+    /// Removes every buffered message addressed exactly to `tid`.
+    pub fn purge_thread_messages(&mut self, tid: ThreadIdentifier) -> usize {
+        self.mailbox.purge_thread(tid)
+    }
+
+    /// Removes every buffered message.
+    pub fn purge_messages(&mut self) -> usize {
+        self.mailbox.purge_all()
+    }
+
     /// # Description
     ///
     /// Adds an MMIO region to the process state.

--- a/src/kernel/src/pm/test.rs
+++ b/src/kernel/src/pm/test.rs
@@ -32,6 +32,10 @@ use ::sys::{
         MessageType,
     },
     mm::Address,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
 };
 
 //==================================================================================================
@@ -61,6 +65,42 @@ fn test_mailbox_is_empty_tracks_buffered_messages() -> bool {
     mailbox.send(message);
     if mailbox.is_empty() {
         error!("mailbox reported as empty after sending a message");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// Verifies that mailbox purge operations report how many messages they remove.
+///
+fn test_mailbox_purge_counts_removed_messages() -> bool {
+    let mut mailbox: Mailbox = Mailbox::default();
+    let tid: ThreadIdentifier = ThreadIdentifier::from(42);
+    let thread_receiver: MessageReceiver = MessageReceiver::new(ProcessIdentifier::KERNEL, tid);
+    let process_receiver: MessageReceiver =
+        MessageReceiver::new(ProcessIdentifier::KERNEL, ThreadIdentifier::NONE);
+    for receiver in [thread_receiver, process_receiver] {
+        mailbox.send(Message::new(
+            MessageSender::KERNEL,
+            receiver,
+            MessageType::Ipc,
+            Option::<ErrorCode>::None,
+            [0u8; Message::PAYLOAD_SIZE],
+        ));
+    }
+
+    if mailbox.purge_thread(tid) != 1 {
+        error!("thread-message purge removed an unexpected number of messages");
+        return false;
+    }
+    if mailbox.purge_all() != 1 {
+        error!("whole-mailbox purge removed an unexpected number of messages");
+        return false;
+    }
+    if !mailbox.is_empty() {
+        error!("mailbox remained non-empty after purging every message");
         return false;
     }
     true
@@ -861,6 +901,7 @@ fn test_link_user_pages_rolls_back_on_partial_failure() -> bool {
 pub fn test() -> bool {
     let mut passed: bool = true;
     passed &= run_test!(test_mailbox_is_empty_tracks_buffered_messages);
+    passed &= run_test!(test_mailbox_purge_counts_removed_messages);
     passed &= run_test!(test_kernel_process_has_no_special_resources);
     passed &= run_test!(test_cow_resolution_creates_private_frame);
     passed &= run_test!(test_cow_resolution_fast_path_when_sole_owner);


### PR DESCRIPTION
## Summary

Fix IPC mailbox lifecycle bugs in the kernel so that buffered messages
cannot outlive their recipients or be delivered to terminated targets,
and keep the global buffered-message accounting consistent.

## Changes

- **Purge buffered messages on exit.** Drain a process's or thread's
  buffered messages when it exits so stale mailbox entries are not
  stranded. Add `Mailbox::purge_thread()` / `purge_all()` (each returning
  the number of removed messages) and `ProcessState` wrappers; subtract
  purged counts from `number_buffered_messages` via
  `note_messages_purged()`, panicking on accounting underflow.
- **Reject message posts to zombies.** Fail delivery with
  `ErrorCode::NoSuchEntry` (and a logged reason) when the resolved
  receiver is a zombie process or zombie thread, instead of buffering
  into state that will never be drained.
- **Tests.** Add `test_mailbox_purge_counts_removed_messages` verifying
  that `purge_thread()` and `purge_all()` report the correct removal
  counts and leave the mailbox empty.