### PR TITLE
[vfs] Add ResolvedPath struct

### DIFF
--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -413,11 +413,9 @@ pub(crate) fn handle_fstatat_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let resolved: alloc::string::String =
-        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path) {
-            Some(p) => p,
-            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
-        };
+    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.path) else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    };
     let final_path: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_path) {
@@ -474,9 +472,8 @@ pub(crate) fn handle_chdir_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let resolved = match vfs_resolve_path(AT_FDCWD, &request.path) {
-        Some(p) => p,
-        None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
+    let Some(resolved) = vfs_resolve_path(AT_FDCWD, &request.path) else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
 
     if hostfs::is_hostfs_path(&resolved) {
@@ -758,11 +755,9 @@ pub(crate) fn handle_openat_with_hostfs(
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
     request.mode = ::vfs::fd::vfs_apply_umask(request.mode);
-    let resolved: alloc::string::String =
-        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.pathname) {
-            Some(p) => p,
-            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
-        };
+    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    };
     let final_path: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_path) {
@@ -803,16 +798,12 @@ pub(crate) fn handle_renameat_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let old_resolved: alloc::string::String =
-        match ::vfs::fd::vfs_resolve_path(request.olddirfd, &request.oldpath) {
-            Some(p) => p,
-            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
-        };
-    let new_resolved: alloc::string::String =
-        match ::vfs::fd::vfs_resolve_path(request.newdirfd, &request.newpath) {
-            Some(p) => p,
-            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
-        };
+    let Some(old_resolved) = vfs_resolve_path(request.olddirfd, &request.oldpath) else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    };
+    let Some(new_resolved) = vfs_resolve_path(request.newdirfd, &request.newpath) else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    };
     let old_final: &str = &old_resolved;
     let new_final: &str = &new_resolved;
 
@@ -861,11 +852,9 @@ pub(crate) fn handle_unlinkat_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let resolved: alloc::string::String =
-        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.pathname) {
-            Some(p) => p,
-            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
-        };
+    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    };
     let final_path: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_path) {
@@ -917,11 +906,9 @@ pub(crate) fn handle_mkdirat_with_hostfs(
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
     request.mode = ::vfs::fd::vfs_apply_umask(request.mode);
-    let resolved: alloc::string::String =
-        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.pathname) {
-            Some(p) => p,
-            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
-        };
+    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    };
     let final_path: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_path) {
@@ -963,11 +950,9 @@ pub(crate) fn handle_symlinkat_with_hostfs(
     let source: ThreadIdentifier = response_context.source_tid();
     // Routing key is `linkpath` (where the symlink will live). `target` is an opaque
     // string stored verbatim by the host and intentionally not consulted here.
-    let resolved: alloc::string::String =
-        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.linkpath) {
-            Some(p) => p,
-            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
-        };
+    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.linkpath) else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    };
     let final_link: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_link) {
@@ -1007,11 +992,9 @@ pub(crate) fn handle_readlinkat_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let resolved: alloc::string::String =
-        match ::vfs::fd::vfs_resolve_path(request.dirfd, &request.path) {
-            Some(p) => p,
-            None => return Some(vec![build_error(source, ErrorCode::InvalidArgument)]),
-        };
+    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.path) else {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    };
     let final_path: &str = &resolved;
 
     if hostfs::is_hostfs_path(final_path) {

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -416,9 +416,8 @@ pub(crate) fn handle_fstatat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.path) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = resolved.as_str();
 
