### PR TITLE
Feat/3039/resolvedpath

### DIFF
--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -460,29 +460,29 @@ pub(crate) fn handle_chdir_with_hostfs(
     request: ChangeDirectoryRequest,
     pending: &mut PendingQueue,
 ) -> Option<Vec<Message>> {
-    let resolved = match vfs_resolve_path(AT_FDCWD, &request.path) {
-        Some(p) => p,
-        None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
+    let Some(resolved) = vfs_resolve_path(AT_FDCWD, &request.path)
+        .as_deref()
+        .and_then(ResolvedPath::new)
+    else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
 
-    if hostfs::is_hostfs_path(&resolved) {
+    if hostfs::is_hostfs_path(resolved.as_str()) {
         if !pending.has_capacity() {
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id = pending.alloc_op_id();
-        match hostfs::send_pathstat_request(&resolved, op_id) {
+        match hostfs::send_pathstat_request(resolved.as_str(), op_id) {
             Ok(()) => {
-                if pending
-                    .insert(
-                        op_id,
-                        PendingOp {
-                            source_tid: source,
-                            source_pid,
-                            kind: PendingOpKind::Chdir { path: resolved },
-                        },
-                    )
-                    .is_err()
-                {
+                let res = pending.insert(
+                    op_id,
+                    PendingOp {
+                        source_tid: source,
+                        source_pid,
+                        kind: PendingOpKind::Chdir { path: resolved },
+                    },
+                );
+                if res.is_err() {
                     return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
                 }
                 return None;
@@ -647,7 +647,10 @@ use ::syscall::{
         SymbolicLinkAtRequest,
     },
 };
-use ::vfs::fd::vfs_resolve_path;
+use ::vfs::fd::{
+    vfs_resolve_path,
+    ResolvedPath,
+};
 use alloc::{
     vec,
     vec::Vec,

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -1186,6 +1186,7 @@ fn complete_lstat(source_tid: ThreadIdentifier, response_payload: &[u8; Message:
 fn complete_chdir(
     source_tid: ThreadIdentifier,
     response_payload: &[u8; Message::PAYLOAD_SIZE],
+<<<<<<< HEAD
     path: String,
 ) {
     let resp: LstatResponse = match LstatResponse::decode(response_payload) {
@@ -1208,6 +1209,31 @@ fn complete_chdir(
     }
 
     if let Err(e) = vfs_set_cwd(&path) {
+||||||| parent of e3de1c841 ([vfsd] E: hostfs-aware chdir)
+=======
+    path: &str,
+) {
+    let resp: LstatResponse = match LstatResponse::decode(response_payload) {
+        Some(r) => r,
+        None => {
+            ::syslog::error!("complete_chdir: failed to decode response");
+            send_response(&build_error(source_tid, ErrorCode::IoErr));
+            return;
+        },
+    };
+
+    if resp.status < 0 {
+        send_response(&build_error(source_tid, hostfs_error_to_code(resp.status)));
+        return;
+    }
+
+    if resp.kind != file_kind::DIRECTORY {
+        send_response(&build_error(source_tid, ErrorCode::InvalidDirectory));
+        return;
+    }
+
+    if let Err(e) = vfs_set_cwd(path) {
+>>>>>>> e3de1c841 ([vfsd] E: hostfs-aware chdir)
         send_response(&build_error(source_tid, fat32_to_error_code(&e)));
         return;
     }

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -20,13 +20,9 @@ extern crate alloc;
 
 use crate::error::{
     build_error,
-    fat32_to_error_code,
     send_response,
 };
-use ::alloc::{
-    collections::BTreeMap,
-    string::String,
-};
+use ::alloc::collections::BTreeMap;
 use ::hostfs_api::{
     file_kind,
     LstatResponse,
@@ -45,7 +41,10 @@ use ::sys::{
     },
 };
 use ::syscall::unistd::message::ChangeDirectoryResponse;
-use ::vfs::fd::vfs_set_cwd;
+use ::vfs::fd::{
+    vfs_set_cwd,
+    ResolvedPath,
+};
 
 //==================================================================================================
 // Pending Operation Descriptor
@@ -109,7 +108,7 @@ pub(crate) enum PendingOpKind {
     /// when the target is a directory (else `ENOTDIR`). Reuses the `PathStat` wire form.
     Chdir {
         /// Absolute hostfs path to become the cwd once confirmed to be a directory.
-        path: String,
+        path: ResolvedPath,
     },
     /// getdents — directory listing over hostfs.
     ///
@@ -1186,8 +1185,7 @@ fn complete_lstat(source_tid: ThreadIdentifier, response_payload: &[u8; Message:
 fn complete_chdir(
     source_tid: ThreadIdentifier,
     response_payload: &[u8; Message::PAYLOAD_SIZE],
-<<<<<<< HEAD
-    path: String,
+    path: ResolvedPath,
 ) {
     let resp: LstatResponse = match LstatResponse::decode(response_payload) {
         Some(r) => r,
@@ -1208,35 +1206,7 @@ fn complete_chdir(
         return;
     }
 
-    if let Err(e) = vfs_set_cwd(&path) {
-||||||| parent of e3de1c841 ([vfsd] E: hostfs-aware chdir)
-=======
-    path: &str,
-) {
-    let resp: LstatResponse = match LstatResponse::decode(response_payload) {
-        Some(r) => r,
-        None => {
-            ::syslog::error!("complete_chdir: failed to decode response");
-            send_response(&build_error(source_tid, ErrorCode::IoErr));
-            return;
-        },
-    };
-
-    if resp.status < 0 {
-        send_response(&build_error(source_tid, hostfs_error_to_code(resp.status)));
-        return;
-    }
-
-    if resp.kind != file_kind::DIRECTORY {
-        send_response(&build_error(source_tid, ErrorCode::InvalidDirectory));
-        return;
-    }
-
-    if let Err(e) = vfs_set_cwd(path) {
->>>>>>> e3de1c841 ([vfsd] E: hostfs-aware chdir)
-        send_response(&build_error(source_tid, fat32_to_error_code(&e)));
-        return;
-    }
+    vfs_set_cwd(path);
     send_response(&ChangeDirectoryResponse::build(
         source_tid,
         ProcessIdentifier::VFSD,

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -1495,22 +1495,42 @@ pub fn vfs_chdir(path: &str) -> Result<(), Fat32Error> {
     Ok(())
 }
 
-/// Commits the current working directory to a hostfs path, bypassing local
-/// mount-table validation but still enforcing an absolute, normalized cwd.
+/// An absolute, lexically-normalized VFS path.
 ///
-/// Unlike [`vfs_chdir`], this performs NO existence/type check: vfsd uses it to
-/// finalize a chdir onto a hostfs path after hostfsd has confirmed the target is
-/// a directory (hostfs paths live outside the local FAT mount table, so
-/// [`vfs_chdir`] would reject them). `path` is normalized here so the stored cwd
-/// keeps the same absolute, canonical form as every other code path; a relative
-/// or malformed `path` is rejected with [`Fat32Error::InvalidPath`].
-pub fn vfs_set_cwd(path: &str) -> Result<(), Fat32Error> {
-    if !path.starts_with('/') {
-        return Err(Fat32Error::InvalidPath);
+/// Constructible via [`ResolvedPath::new`] for already-absolute paths or
+/// [`ResolvedPath::new_relative`] for paths relative to a known directory.
+/// Both constructors normalize `.`/`..` components.
+#[derive(Clone, Debug)]
+pub struct ResolvedPath(String);
+
+impl ResolvedPath {
+    /// Normalizes `path` and wraps it, anchoring relative paths at root.
+    ///
+    /// Returns `None` if normalization fails (e.g. too many `..` components).
+    pub fn new(path: &str) -> Option<Self> {
+        filesystem::normalize("/", path).ok().map(Self)
     }
-    let normalized: String = filesystem::normalize(&current_cwd(), path)?;
-    set_current_cwd(normalized);
-    Ok(())
+
+    /// Normalizes `path` relative to `cwd` and wraps it.
+    ///
+    /// Returns `None` if normalization fails.
+    pub fn new_relative(path: &str, cwd: &str) -> Option<Self> {
+        filesystem::normalize(cwd, path).ok().map(Self)
+    }
+
+    /// Returns the normalized path string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Commits the current working directory to a hostfs path.
+///
+/// vfsd uses this to finalize a chdir onto a hostfs path after hostfsd has
+/// confirmed the target is a directory (hostfs paths live outside the local FAT
+/// mount table, so [`vfs_chdir`] would reject them).
+pub fn vfs_set_cwd(path: ResolvedPath) {
+    set_current_cwd(path.0);
 }
 
 /// Changes the current working directory to the directory referenced by a VFS FD.


### PR DESCRIPTION
Adds `ResolvedPath` struct for better semantics and type safety around vfsd chdir operations.

Closes #3039 
Based on #3038 