-    if hostfs::is_hostfs_path(final_path) {
+    if hostfs::is_hostfs_path(resolved.as_str()) {
         // Both stat modes are supported over hostfs. No-follow (`AT_SYMLINK_NOFOLLOW`)
         // maps to a path-based lstat; following stat (the default for `stat(2)`) maps to
         // a path-based following stat. Both reuse the same response wire format
@@ -430,9 +429,9 @@ pub(crate) fn handle_fstatat_with_hostfs(
         }
         let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
         let (send_result, kind) = if no_follow {
-            (hostfs::send_lstat_request(final_path, op_id), PendingOpKind::Lstat)
+            (hostfs::send_lstat_request(&resolved, op_id), PendingOpKind::Lstat)
         } else {
-            (hostfs::send_pathstat_request(final_path, op_id), PendingOpKind::PathStat)
+            (hostfs::send_pathstat_request(&resolved, op_id), PendingOpKind::PathStat)
         };
         match send_result {
             Ok(()) => {
@@ -456,7 +455,7 @@ pub(crate) fn handle_fstatat_with_hostfs(
         }
     }
 
-    Some(super::long::handle_fstatat(source, request))
+    Some(super::long::handle_fstatat(source, resolved))
 }
 
 /// hostfs-aware `chdir`.
@@ -481,7 +480,7 @@ pub(crate) fn handle_chdir_with_hostfs(
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id = pending.alloc_op_id();
-        match hostfs::send_pathstat_request(resolved.as_str(), op_id) {
+        match hostfs::send_pathstat_request(&resolved, op_id) {
             Ok(()) => {
                 if pending
                     .insert(
@@ -758,15 +757,14 @@ pub(crate) fn handle_openat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = resolved.as_str();
 
-    if hostfs::is_hostfs_path(final_path) {
+    if hostfs::is_hostfs_path(resolved.as_str()) {
         if !pending.has_capacity() {
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
-        let open_path: alloc::string::String = alloc::string::String::from(final_path);
-        match hostfs::send_open_request(final_path, request.flags, request.mode, op_id) {
+        let open_path: alloc::string::String = alloc::string::String::from(resolved.as_str());
+        match hostfs::send_open_request(&resolved, request.flags, request.mode, op_id) {
             Ok(()) => {
                 if pending
                     .insert(
@@ -788,7 +786,7 @@ pub(crate) fn handle_openat_with_hostfs(
         }
     }
 
-    Some(super::long::handle_openat(source, request))
+    Some(super::long::handle_openat(source, resolved, request.flags))
 }
 
 pub(crate) fn handle_renameat_with_hostfs(
@@ -804,11 +802,8 @@ pub(crate) fn handle_renameat_with_hostfs(
     let Some(new_resolved) = vfs_resolve_path(request.newdirfd, &request.newpath) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let old_final: &str = old_resolved.as_str();
-    let new_final: &str = new_resolved.as_str();
-
-    let old_is_hostfs: bool = hostfs::is_hostfs_path(old_final);
-    let new_is_hostfs: bool = hostfs::is_hostfs_path(new_final);
+    let old_is_hostfs: bool = hostfs::is_hostfs_path(old_resolved.as_str());
+    let new_is_hostfs: bool = hostfs::is_hostfs_path(new_resolved.as_str());
 
     // Reject cross-filesystem renames (one path on hostfs, the other on ramfs).
     if old_is_hostfs != new_is_hostfs {
@@ -820,7 +815,7 @@ pub(crate) fn handle_renameat_with_hostfs(
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
-        match hostfs::send_rename_request(old_final, new_final, op_id) {
+        match hostfs::send_rename_request(&old_resolved, &new_resolved, op_id) {
             Ok(()) => {
                 if pending
                     .insert(
@@ -842,7 +837,7 @@ pub(crate) fn handle_renameat_with_hostfs(
         }
     }
 
-    Some(super::long::handle_renameat(source, request))
+    Some(super::long::handle_renameat(source, old_resolved, new_resolved))
 }
 
 pub(crate) fn handle_unlinkat_with_hostfs(
@@ -855,18 +850,17 @@ pub(crate) fn handle_unlinkat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = resolved.as_str();
 
-    if hostfs::is_hostfs_path(final_path) {
+    if hostfs::is_hostfs_path(resolved.as_str()) {
         if !pending.has_capacity() {
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
         let is_rmdir: bool = (request.flags & ::sysapi::fcntl::atflags::AT_REMOVEDIR) != 0;
         let result = if is_rmdir {
-            hostfs::send_rmdir_request(final_path, op_id)
+            hostfs::send_rmdir_request(&resolved, op_id)
         } else {
-            hostfs::send_unlink_request(final_path, op_id)
+            hostfs::send_unlink_request(&resolved, op_id)
         };
         match result {
             Ok(()) => {
@@ -895,7 +889,7 @@ pub(crate) fn handle_unlinkat_with_hostfs(
         }
     }
 
-    Some(super::long::handle_unlinkat(source, request))
+    Some(super::long::handle_unlinkat(source, resolved, request.flags))
 }
 
 pub(crate) fn handle_mkdirat_with_hostfs(
@@ -909,14 +903,13 @@ pub(crate) fn handle_mkdirat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = resolved.as_str();
 
-    if hostfs::is_hostfs_path(final_path) {
+    if hostfs::is_hostfs_path(resolved.as_str()) {
         if !pending.has_capacity() {
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
-        match hostfs::send_mkdir_request(final_path, request.mode, op_id) {
+        match hostfs::send_mkdir_request(&resolved, request.mode, op_id) {
             Ok(()) => {
                 if pending
                     .insert(
@@ -938,7 +931,7 @@ pub(crate) fn handle_mkdirat_with_hostfs(
         }
     }
 
-    Some(super::long::handle_mkdirat(source, request))
+    Some(super::long::handle_mkdirat(source, resolved))
 }
 
 pub(crate) fn handle_symlinkat_with_hostfs(
@@ -953,14 +946,13 @@ pub(crate) fn handle_symlinkat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.linkpath) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_link: &str = resolved.as_str();
 
-    if hostfs::is_hostfs_path(final_link) {
+    if hostfs::is_hostfs_path(resolved.as_str()) {
         if !pending.has_capacity() {
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
-        match hostfs::send_symlink_request(&request.target, final_link, op_id) {
+        match hostfs::send_symlink_request(&request.target, &resolved, op_id) {
             Ok(()) => {
                 if pending
                     .insert(
@@ -995,15 +987,14 @@ pub(crate) fn handle_readlinkat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.path) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = resolved.as_str();
 
-    if hostfs::is_hostfs_path(final_path) {
+    if hostfs::is_hostfs_path(resolved.as_str()) {
         if !pending.has_capacity() {
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
         let bufsiz: usize = request.bufsiz;
-        match hostfs::send_readlink_request(final_path, op_id) {
+        match hostfs::send_readlink_request(&resolved, op_id) {
             Ok(()) => {
                 if pending
                     .insert(

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -416,7 +416,7 @@ pub(crate) fn handle_fstatat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.path) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = &resolved;
+    let final_path: &str = resolved.as_str();
 
     if hostfs::is_hostfs_path(final_path) {
         // Both stat modes are supported over hostfs. No-follow (`AT_SYMLINK_NOFOLLOW`)
@@ -476,12 +476,12 @@ pub(crate) fn handle_chdir_with_hostfs(
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
 
-    if hostfs::is_hostfs_path(&resolved) {
+    if hostfs::is_hostfs_path(resolved.as_str()) {
         if !pending.has_capacity() {
             return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
         }
         let op_id = pending.alloc_op_id();
-        match hostfs::send_pathstat_request(&resolved, op_id) {
+        match hostfs::send_pathstat_request(resolved.as_str(), op_id) {
             Ok(()) => {
                 if pending
                     .insert(
@@ -660,7 +660,7 @@ use ::syscall::{
         SymbolicLinkAtRequest,
     },
 };
-use ::vfs::fd::vfs_resolve_path;
+use ::vfs::path::vfs_resolve_path;
 use alloc::{
     vec,
     vec::Vec,
@@ -758,7 +758,7 @@ pub(crate) fn handle_openat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = &resolved;
+    let final_path: &str = resolved.as_str();
 
     if hostfs::is_hostfs_path(final_path) {
         if !pending.has_capacity() {
@@ -804,8 +804,8 @@ pub(crate) fn handle_renameat_with_hostfs(
     let Some(new_resolved) = vfs_resolve_path(request.newdirfd, &request.newpath) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let old_final: &str = &old_resolved;
-    let new_final: &str = &new_resolved;
+    let old_final: &str = old_resolved.as_str();
+    let new_final: &str = new_resolved.as_str();
 
     let old_is_hostfs: bool = hostfs::is_hostfs_path(old_final);
     let new_is_hostfs: bool = hostfs::is_hostfs_path(new_final);
@@ -855,7 +855,7 @@ pub(crate) fn handle_unlinkat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = &resolved;
+    let final_path: &str = resolved.as_str();
 
     if hostfs::is_hostfs_path(final_path) {
         if !pending.has_capacity() {
@@ -909,7 +909,7 @@ pub(crate) fn handle_mkdirat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = &resolved;
+    let final_path: &str = resolved.as_str();
 
     if hostfs::is_hostfs_path(final_path) {
         if !pending.has_capacity() {
@@ -953,7 +953,7 @@ pub(crate) fn handle_symlinkat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.linkpath) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_link: &str = &resolved;
+    let final_link: &str = resolved.as_str();
 
     if hostfs::is_hostfs_path(final_link) {
         if !pending.has_capacity() {
@@ -995,7 +995,7 @@ pub(crate) fn handle_readlinkat_with_hostfs(
     let Some(resolved) = vfs_resolve_path(request.dirfd, &request.path) else {
         return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
     };
-    let final_path: &str = &resolved;
+    let final_path: &str = resolved.as_str();
 
     if hostfs::is_hostfs_path(final_path) {
         if !pending.has_capacity() {

--- a/src/daemons/vfsd/src/handler/long.rs
+++ b/src/daemons/vfsd/src/handler/long.rs
@@ -27,21 +27,16 @@ use ::syscall::{
         GetDirectoryEntriesResponse,
     },
     fcntl::message::{
-        OpenAtRequest,
         OpenAtResponse,
-        RenameAtRequest,
         RenameAtResponse,
-        UnlinkAtRequest,
         UnlinkAtResponse,
     },
     message::MessagePartitioner,
     sys::stat::message::{
         FileChmodAtRequest,
         FileChmodAtResponse,
-        FileStatAtRequest,
         FileStatAtResponse,
         FileStatRequest,
-        MakeDirectoryAtRequest,
         MakeDirectoryAtResponse,
         UpdateFileAccessTimeAtRequest,
         UpdateFileAccessTimeAtResponse,
@@ -62,6 +57,7 @@ use ::syscall::{
     },
     SystemCallMessage,
 };
+use ::vfs::path::ResolvedPath;
 use alloc::{
     vec,
     vec::Vec,
@@ -136,8 +132,12 @@ pub(crate) fn handle_getdents(source: ThreadIdentifier, msg: SystemCallMessage) 
 // Long Request Handlers (multi-part request, single or multi-part response)
 //==================================================================================================
 
-pub(crate) fn handle_openat(source: ThreadIdentifier, request: OpenAtRequest) -> Vec<Message> {
-    match ::vfs::fd::vfs_openat(request.dirfd, &request.pathname, request.flags) {
+pub(crate) fn handle_openat(
+    source: ThreadIdentifier,
+    path: ResolvedPath,
+    flags: i32,
+) -> Vec<Message> {
+    match ::vfs::fd::vfs_open_resolved(path, flags) {
         Ok(fd) => {
             let epoch: u64 = ::vfs::fd::vfs_current_generation();
             vec![OpenAtResponse::build(
@@ -152,13 +152,12 @@ pub(crate) fn handle_openat(source: ThreadIdentifier, request: OpenAtRequest) ->
     }
 }
 
-pub(crate) fn handle_renameat(source: ThreadIdentifier, request: RenameAtRequest) -> Vec<Message> {
-    match ::vfs::fd::vfs_renameat(
-        request.olddirfd,
-        &request.oldpath,
-        request.newdirfd,
-        &request.newpath,
-    ) {
+pub(crate) fn handle_renameat(
+    source: ThreadIdentifier,
+    old_path: ResolvedPath,
+    new_path: ResolvedPath,
+) -> Vec<Message> {
+    match ::vfs::fd::vfs_rename_resolved(old_path, new_path) {
         Ok(()) => {
             vec![RenameAtResponse::build(
                 source,
@@ -171,8 +170,12 @@ pub(crate) fn handle_renameat(source: ThreadIdentifier, request: RenameAtRequest
     }
 }
 
-pub(crate) fn handle_unlinkat(source: ThreadIdentifier, request: UnlinkAtRequest) -> Vec<Message> {
-    match ::vfs::fd::vfs_unlinkat(request.dirfd, &request.pathname, request.flags) {
+pub(crate) fn handle_unlinkat(
+    source: ThreadIdentifier,
+    path: ResolvedPath,
+    flags: i32,
+) -> Vec<Message> {
+    match ::vfs::fd::vfs_unlink_resolved(path, flags) {
         Ok(()) => {
             vec![UnlinkAtResponse::build(
                 source,
@@ -185,11 +188,8 @@ pub(crate) fn handle_unlinkat(source: ThreadIdentifier, request: UnlinkAtRequest
     }
 }
 
-pub(crate) fn handle_mkdirat(
-    source: ThreadIdentifier,
-    request: MakeDirectoryAtRequest,
-) -> Vec<Message> {
-    match ::vfs::fd::vfs_mkdirat(request.dirfd, &request.pathname) {
+pub(crate) fn handle_mkdirat(source: ThreadIdentifier, path: ResolvedPath) -> Vec<Message> {
+    match ::vfs::fd::vfs_mkdir_resolved(path) {
         Ok(()) => {
             vec![MakeDirectoryAtResponse::build(
                 source,
@@ -202,9 +202,9 @@ pub(crate) fn handle_mkdirat(
     }
 }
 
-pub(crate) fn handle_fstatat(source: ThreadIdentifier, request: FileStatAtRequest) -> Vec<Message> {
+pub(crate) fn handle_fstatat(source: ThreadIdentifier, path: ResolvedPath) -> Vec<Message> {
     let mut st = stat::default();
-    match ::vfs::fd::vfs_fstatat(request.dirfd, &request.path, &mut st) {
+    match ::vfs::fd::vfs_stat_resolved(path, &mut st) {
         Ok(()) => {
             let response: FileStatAtResponse = FileStatAtResponse::new(st);
             match response.into_parts(source, ProcessIdentifier::VFSD, MessageType::Ipc) {

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -35,6 +35,7 @@ use ::syscall::{
     message::SystemCallMessagePart,
     SystemCallMessageKind,
 };
+use ::vfs::path::ResolvedPath;
 
 extern crate alloc;
 
@@ -185,12 +186,12 @@ fn send_long_request(
 
 /// Sends an OPEN request to hostfsd as a multi-part IKC message.
 pub fn send_open_request(
-    path: &str,
+    path: &ResolvedPath,
     flags: i32,
     mode: u32,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let relative: &str = strip_mount_prefix(path);
+    let relative: &str = strip_mount_prefix(path.as_str());
     let buf: alloc::vec::Vec<u8> =
         long_msg::serialize_long_open_request(op_id, flags, mode, relative.as_bytes())
             .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
@@ -308,11 +309,11 @@ pub fn send_flush_request(
 
 /// Sends a MKDIR request to hostfsd as a multi-part IKC message.
 pub fn send_mkdir_request(
-    path: &str,
+    path: &ResolvedPath,
     mode: u32,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let relative: &str = strip_mount_prefix(path);
+    let relative: &str = strip_mount_prefix(path.as_str());
     let buf: alloc::vec::Vec<u8> =
         long_msg::serialize_long_mkdir_request(op_id, mode, relative.as_bytes())
             .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
@@ -321,8 +322,11 @@ pub fn send_mkdir_request(
 }
 
 /// Sends an RMDIR request to hostfsd as a multi-part IKC message.
-pub fn send_rmdir_request(path: &str, op_id: OperationId) -> Result<(), ::sys::error::ErrorCode> {
-    let relative: &str = strip_mount_prefix(path);
+pub fn send_rmdir_request(
+    path: &ResolvedPath,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path.as_str());
     let buf: alloc::vec::Vec<u8> =
         long_msg::serialize_long_rmdir_request(op_id, relative.as_bytes())
             .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
@@ -331,8 +335,11 @@ pub fn send_rmdir_request(path: &str, op_id: OperationId) -> Result<(), ::sys::e
 }
 
 /// Sends an UNLINK request to hostfsd as a multi-part IKC message.
-pub fn send_unlink_request(path: &str, op_id: OperationId) -> Result<(), ::sys::error::ErrorCode> {
-    let relative: &str = strip_mount_prefix(path);
+pub fn send_unlink_request(
+    path: &ResolvedPath,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path.as_str());
     let buf: alloc::vec::Vec<u8> =
         long_msg::serialize_long_unlink_request(op_id, relative.as_bytes())
             .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
@@ -382,12 +389,12 @@ pub fn send_readdir_request(
 
 /// Sends a RENAME request to hostfsd as a multi-part IKC message.
 pub fn send_rename_request(
-    old_path: &str,
-    new_path: &str,
+    old_path: &ResolvedPath,
+    new_path: &ResolvedPath,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let old_relative: &str = strip_mount_prefix(old_path);
-    let new_relative: &str = strip_mount_prefix(new_path);
+    let old_relative: &str = strip_mount_prefix(old_path.as_str());
+    let new_relative: &str = strip_mount_prefix(new_path.as_str());
     let buf: alloc::vec::Vec<u8> = long_msg::serialize_long_rename_request(
         op_id,
         old_relative.as_bytes(),
@@ -410,11 +417,11 @@ pub fn send_rename_request(
 /// acceptable since symlink creation is rare relative to readlink/lstat.
 pub fn send_symlink_request(
     target: &str,
-    linkpath: &str,
+    linkpath: &ResolvedPath,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
     // The target is opaque to vfsd and stored verbatim by the host; do not strip /mnt.
-    let link_relative: &str = strip_mount_prefix(linkpath);
+    let link_relative: &str = strip_mount_prefix(linkpath.as_str());
     let buf: alloc::vec::Vec<u8> = long_msg::serialize_long_symlink_request(
         op_id,
         target.as_bytes(),
@@ -430,10 +437,10 @@ pub fn send_symlink_request(
 /// Uses the single-message inline form when the path fits within
 /// [`MAX_INLINE_PATH_LEN`], and falls back to a multi-part request otherwise.
 pub fn send_readlink_request(
-    path: &str,
+    path: &ResolvedPath,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let relative: &str = strip_mount_prefix(path);
+    let relative: &str = strip_mount_prefix(path.as_str());
     let path_bytes: &[u8] = relative.as_bytes();
 
     // Inline fast path: avoids the multi-part assembler when the path fits.
@@ -460,8 +467,11 @@ pub fn send_readlink_request(
 /// stat that does not follow the final symbolic link component. Uses the
 /// single-message inline form when the path fits within [`MAX_INLINE_PATH_LEN`],
 /// and falls back to a multi-part request otherwise.
-pub fn send_lstat_request(path: &str, op_id: OperationId) -> Result<(), ::sys::error::ErrorCode> {
-    let relative: &str = strip_mount_prefix(path);
+pub fn send_lstat_request(
+    path: &ResolvedPath,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path.as_str());
     let path_bytes: &[u8] = relative.as_bytes();
 
     // Inline fast path: avoids the multi-part assembler when the path fits.
@@ -491,10 +501,10 @@ pub fn send_lstat_request(path: &str, op_id: OperationId) -> Result<(), ::sys::e
 /// form when the path fits within [`MAX_INLINE_PATH_LEN`], and falls back to a
 /// multi-part request otherwise.
 pub fn send_pathstat_request(
-    path: &str,
+    path: &ResolvedPath,
     op_id: OperationId,
 ) -> Result<(), ::sys::error::ErrorCode> {
-    let relative: &str = strip_mount_prefix(path);
+    let relative: &str = strip_mount_prefix(path.as_str());
     let path_bytes: &[u8] = relative.as_bytes();
 
     // Inline fast path: avoids the multi-part assembler when the path fits.

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -44,9 +44,9 @@ use ::sys::{
     },
 };
 use ::syscall::unistd::message::ChangeDirectoryResponse;
-use ::vfs::fd::{
-    vfs_set_cwd,
-    ResolvedPath,
+use ::vfs::{
+    fd::vfs_set_cwd,
+    path::ResolvedPath,
 };
 
 //==================================================================================================

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -20,15 +20,11 @@ extern crate alloc;
 
 use crate::error::{
     build_error,
-    fat32_to_error_code,
     ResponseContext,
 };
-use ::alloc::{
-    collections::{
-        BTreeMap,
-        BTreeSet,
-    },
-    string::String,
+use ::alloc::collections::{
+    BTreeMap,
+    BTreeSet,
 };
 use ::hostfs_api::{
     file_kind,
@@ -48,7 +44,10 @@ use ::sys::{
     },
 };
 use ::syscall::unistd::message::ChangeDirectoryResponse;
-use ::vfs::fd::vfs_set_cwd;
+use ::vfs::fd::{
+    vfs_set_cwd,
+    ResolvedPath,
+};
 
 //==================================================================================================
 // Pending Operation Descriptor
@@ -114,7 +113,7 @@ pub(crate) enum PendingOpKind {
     /// when the target is a directory (else `ENOTDIR`). Reuses the `PathStat` wire form.
     Chdir {
         /// Absolute hostfs path to become the cwd once confirmed to be a directory.
-        path: String,
+        path: ResolvedPath,
     },
     /// getdents — directory listing over hostfs.
     ///
@@ -1400,7 +1399,7 @@ fn complete_lstat(
 fn complete_chdir(
     response_context: ResponseContext,
     response_payload: &[u8; Message::PAYLOAD_SIZE],
-    path: String,
+    path: ResolvedPath,
 ) {
     let source_tid: ThreadIdentifier = response_context.source_tid();
     let resp: LstatResponse = match LstatResponse::decode(response_payload) {
@@ -1422,10 +1421,7 @@ fn complete_chdir(
         return;
     }
 
-    if let Err(e) = vfs_set_cwd(&path) {
-        response_context.send(&build_error(source_tid, fat32_to_error_code(&e)));
-        return;
-    }
+    vfs_set_cwd(path);
     response_context.send(&ChangeDirectoryResponse::build(
         source_tid,
         ProcessIdentifier::VFSD,

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -34,6 +34,7 @@ use crate::{
         LineDiscipline,
         TerminalSignal,
     },
+    mount::normalize_absolute,
     process::{
         current_cwd,
         current_pid,
@@ -53,6 +54,7 @@ use ::alloc::{
         BTreeMap,
         BTreeSet,
     },
+    format,
     string::String,
     sync::Arc,
     vec::Vec,
@@ -960,6 +962,23 @@ pub fn vfs_poll(fd: c_int, events: c_short) -> Result<c_short, Fat32Error> {
     Ok(revents)
 }
 
+/// An absolute VFS path produced by [`vfs_resolve_path`].
+///
+/// Carries the proof that a `dirfd` + `path` pair has already been anchored, so
+/// callees need not re-check it. The path is absolute but not necessarily
+/// lexically normalized: `.`/`..` are left for whoever owns the path to
+/// interpret, since hostfs resolves them against the real filesystem.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedPath(String);
+
+impl core::ops::Deref for ResolvedPath {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// Resolves a `dirfd` + `path` pair into an absolute VFS path.
 ///
 /// If `path` is absolute, it is returned as-is (dirfd is ignored per POSIX).
@@ -968,7 +987,7 @@ pub fn vfs_poll(fd: c_int, events: c_short) -> Result<c_short, Fat32Error> {
 /// relative to that directory's path.
 ///
 /// Returns `None` if `dirfd` is neither `AT_FDCWD` nor a directory descriptor of the current
-/// process, indicating that VFS cannot handle this request.
+/// process, indicating that VFS cannot handle this request, or if `path` is empty.
 ///
 /// # Limitations
 ///
@@ -977,12 +996,18 @@ pub fn vfs_poll(fd: c_int, events: c_short) -> Result<c_short, Fat32Error> {
 /// using this dirfd will resolve against the stale path. A future protocol
 /// extension could support `*at()` operations relative to a remote directory
 /// FD on the host side to provide stable POSIX-like dirfd semantics.
-pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<String> {
+pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<ResolvedPath> {
     use ::sysapi::fcntl::atflags::AT_FDCWD;
+
+    // An empty path names nothing. Anchoring one would silently yield the base
+    // directory, so reject it here rather than resolve to the cwd.
+    if path.is_empty() {
+        return None;
+    }
 
     // Absolute paths are always resolved directly (dirfd ignored per POSIX).
     if path.starts_with('/') {
-        return Some(String::from(path));
+        return Some(ResolvedPath(String::from(path)));
     }
 
     // Relative path with AT_FDCWD: resolve against VFS cwd.
@@ -991,11 +1016,7 @@ pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<String> {
             return None;
         }
         let cwd: String = current_cwd();
-        return if cwd.ends_with('/') {
-            Some(alloc::format!("{}{}", cwd, path))
-        } else {
-            Some(alloc::format!("{}/{}", cwd, path))
-        };
+        return Some(ResolvedPath(join(&cwd, path)));
     }
 
     // Relative path with a directory descriptor: resolve against that directory. Validity is the
@@ -1009,10 +1030,15 @@ pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<String> {
         _ => return None, // fd is not a directory
     };
 
-    if dir_path.ends_with('/') {
-        Some(alloc::format!("{}{}", dir_path, path))
+    Some(ResolvedPath(join(dir_path, path)))
+}
+
+/// Joins `path` onto the absolute `base`.
+fn join(base: &str, path: &str) -> String {
+    if base.ends_with('/') {
+        format!("{}{}", base, path)
     } else {
-        Some(alloc::format!("{}/{}", dir_path, path))
+        format!("{}/{}", base, path)
     }
 }
 
@@ -1048,7 +1074,7 @@ pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
 /// example, when it is not a VFS directory file descriptor). The `dirfd` is
 /// never silently ignored.
 pub fn vfs_openat(dirfd: c_int, path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
-    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     vfs_open(&resolved, flags)
 }
 
@@ -1446,7 +1472,7 @@ pub fn vfs_fstatat(
     path: &str,
     buf: &mut ::sysapi::sys_stat::stat,
 ) -> Result<(), Fat32Error> {
-    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     vfs_stat(&resolved, buf)
 }
 
@@ -1478,7 +1504,7 @@ pub fn vfs_mkdir(path: &str) -> Result<(), Fat32Error> {
 /// example, when it is not a VFS directory file descriptor). The `dirfd` is
 /// never silently ignored.
 pub fn vfs_mkdirat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
-    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     vfs_mkdir(&resolved)
 }
 
@@ -1496,21 +1522,16 @@ pub fn vfs_chdir(path: &str) -> Result<(), Fat32Error> {
 }
 
 /// Commits the current working directory to a hostfs path, bypassing local
-/// mount-table validation but still enforcing an absolute, normalized cwd.
+/// mount-table validation.
 ///
 /// Unlike [`vfs_chdir`], this performs NO existence/type check: vfsd uses it to
 /// finalize a chdir onto a hostfs path after hostfsd has confirmed the target is
 /// a directory (hostfs paths live outside the local FAT mount table, so
-/// [`vfs_chdir`] would reject them). `path` is normalized here so the stored cwd
-/// keeps the same absolute, canonical form as every other code path; a relative
-/// or malformed `path` is rejected with [`Fat32Error::InvalidPath`].
-pub fn vfs_set_cwd(path: &str) -> Result<(), Fat32Error> {
-    if !path.starts_with('/') {
-        return Err(Fat32Error::InvalidPath);
-    }
-    let normalized: String = filesystem::normalize(&current_cwd(), path)?;
-    set_current_cwd(normalized);
-    Ok(())
+/// [`vfs_chdir`] would reject them). Taking a [`ResolvedPath`] moves the
+/// absolute-path check to the caller; the path is normalized here so the stored
+/// cwd keeps the same canonical form as every other code path.
+pub fn vfs_set_cwd(path: ResolvedPath) {
+    set_current_cwd(normalize_absolute(&path));
 }
 
 /// Changes the current working directory to the directory referenced by a VFS FD.
@@ -1881,7 +1902,7 @@ pub fn vfs_access(path: &str) -> Result<(), Fat32Error> {
 /// example, when it is not a VFS directory file descriptor). The `dirfd` is
 /// never silently ignored.
 pub fn vfs_accessat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
-    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     vfs_access(&resolved)
 }
 
@@ -1994,10 +2015,8 @@ pub fn vfs_renameat(
     newdirfd: c_int,
     newpath: &str,
 ) -> Result<(), Fat32Error> {
-    let old_resolved: String =
-        vfs_resolve_path(olddirfd, oldpath).ok_or(Fat32Error::InvalidArgument)?;
-    let new_resolved: String =
-        vfs_resolve_path(newdirfd, newpath).ok_or(Fat32Error::InvalidArgument)?;
+    let old_resolved = vfs_resolve_path(olddirfd, oldpath).ok_or(Fat32Error::InvalidArgument)?;
+    let new_resolved = vfs_resolve_path(newdirfd, newpath).ok_or(Fat32Error::InvalidArgument)?;
     filesystem::rename(&current_cwd(), &old_resolved, &new_resolved)
 }
 
@@ -2019,7 +2038,7 @@ pub fn vfs_renameat(
 /// a directory), or the path refers to a directory but `AT_REMOVEDIR` is not set.
 pub fn vfs_unlinkat(dirfd: c_int, path: &str, flags: c_int) -> Result<(), Fat32Error> {
     use ::sysapi::fcntl::atflags::AT_REMOVEDIR;
-    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     if flags & AT_REMOVEDIR != 0 {
         filesystem::rmdir(&current_cwd(), &resolved)
     } else {
@@ -2093,7 +2112,7 @@ pub fn vfs_fchmodat(
     _mode: ::sysapi::sys_types::mode_t,
     _flag: c_int,
 ) -> Result<(), Fat32Error> {
-    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     // Verify that the target exists using the VFS-level stat for consistent semantics.
     filesystem::stat(&current_cwd(), &resolved).map(|_| ())
 }
@@ -2122,7 +2141,7 @@ pub fn vfs_fchownat(
     _group: gid_t,
     _flag: c_int,
 ) -> Result<(), Fat32Error> {
-    let resolved: String = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     // Verify that the target exists using the VFS-level stat for consistent semantics.
     filesystem::stat(&current_cwd(), &resolved).map(|_| ())
 }
@@ -2154,9 +2173,9 @@ pub fn vfs_utimensat(
     if flags != 0 {
         return Err(Fat32Error::InvalidArgument);
     }
-    let path: String = vfs_resolve_path(dirfd, pathname).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, pathname).ok_or(Fat32Error::InvalidArgument)?;
     // Verify that the target exists using the VFS-level stat for consistent semantics.
-    filesystem::stat(&current_cwd(), &path).map(|_| ())
+    filesystem::stat(&current_cwd(), &resolved).map(|_| ())
 }
 
 //==================================================================================================

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -998,7 +998,14 @@ pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
 /// never silently ignored.
 pub fn vfs_openat(dirfd: c_int, path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
-    vfs_open(resolved.as_str(), flags)
+    vfs_open_resolved(resolved, flags)
+}
+
+/// Opens an already-resolved path and allocates a system-wide FD.
+///
+/// Skips the [`vfs_resolve_path`] step: the caller already anchored the path.
+pub fn vfs_open_resolved(path: ResolvedPath, flags: c_int) -> Result<c_int, Fat32Error> {
+    vfs_open(path.as_str(), flags)
 }
 
 /// Reads from a VFS file descriptor.
@@ -1396,7 +1403,17 @@ pub fn vfs_fstatat(
     buf: &mut ::sysapi::sys_stat::stat,
 ) -> Result<(), Fat32Error> {
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
-    vfs_stat(resolved.as_str(), buf)
+    vfs_stat_resolved(resolved, buf)
+}
+
+/// Gets file status for an already-resolved path.
+///
+/// Skips the [`vfs_resolve_path`] step: the caller already anchored the path.
+pub fn vfs_stat_resolved(
+    path: ResolvedPath,
+    buf: &mut ::sysapi::sys_stat::stat,
+) -> Result<(), Fat32Error> {
+    vfs_stat(path.as_str(), buf)
 }
 
 /// Renames a file or directory through the VFS.
@@ -1428,7 +1445,14 @@ pub fn vfs_mkdir(path: &str) -> Result<(), Fat32Error> {
 /// never silently ignored.
 pub fn vfs_mkdirat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
-    vfs_mkdir(resolved.as_str())
+    vfs_mkdir_resolved(resolved)
+}
+
+/// Creates a directory at an already-resolved path.
+///
+/// Skips the [`vfs_resolve_path`] step: the caller already anchored the path.
+pub fn vfs_mkdir_resolved(path: ResolvedPath) -> Result<(), Fat32Error> {
+    vfs_mkdir(path.as_str())
 }
 
 /// Removes an empty directory through the VFS.
@@ -1940,7 +1964,17 @@ pub fn vfs_renameat(
 ) -> Result<(), Fat32Error> {
     let old_resolved = vfs_resolve_path(olddirfd, oldpath).ok_or(Fat32Error::InvalidArgument)?;
     let new_resolved = vfs_resolve_path(newdirfd, newpath).ok_or(Fat32Error::InvalidArgument)?;
-    filesystem::rename(&current_cwd(), old_resolved.as_str(), new_resolved.as_str())
+    vfs_rename_resolved(old_resolved, new_resolved)
+}
+
+/// Renames between two already-resolved paths.
+///
+/// Skips the [`vfs_resolve_path`] step: the caller already anchored both paths.
+pub fn vfs_rename_resolved(
+    old_path: ResolvedPath,
+    new_path: ResolvedPath,
+) -> Result<(), Fat32Error> {
+    filesystem::rename(&current_cwd(), old_path.as_str(), new_path.as_str())
 }
 
 /// Unlinks a file or removes a directory relative to a directory file descriptor through the VFS.
@@ -1960,12 +1994,19 @@ pub fn vfs_renameat(
 /// Returns a [`Fat32Error`] if the path does not exist, the directory is not empty (when removing
 /// a directory), or the path refers to a directory but `AT_REMOVEDIR` is not set.
 pub fn vfs_unlinkat(dirfd: c_int, path: &str, flags: c_int) -> Result<(), Fat32Error> {
-    use ::sysapi::fcntl::atflags::AT_REMOVEDIR;
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    vfs_unlink_resolved(resolved, flags)
+}
+
+/// Unlinks a file or removes a directory at an already-resolved path.
+///
+/// Skips the [`vfs_resolve_path`] step: the caller already anchored the path.
+pub fn vfs_unlink_resolved(path: ResolvedPath, flags: c_int) -> Result<(), Fat32Error> {
+    use ::sysapi::fcntl::atflags::AT_REMOVEDIR;
     if flags & AT_REMOVEDIR != 0 {
-        filesystem::rmdir(&current_cwd(), resolved.as_str())
+        filesystem::rmdir(&current_cwd(), path.as_str())
     } else {
-        filesystem::unlink(&current_cwd(), resolved.as_str())
+        filesystem::unlink(&current_cwd(), path.as_str())
     }
 }
 

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -35,6 +35,10 @@ use crate::{
         TerminalSignal,
     },
     mount::normalize_absolute,
+    path::{
+        vfs_resolve_path,
+        ResolvedPath,
+    },
     process::{
         current_cwd,
         current_pid,
@@ -54,7 +58,6 @@ use ::alloc::{
         BTreeMap,
         BTreeSet,
     },
-    format,
     string::String,
     sync::Arc,
     vec::Vec,
@@ -167,7 +170,7 @@ pub use crate::{
 /// descriptor with no slot in the current process is rejected. vfsd serves no I/O on console or
 /// socket tokens; the I/O methods on [`VfsFileHandle`] reject those handles, so this accessor does
 /// not need to special-case them.
-fn entry_arc(fd: c_int) -> Result<OpenFile, Fat32Error> {
+pub(crate) fn entry_arc(fd: c_int) -> Result<OpenFile, Fat32Error> {
     let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> = PROCESSES.lock();
     let state: &ProcessState = procs.get(&current_pid()).ok_or(Fat32Error::InvalidFd)?;
     state
@@ -962,86 +965,6 @@ pub fn vfs_poll(fd: c_int, events: c_short) -> Result<c_short, Fat32Error> {
     Ok(revents)
 }
 
-/// An absolute VFS path produced by [`vfs_resolve_path`].
-///
-/// Carries the proof that a `dirfd` + `path` pair has already been anchored, so
-/// callees need not re-check it. The path is absolute but not necessarily
-/// lexically normalized: `.`/`..` are left for whoever owns the path to
-/// interpret, since hostfs resolves them against the real filesystem.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ResolvedPath(String);
-
-impl core::ops::Deref for ResolvedPath {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// Resolves a `dirfd` + `path` pair into an absolute VFS path.
-///
-/// If `path` is absolute, it is returned as-is (dirfd is ignored per POSIX).
-/// If `dirfd` is `AT_FDCWD`, the path is resolved against the VFS current
-/// working directory. If `dirfd` is a directory descriptor, the path is resolved
-/// relative to that directory's path.
-///
-/// Returns `None` if `dirfd` is neither `AT_FDCWD` nor a directory descriptor of the current
-/// process, indicating that VFS cannot handle this request, or if `path` is empty.
-///
-/// # Limitations
-///
-/// For hostfs directory fds, resolution uses the path stored at open time.
-/// If the directory is renamed after being opened, subsequent `*at()` calls
-/// using this dirfd will resolve against the stale path. A future protocol
-/// extension could support `*at()` operations relative to a remote directory
-/// FD on the host side to provide stable POSIX-like dirfd semantics.
-pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<ResolvedPath> {
-    use ::sysapi::fcntl::atflags::AT_FDCWD;
-
-    // An empty path names nothing. Anchoring one would silently yield the base
-    // directory, so reject it here rather than resolve to the cwd.
-    if path.is_empty() {
-        return None;
-    }
-
-    // Absolute paths are always resolved directly (dirfd ignored per POSIX).
-    if path.starts_with('/') {
-        return Some(ResolvedPath(String::from(path)));
-    }
-
-    // Relative path with AT_FDCWD: resolve against VFS cwd.
-    if dirfd == AT_FDCWD {
-        if !crate::state::is_initialized() {
-            return None;
-        }
-        let cwd: String = current_cwd();
-        return Some(ResolvedPath(join(&cwd, path)));
-    }
-
-    // Relative path with a directory descriptor: resolve against that directory. Validity is the
-    // slot's handle type, not the descriptor number — a non-directory or absent descriptor yields
-    // `None` below rather than being pre-screened by a number range.
-    let file: OpenFile = entry_arc(dirfd).ok()?;
-    let guard = file.lock();
-    let dir_path: &str = match &guard.handle {
-        VfsFileHandle::Directory(dh) => dh.path(),
-        VfsFileHandle::HostFs(hh) if hh.is_dir() => hh.path()?,
-        _ => return None, // fd is not a directory
-    };
-
-    Some(ResolvedPath(join(dir_path, path)))
-}
-
-/// Joins `path` onto the absolute `base`.
-fn join(base: &str, path: &str) -> String {
-    if base.ends_with('/') {
-        format!("{}{}", base, path)
-    } else {
-        format!("{}/{}", base, path)
-    }
-}
-
 //==================================================================================================
 // POSIX-Compatible Operations
 //==================================================================================================
@@ -1075,7 +998,7 @@ pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
 /// never silently ignored.
 pub fn vfs_openat(dirfd: c_int, path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
-    vfs_open(&resolved, flags)
+    vfs_open(resolved.as_str(), flags)
 }
 
 /// Reads from a VFS file descriptor.
@@ -1473,7 +1396,7 @@ pub fn vfs_fstatat(
     buf: &mut ::sysapi::sys_stat::stat,
 ) -> Result<(), Fat32Error> {
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
-    vfs_stat(&resolved, buf)
+    vfs_stat(resolved.as_str(), buf)
 }
 
 /// Renames a file or directory through the VFS.
@@ -1505,7 +1428,7 @@ pub fn vfs_mkdir(path: &str) -> Result<(), Fat32Error> {
 /// never silently ignored.
 pub fn vfs_mkdirat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
-    vfs_mkdir(&resolved)
+    vfs_mkdir(resolved.as_str())
 }
 
 /// Removes an empty directory through the VFS.
@@ -1903,7 +1826,7 @@ pub fn vfs_access(path: &str) -> Result<(), Fat32Error> {
 /// never silently ignored.
 pub fn vfs_accessat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
-    vfs_access(&resolved)
+    vfs_access(resolved.as_str())
 }
 
 /// File control operation on a VFS file descriptor.
@@ -2017,7 +1940,7 @@ pub fn vfs_renameat(
 ) -> Result<(), Fat32Error> {
     let old_resolved = vfs_resolve_path(olddirfd, oldpath).ok_or(Fat32Error::InvalidArgument)?;
     let new_resolved = vfs_resolve_path(newdirfd, newpath).ok_or(Fat32Error::InvalidArgument)?;
-    filesystem::rename(&current_cwd(), &old_resolved, &new_resolved)
+    filesystem::rename(&current_cwd(), old_resolved.as_str(), new_resolved.as_str())
 }
 
 /// Unlinks a file or removes a directory relative to a directory file descriptor through the VFS.
@@ -2040,9 +1963,9 @@ pub fn vfs_unlinkat(dirfd: c_int, path: &str, flags: c_int) -> Result<(), Fat32E
     use ::sysapi::fcntl::atflags::AT_REMOVEDIR;
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     if flags & AT_REMOVEDIR != 0 {
-        filesystem::rmdir(&current_cwd(), &resolved)
+        filesystem::rmdir(&current_cwd(), resolved.as_str())
     } else {
-        filesystem::unlink(&current_cwd(), &resolved)
+        filesystem::unlink(&current_cwd(), resolved.as_str())
     }
 }
 
@@ -2114,7 +2037,7 @@ pub fn vfs_fchmodat(
 ) -> Result<(), Fat32Error> {
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     // Verify that the target exists using the VFS-level stat for consistent semantics.
-    filesystem::stat(&current_cwd(), &resolved).map(|_| ())
+    filesystem::stat(&current_cwd(), resolved.as_str()).map(|_| ())
 }
 
 /// Changes the owner and group of a file relative to a directory file descriptor through the VFS.
@@ -2143,7 +2066,7 @@ pub fn vfs_fchownat(
 ) -> Result<(), Fat32Error> {
     let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
     // Verify that the target exists using the VFS-level stat for consistent semantics.
-    filesystem::stat(&current_cwd(), &resolved).map(|_| ())
+    filesystem::stat(&current_cwd(), resolved.as_str()).map(|_| ())
 }
 
 /// Sets file access and modification times through the VFS.
@@ -2175,7 +2098,7 @@ pub fn vfs_utimensat(
     }
     let resolved = vfs_resolve_path(dirfd, pathname).ok_or(Fat32Error::InvalidArgument)?;
     // Verify that the target exists using the VFS-level stat for consistent semantics.
-    filesystem::stat(&current_cwd(), &resolved).map(|_| ())
+    filesystem::stat(&current_cwd(), resolved.as_str()).map(|_| ())
 }
 
 //==================================================================================================

--- a/src/libs/vfs/src/lib.rs
+++ b/src/libs/vfs/src/lib.rs
@@ -83,6 +83,9 @@ pub mod line_discipline;
 /// Mount table and path resolution.
 pub mod mount;
 
+/// Resolved VFS paths.
+pub mod path;
+
 /// In-memory pipe buffers for POSIX unnamed pipes.
 pub mod pipe;
 

--- a/src/libs/vfs/src/mount.rs
+++ b/src/libs/vfs/src/mount.rs
@@ -15,6 +15,7 @@ mod vfs;
 // Re-Exports
 //==================================================================================================
 
+pub(crate) use self::vfs::normalize_absolute;
 pub use self::{
     mount_point::Mount,
     vfs::Vfs,

--- a/src/libs/vfs/src/mount/vfs.rs
+++ b/src/libs/vfs/src/mount/vfs.rs
@@ -23,6 +23,7 @@ use super::{
     path_cache::PathCache,
     Mount,
 };
+use crate::fd::ResolvedPath;
 use ::alloc::{
     string::String,
     vec::Vec,
@@ -135,9 +136,8 @@ impl Vfs {
     ///
     /// # Errors
     ///
-    /// Returns [`Fat32Error::InvalidPath`] if the path is empty, if a relative `path` is
-    /// anchored to a `cwd` that is not absolute, or if the path contains invalid sequences
-    /// (e.g., too many `..`).
+    /// Returns [`Fat32Error::InvalidPath`] if the path is empty or if a relative `path` is
+    /// anchored to a `cwd` that is not absolute. `..` at the root clamps to the root, per POSIX.
     pub fn normalize_path(&self, path: &str, cwd: &str) -> Result<String, Fat32Error> {
         if path.is_empty() {
             return Err(Fat32Error::InvalidPath);
@@ -155,32 +155,7 @@ impl Vfs {
             alloc::format!("{}/{}", cwd, path)
         };
 
-        let mut components: Vec<&str> = Vec::new();
-
-        for component in abs_path.split('/') {
-            match component {
-                "" | "." => {},
-                ".." => {
-                    if components.pop().is_none() {
-                        return Err(Fat32Error::InvalidPath);
-                    }
-                },
-                other => {
-                    components.push(other);
-                },
-            }
-        }
-
-        if components.is_empty() {
-            Ok(String::from("/"))
-        } else {
-            let mut result: String = String::new();
-            for component in components {
-                result.push('/');
-                result.push_str(component);
-            }
-            Ok(result)
-        }
+        Ok(normalize_components(&abs_path))
     }
 
     /// Resolves a path to a mount and relative path within that mount.
@@ -260,6 +235,46 @@ impl Vfs {
     }
 }
 
+/// Lexically normalizes a resolved path.
+///
+/// Resolves `.` and `..`, collapses repeated separators, and drops trailing
+/// slashes. Never fails: [`ResolvedPath`] is absolute by construction, and `..`
+/// at the root clamps to the root, as POSIX defines `/..` to be `/`.
+pub(crate) fn normalize_absolute(path: &ResolvedPath) -> String {
+    normalize_components(path)
+}
+
+/// Lexically normalizes an absolute `path`.
+///
+/// Shared with [`Vfs::normalize_path`], which anchors relative paths against a
+/// `cwd` before calling in and so cannot hand over a [`ResolvedPath`].
+fn normalize_components(path: &str) -> String {
+    let mut components: Vec<&str> = Vec::new();
+
+    for component in path.split('/') {
+        match component {
+            "" | "." => {},
+            ".." => {
+                components.pop();
+            },
+            other => {
+                components.push(other);
+            },
+        }
+    }
+
+    if components.is_empty() {
+        return String::from("/");
+    }
+
+    let mut result: String = String::new();
+    for component in components {
+        result.push('/');
+        result.push_str(component);
+    }
+    result
+}
+
 //==================================================================================================
 // Trait Implementations
 //==================================================================================================
@@ -327,12 +342,14 @@ mod tests {
         assert_eq!(result, "/");
     }
 
-    /// Tests that too many ".." returns an error.
+    /// Tests that ".." past the root clamps to the root, per POSIX.
     #[test]
-    fn normalize_too_many_dotdot() {
+    fn normalize_dotdot_past_root_clamps() {
         let vfs: Vfs = Vfs::new();
-        let result = vfs.normalize_path("/data/../..", "/");
-        assert_eq!(result.unwrap_err(), Fat32Error::InvalidPath, "should fail with InvalidPath");
+        let result: String = vfs
+            .normalize_path("/data/../..", "/")
+            .expect("should succeed");
+        assert_eq!(result, "/", ".. past root should clamp to root");
     }
 
     /// Tests that empty path returns an error.

--- a/src/libs/vfs/src/mount/vfs.rs
+++ b/src/libs/vfs/src/mount/vfs.rs
@@ -23,7 +23,7 @@ use super::{
     path_cache::PathCache,
     Mount,
 };
-use crate::fd::ResolvedPath;
+use crate::path::ResolvedPath;
 use ::alloc::{
     string::String,
     vec::Vec,
@@ -241,7 +241,7 @@ impl Vfs {
 /// slashes. Never fails: [`ResolvedPath`] is absolute by construction, and `..`
 /// at the root clamps to the root, as POSIX defines `/..` to be `/`.
 pub(crate) fn normalize_absolute(path: &ResolvedPath) -> String {
-    normalize_components(path)
+    normalize_components(path.as_str())
 }
 
 /// Lexically normalizes an absolute `path`.

--- a/src/libs/vfs/src/path.rs
+++ b/src/libs/vfs/src/path.rs
@@ -1,0 +1,123 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Resolved VFS paths.
+//!
+//! [`ResolvedPath`] records that a `dirfd` + `path` pair has been anchored into
+//! an absolute path. The inner value is private to this module and
+//! [`vfs_resolve_path`] is the only way to produce one, so holding a
+//! `ResolvedPath` is proof that resolution actually happened.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    descriptor::VfsFileHandle,
+    fd::entry_arc,
+    process::{
+        current_cwd,
+        OpenFile,
+    },
+};
+use ::alloc::{
+    format,
+    string::String,
+};
+use ::sysapi::ffi::c_int;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// An absolute VFS path produced by [`vfs_resolve_path`].
+///
+/// Carries the proof that a `dirfd` + `path` pair has already been anchored, so
+/// callees need not re-check it. The path is absolute but not necessarily
+/// lexically normalized: `.`/`..` are left for whoever owns the path to
+/// interpret, since hostfs resolves them against the real filesystem.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedPath(String);
+
+impl ResolvedPath {
+    /// Returns the absolute path.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consumes the resolved path, returning the absolute path.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+//==================================================================================================
+// Public Functions
+//==================================================================================================
+
+/// Resolves a `dirfd` + `path` pair into an absolute VFS path.
+///
+/// If `path` is absolute, it is returned as-is (dirfd is ignored per POSIX).
+/// If `dirfd` is `AT_FDCWD`, the path is resolved against the VFS current
+/// working directory. If `dirfd` is a directory descriptor, the path is resolved
+/// relative to that directory's path.
+///
+/// Returns `None` if `dirfd` is neither `AT_FDCWD` nor a directory descriptor of the current
+/// process, indicating that VFS cannot handle this request, or if `path` is empty.
+///
+/// # Limitations
+///
+/// For hostfs directory fds, resolution uses the path stored at open time.
+/// If the directory is renamed after being opened, subsequent `*at()` calls
+/// using this dirfd will resolve against the stale path. A future protocol
+/// extension could support `*at()` operations relative to a remote directory
+/// FD on the host side to provide stable POSIX-like dirfd semantics.
+pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<ResolvedPath> {
+    use ::sysapi::fcntl::atflags::AT_FDCWD;
+
+    // An empty path names nothing. Anchoring one would silently yield the base
+    // directory, so reject it here rather than resolve to the cwd.
+    if path.is_empty() {
+        return None;
+    }
+
+    // Absolute paths are always resolved directly (dirfd ignored per POSIX).
+    if path.starts_with('/') {
+        return Some(ResolvedPath(String::from(path)));
+    }
+
+    // Relative path with AT_FDCWD: resolve against VFS cwd.
+    if dirfd == AT_FDCWD {
+        if !crate::state::is_initialized() {
+            return None;
+        }
+        let cwd: String = current_cwd();
+        return Some(ResolvedPath(join(&cwd, path)));
+    }
+
+    // Relative path with a directory descriptor: resolve against that directory. Validity is the
+    // slot's handle type, not the descriptor number — a non-directory or absent descriptor yields
+    // `None` below rather than being pre-screened by a number range.
+    let file: OpenFile = entry_arc(dirfd).ok()?;
+    let guard = file.lock();
+    let dir_path: &str = match &guard.handle {
+        VfsFileHandle::Directory(dh) => dh.path(),
+        VfsFileHandle::HostFs(hh) if hh.is_dir() => hh.path()?,
+        _ => return None, // fd is not a directory
+    };
+
+    Some(ResolvedPath(join(dir_path, path)))
+}
+
+//==================================================================================================
+// Private Functions
+//==================================================================================================
+
+/// Joins `path` onto the absolute `base`.
+fn join(base: &str, path: &str) -> String {
+    if base.ends_with('/') {
+        format!("{}{}", base, path)
+    } else {
+        format!("{}/{}", base, path)
+    }
+}

--- a/src/tests/integration/test-rust-vfs-test/src/main.rs
+++ b/src/tests/integration/test-rust-vfs-test/src/main.rs
@@ -41,6 +41,7 @@ use ::sysapi::{
         posix_dent,
     },
     fcntl::{
+        atflags::AT_FDCWD,
         file_control_request,
         file_creation_flags,
         file_descriptor_flags,
@@ -50,6 +51,10 @@ use ::sysapi::{
         stat,
     },
     time::timespec,
+};
+use ::vfs::fd::{
+    vfs_resolve_path,
+    ResolvedPath,
 };
 
 //==================================================================================================
@@ -1032,27 +1037,26 @@ fn test_resolve_path() -> Result<(), Error> {
     vfs::mkdir("/rp/sub").map_err(|e| fat_err(e, "mkdir /rp/sub failed"))?;
 
     // Absolute path: dirfd should be ignored.
-    let resolved: alloc::string::String = vfs::fd::vfs_resolve_path(0, "/rp/sub/file.txt")
+    let resolved: ResolvedPath = vfs_resolve_path(0, "/rp/sub/file.txt")
         .ok_or(Error::new(ErrorCode::InvalidArgument, "absolute resolve failed"))?;
-    if resolved != "/rp/sub/file.txt" {
+    if &*resolved != "/rp/sub/file.txt" {
         return Err(Error::new(ErrorCode::InvalidArgument, "absolute path mismatch"));
     }
 
     // AT_FDCWD: resolve relative to VFS cwd.
     vfs::chdir("/rp").map_err(|e| fat_err(e, "chdir /rp failed"))?;
-    let resolved_cwd: alloc::string::String =
-        vfs::fd::vfs_resolve_path(::sysapi::fcntl::atflags::AT_FDCWD, "sub")
-            .ok_or(Error::new(ErrorCode::InvalidArgument, "AT_FDCWD resolve failed"))?;
-    if resolved_cwd != "/rp/sub" {
+    let resolved_cwd = vfs_resolve_path(AT_FDCWD, "sub")
+        .ok_or(Error::new(ErrorCode::InvalidArgument, "AT_FDCWD resolve failed"))?;
+    if &*resolved_cwd != "/rp/sub" {
         return Err(Error::new(ErrorCode::InvalidArgument, "AT_FDCWD path mismatch"));
     }
 
     // VFS directory fd: resolve relative to directory path.
     let dir_fd: i32 = vfs::fd::vfs_open("/rp/sub", file_creation_flags::O_DIRECTORY)
         .map_err(|e| fat_err(e, "vfs_open /rp/sub O_DIRECTORY"))?;
-    let resolved_dir: alloc::string::String = vfs::fd::vfs_resolve_path(dir_fd, "nested.txt")
+    let resolved_dir = vfs_resolve_path(dir_fd, "nested.txt")
         .ok_or(Error::new(ErrorCode::InvalidArgument, "dirfd resolve failed"))?;
-    if resolved_dir != "/rp/sub/nested.txt" {
+    if &*resolved_dir != "/rp/sub/nested.txt" {
         return Err(Error::new(ErrorCode::InvalidArgument, "dirfd path mismatch"));
     }
 
@@ -1060,8 +1064,13 @@ fn test_resolve_path() -> Result<(), Error> {
     // the slot's handle type, not a number range: close the directory fd so it is absent, then it
     // no longer resolves.
     vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir fd"))?;
-    if vfs::fd::vfs_resolve_path(dir_fd, "file.txt").is_some() {
+    if vfs_resolve_path(dir_fd, "file.txt").is_some() {
         return Err(Error::new(ErrorCode::InvalidArgument, "absent fd should return None"));
+    }
+
+    // An empty path names nothing, so it must not resolve to the cwd.
+    if vfs_resolve_path(AT_FDCWD, "").is_some() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "empty path should return None"));
     }
 
     // Clean up.

--- a/src/tests/integration/test-rust-vfs-test/src/main.rs
+++ b/src/tests/integration/test-rust-vfs-test/src/main.rs
@@ -52,10 +52,7 @@ use ::sysapi::{
     },
     time::timespec,
 };
-use ::vfs::fd::{
-    vfs_resolve_path,
-    ResolvedPath,
-};
+use ::vfs::path::vfs_resolve_path;
 
 //==================================================================================================
 // Constants
@@ -1037,9 +1034,9 @@ fn test_resolve_path() -> Result<(), Error> {
     vfs::mkdir("/rp/sub").map_err(|e| fat_err(e, "mkdir /rp/sub failed"))?;
 
     // Absolute path: dirfd should be ignored.
-    let resolved: ResolvedPath = vfs_resolve_path(0, "/rp/sub/file.txt")
+    let resolved = vfs_resolve_path(0, "/rp/sub/file.txt")
         .ok_or(Error::new(ErrorCode::InvalidArgument, "absolute resolve failed"))?;
-    if &*resolved != "/rp/sub/file.txt" {
+    if resolved.as_str() != "/rp/sub/file.txt" {
         return Err(Error::new(ErrorCode::InvalidArgument, "absolute path mismatch"));
     }
 
@@ -1047,7 +1044,7 @@ fn test_resolve_path() -> Result<(), Error> {
     vfs::chdir("/rp").map_err(|e| fat_err(e, "chdir /rp failed"))?;
     let resolved_cwd = vfs_resolve_path(AT_FDCWD, "sub")
         .ok_or(Error::new(ErrorCode::InvalidArgument, "AT_FDCWD resolve failed"))?;
-    if &*resolved_cwd != "/rp/sub" {
+    if resolved_cwd.as_str() != "/rp/sub" {
         return Err(Error::new(ErrorCode::InvalidArgument, "AT_FDCWD path mismatch"));
     }
 
@@ -1056,7 +1053,7 @@ fn test_resolve_path() -> Result<(), Error> {
         .map_err(|e| fat_err(e, "vfs_open /rp/sub O_DIRECTORY"))?;
     let resolved_dir = vfs_resolve_path(dir_fd, "nested.txt")
         .ok_or(Error::new(ErrorCode::InvalidArgument, "dirfd resolve failed"))?;
-    if &*resolved_dir != "/rp/sub/nested.txt" {
+    if resolved_dir.as_str() != "/rp/sub/nested.txt" {
         return Err(Error::new(ErrorCode::InvalidArgument, "dirfd path mismatch"));
     }
 


### PR DESCRIPTION
Adds a `ResolvedPath` newtype marking paths that have been through
`vfs_resolve_path`, so callees stop re-validating. Closes #3039.

`Resolved` means *provenance*: the path is absolute because it was anchored
against a dirfd or the cwd. It deliberately does **not** mean normalized —
hostfs paths go to hostfsd verbatim, which resolves `..` physically. Collapsing
them lexically here would diverge whenever a component is a symlink.

Three consequences worth review:

- `vfs_set_cwd` takes `ResolvedPath` and returns `()`. The absolute check is now
  the type's job. Normalization stays (otherwise `cd /mnt/foo/..` is stored
  verbatim and grows), which means it has to be infallible — hence:
- `..` past the root now clamps to `/` instead of returning `InvalidPath`.
  POSIX defines `/..` as `/`. Guest-visible: `stat("/..")` was EINVAL, now
  succeeds.
- `vfs_resolve_path("")` now returns `None`. It previously resolved to the cwd,
  so `open("")` handed back a directory fd and `chdir("")` silently succeeded.

`normalize_absolute` takes `&ResolvedPath` rather than `&str` so its
precondition is carried by the type instead of asserted. That puts one upward
`mount` -> `fd` import in the crate; the alternative is `debug_assert!` on a
`&str`.

Follow-up: #3043 (backend-routed path type).
