### PR TITLE
[vfs] Fix POSIX rename replace-existing semantics

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -117,7 +117,7 @@ $(POSIX_TESTS_OBJDIR)/%.o: $(POSIX_TESTS_STRESS_SRCDIR)/%.c
 POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
-	fdatasync.c stat.c ftruncate.c truncate.c renameat.c unlinkat.c mkdirat.c mkdir.c \
+	fdatasync.c stat.c ftruncate.c truncate.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
 	mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -250,9 +250,17 @@ pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Vec<DirEntry>, Fat32Erro
 /// # Errors
 ///
 /// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized.
+/// - [`Fat32Error::ReadOnly`] if the mount is read-only.
 /// - [`Fat32Error::NotFound`] if `old_path` doesn't exist.
-/// - [`Fat32Error::AlreadyExists`] if `new_path` already exists.
-/// - [`Fat32Error::InvalidPath`] if paths are on different mounts.
+/// - [`Fat32Error::NotADirectory`] if source is a directory but destination is a file.
+/// - [`Fat32Error::NotAFile`] if source is a file but destination is a directory.
+/// - [`Fat32Error::NotEmpty`] if destination is a non-empty directory (via `rmdir`).
+/// - [`Fat32Error::InvalidPath`] if paths are on different mounts, or if path resolution
+///   fails (e.g. an empty path, or a `cwd` that is not absolute).
+///
+/// # References
+///
+/// - [POSIX rename()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/rename.html)
 pub(crate) fn rename(cwd: &str, old_path: &str, new_path: &str) -> Result<(), Fat32Error> {
     let (old_idx, old_rel) = resolve_path(cwd, old_path)?;
     let (new_idx, new_rel) = resolve_path(cwd, new_path)?;
@@ -271,7 +279,42 @@ pub(crate) fn rename(cwd: &str, old_path: &str, new_path: &str) -> Result<(), Fa
 
     state::with_vfs(|vfs| {
         let mount = vfs.get_mount(old_idx).ok_or(Fat32Error::NotFound)?;
-        mount.fat().rename(&old_rel, &new_rel)
+        let fat = mount.fat();
+
+        // Ensure source exists before applying identity-rename fast path.
+        let src_stat = fat.stat(&old_rel)?;
+
+        // POSIX: rename(path, path) is a no-op (when the path exists).
+        if old_rel == new_rel {
+            return Ok(());
+        }
+
+        // POSIX rename(2): if destination exists, replace it.
+        // rust-fatfs returns AlreadyExists instead, so we must remove the
+        // target first after validating type compatibility.
+        // NOTE: unlink + rename is not atomic — if rename fails after
+        // unlink, the destination is lost. Fixing this requires upstream
+        // rust-fatfs changes.
+        match fat.stat(&new_rel) {
+            Ok(dst_stat) => {
+                if src_stat.is_dir && !dst_stat.is_dir {
+                    return Err(Fat32Error::NotADirectory);
+                }
+                if !src_stat.is_dir && dst_stat.is_dir {
+                    return Err(Fat32Error::NotAFile);
+                }
+                if dst_stat.is_dir {
+                    // POSIX: replacing a dir requires it to be empty.
+                    fat.rmdir(&new_rel)?;
+                } else {
+                    fat.unlink(&new_rel)?;
+                }
+            },
+            Err(Fat32Error::NotFound) => {},
+            Err(e) => return Err(e),
+        }
+
+        fat.rename(&old_rel, &new_rel)
     })
 }
 

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -255,6 +255,7 @@ pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Vec<DirEntry>, Fat32Erro
 /// - [`Fat32Error::NotADirectory`] if source is a directory but destination is a file.
 /// - [`Fat32Error::NotAFile`] if source is a file but destination is a directory.
 /// - [`Fat32Error::NotEmpty`] if destination is a non-empty directory (via `rmdir`).
+/// - [`Fat32Error::InvalidArgument`] if either path ends in a `.` or `..` component.
 /// - [`Fat32Error::InvalidPath`] if paths are on different mounts, or if path resolution
 ///   fails (e.g. an empty path, or a `cwd` that is not absolute).
 ///
@@ -262,6 +263,12 @@ pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Vec<DirEntry>, Fat32Erro
 ///
 /// - [POSIX rename()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/rename.html)
 pub(crate) fn rename(cwd: &str, old_path: &str, new_path: &str) -> Result<(), Fat32Error> {
+    // POSIX: a trailing "."/".." component is invalid for rename. Normalization
+    // strips these lexically, so guard on the raw path before resolving.
+    if ends_with_dot(old_path) || ends_with_dot(new_path) {
+        return Err(Fat32Error::InvalidArgument);
+    }
+
     let (old_idx, old_rel) = resolve_path(cwd, old_path)?;
     let (new_idx, new_rel) = resolve_path(cwd, new_path)?;
 
@@ -359,6 +366,15 @@ pub(crate) fn normalize(cwd: &str, path: &str) -> Result<String, Fat32Error> {
 //==================================================================================================
 // Internal Functions
 //==================================================================================================
+
+/// Returns `true` if the final component of `path` is `.` or `..`.
+///
+/// POSIX forbids these as rename operands. Trailing slashes are ignored.
+fn ends_with_dot(path: &str) -> bool {
+    let trimmed: &str = path.trim_end_matches('/');
+    let last: &str = trimmed.rsplit('/').next().unwrap_or(trimmed);
+    last == "." || last == ".."
+}
 
 /// Resolves a path through the VFS to determine which mount handles it.
 ///

--- a/src/libs/vfs/src/mount/vfs.rs
+++ b/src/libs/vfs/src/mount/vfs.rs
@@ -176,7 +176,9 @@ impl Vfs {
     ///
     /// # Errors
     ///
-    /// Returns [`Fat32Error::NotFound`] if no mount matches the path.
+    /// Returns [`Fat32Error::NotFound`] if no mount matches the path. Returns
+    /// [`Fat32Error::InvalidPath`] if `path` fails to normalize (empty path, or a `cwd`
+    /// that is not absolute; see [`Vfs::normalize_path`]).
     pub fn resolve(&mut self, path: &str, cwd: &str) -> Result<(usize, String), Fat32Error> {
         let normalized: String = self.normalize_path(path, cwd)?;
 

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -117,6 +117,9 @@ extern void test_readv(void);
 // Tests whether we can rename a file.
 extern void test_renameat(void);
 
+// Tests rename within subdirectories and replace-existing.
+extern void test_renameat_subdir(void);
+
 // Tests whether we can get file status information.
 extern void test_stat(void);
 

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -138,6 +138,7 @@ int main(int argc, const char *argv[])
     test_readlink();   // requires symlinkat() and unlink().
 #endif                 // __NANVIX_STANDALONE__
     test_renameat();   // requires open(), close() and unlink().
+    test_renameat_subdir(); // subdir rename + replace-existing.
     test_unlinkat();   // requires open() and close().
     test_mkdirat();    // requires stat() and unlinkat().
     test_mkdir();      // requires stat() and unlinkat().

--- a/src/tests/integration/test-c-file/renameat_subdir.c
+++ b/src/tests/integration/test-c-file/renameat_subdir.c
@@ -214,6 +214,56 @@ static void test_rename_slash_in_name(void)
     fprintf(stderr, "passed\n");
 }
 
+// Probe 9: <NUL> terminates a pathname at the C-string boundary, so bytes
+// after it never reach the syscall. (POSIX 3.146: a filename excludes
+// <NUL>/<slash>.) Guards against ever passing a length-bearing name.
+static void test_nul_in_name(void)
+{
+    fprintf(stderr, "  nul in name ... ");
+
+    // The embedded <NUL> ends the string, so this creates "nul_a", not "nul_ab".
+    const char name[] = "nul_a\0b";
+    int fd = open(name, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+    assert_exists("nul_a");
+    assert_not_exists("nul_ab");
+
+    // rename likewise stops at the <NUL>.
+    const char dst[] = "nul_c\0d";
+    assert(rename("nul_a", dst) == 0);
+    assert_exists("nul_c");
+    assert_not_exists("nul_a");
+    assert(unlink("nul_c") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Probe 10: FAT32 reserves bytes that POSIX permits in a filename (only
+// <NUL>/<slash> are excluded). The backend must reject them with EINVAL,
+// and must never treat backslash as a path separator.
+static void assert_rejected(const char *name)
+{
+    errno = 0;
+    int fd = open(name, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd == -1);
+    assert(errno == EINVAL);
+}
+
+static void test_nonportable_names(void)
+{
+    fprintf(stderr, "  non-portable name bytes ... ");
+    assert_rejected("bad\\name");
+    assert_rejected("bad<name");
+    assert_rejected("bad>name");
+    assert_rejected("bad:name");
+    assert_rejected("bad\"name");
+    assert_rejected("bad|name");
+    assert_rejected("bad?name");
+    assert_rejected("bad*name");
+    fprintf(stderr, "passed\n");
+}
+
 //==================================================================================================
 // Entry Point
 //==================================================================================================
@@ -230,6 +280,8 @@ void test_renameat_subdir(void)
     test_rename_identity();
     test_rename_dot_dotdot();
     test_rename_slash_in_name();
+    test_nul_in_name();
+    test_nonportable_names();
 
     fprintf(stderr, "renameat subdir: all passed\n");
 }

--- a/src/tests/integration/test-c-file/renameat_subdir.c
+++ b/src/tests/integration/test-c-file/renameat_subdir.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+/* Must come first. */
+#define _POSIX_C_SOURCE 200809L
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+// Create a file with some content.
+static void create_file(const char *path)
+{
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    const char data[] = "xxxxxxxxxxxxxxxx"; // 16 bytes, matching the repro
+    assert(write(fd, data, sizeof(data) - 1) == (ssize_t)(sizeof(data) - 1));
+    assert(close(fd) == 0);
+}
+
+// Assert a file exists.
+static void assert_exists(const char *path)
+{
+    struct stat st;
+    assert(stat(path, &st) == 0);
+}
+
+// Assert a file does not exist.
+static void assert_not_exists(const char *path)
+{
+    struct stat st;
+    assert(stat(path, &st) == -1);
+    assert(errno == ENOENT);
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+// Probe 1: rename within root (no subdirs).
+static void test_rename_root(void)
+{
+    fprintf(stderr, "  rename within root ... ");
+
+    create_file("rename_a");
+    assert(rename("rename_a", "rename_b") == 0);
+    assert_not_exists("rename_a");
+    assert_exists("rename_b");
+    assert(unlink("rename_b") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Probe 2: rename within one subdir.
+static void test_rename_within_subdir(void)
+{
+    fprintf(stderr, "  rename within subdir ... ");
+
+    assert(mkdir("d", S_IRWXU) == 0);
+    create_file("d/a");
+    assert(rename("d/a", "d/b") == 0);
+    assert_not_exists("d/a");
+    assert_exists("d/b");
+    assert(unlink("d/b") == 0);
+    assert(rmdir("d") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Probe 3: rename from subdir to root.
+static void test_rename_subdir_to_root(void)
+{
+    fprintf(stderr, "  rename subdir -> root ... ");
+
+    assert(mkdir("src_dir", S_IRWXU) == 0);
+    create_file("src_dir/file");
+    assert(rename("src_dir/file", "file_at_root") == 0);
+    assert_not_exists("src_dir/file");
+    assert_exists("file_at_root");
+    assert(unlink("file_at_root") == 0);
+    assert(rmdir("src_dir") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Probe 4: rename across two subdirs.
+static void test_rename_across_subdirs(void)
+{
+    fprintf(stderr, "  rename across subdirs ... ");
+
+    assert(mkdir("dir1", S_IRWXU) == 0);
+    assert(mkdir("dir2", S_IRWXU) == 0);
+    create_file("dir1/x");
+    assert(rename("dir1/x", "dir2/y") == 0);
+    assert_not_exists("dir1/x");
+    assert_exists("dir2/y");
+    assert(unlink("dir2/y") == 0);
+    assert(rmdir("dir1") == 0);
+    assert(rmdir("dir2") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Probe 5: rename replacing an existing file (POSIX atomic replace).
+static void test_rename_replace_existing(void)
+{
+    fprintf(stderr, "  rename replace existing ... ");
+
+    assert(mkdir("rd", S_IRWXU) == 0);
+
+    // Make source and destination distinguishable so we can verify replacement.
+    create_file("rd/old");
+    int fd = open("rd/new", O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    const char dst_data[] = "yyyyyyyyyyyyyyyy"; // 16 bytes
+    assert(write(fd, dst_data, sizeof(dst_data) - 1) == (ssize_t)(sizeof(dst_data) - 1));
+    assert(close(fd) == 0);
+
+    assert(rename("rd/old", "rd/new") == 0);
+    assert_not_exists("rd/old");
+
+    fd = open("rd/new", O_RDONLY);
+    assert(fd != -1);
+    char buf[1];
+    assert(read(fd, buf, sizeof(buf)) == 1);
+    assert(close(fd) == 0);
+    assert(buf[0] == 'x');
+
+    assert(unlink("rd/new") == 0);
+    assert(rmdir("rd") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Probe 6: rename(path, path) is a no-op (POSIX identity rename).
+static void test_rename_identity(void)
+{
+    fprintf(stderr, "  rename identity ... ");
+
+    create_file("id_file");
+    assert(rename("id_file", "id_file") == 0);
+    assert_exists("id_file");
+    assert(unlink("id_file") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+//==================================================================================================
+// Entry Point
+//==================================================================================================
+
+void test_renameat_subdir(void)
+{
+    fprintf(stderr, "testing renameat subdir ...\n");
+
+    test_rename_root();
+    test_rename_within_subdir();
+    test_rename_subdir_to_root();
+    test_rename_across_subdirs();
+    test_rename_replace_existing();
+    test_rename_identity();
+
+    fprintf(stderr, "renameat subdir: all passed\n");
+}

--- a/src/tests/integration/test-c-file/renameat_subdir.c
+++ b/src/tests/integration/test-c-file/renameat_subdir.c
@@ -162,6 +162,58 @@ static void test_rename_identity(void)
     fprintf(stderr, "passed\n");
 }
 
+// Probe 7: renaming dot / dot-dot must fail with EINVAL (POSIX).
+static void test_rename_dot_dotdot(void)
+{
+    fprintf(stderr, "  rename dot / dot-dot ... ");
+
+    assert(mkdir("dd", S_IRWXU) == 0);
+    create_file("dd/f");
+
+    // old = "." / ".."
+    assert(rename("dd/.", "dd/x") == -1);
+    assert(errno == EINVAL);
+    assert(rename("dd/..", "dd/x") == -1);
+    assert(errno == EINVAL);
+
+    // new = "." / ".."
+    assert(rename("dd/f", "dd/.") == -1);
+    assert(errno == EINVAL);
+    assert(rename("dd/f", "dd/..") == -1);
+    assert(errno == EINVAL);
+
+    // Source survived; no stray target created.
+    assert_exists("dd/f");
+    assert_not_exists("dd/x");
+
+    assert(unlink("dd/f") == 0);
+    assert(rmdir("dd") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Probe 8: a slash is always a separator, never part of a name.
+// Names with an embedded slash resolve through a missing directory and
+// fail at construction (open) and at rename (ENOENT).
+static void test_rename_slash_in_name(void)
+{
+    fprintf(stderr, "  slash in name ... ");
+
+    // Cannot create a name with an embedded slash: parent dir is missing.
+    int fd = open("nope/file", O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd == -1);
+    assert(errno == ENOENT);
+
+    // Rename to a target under a missing dir must fail too.
+    create_file("sl_src");
+    assert(rename("sl_src", "nope/dst") == -1);
+    assert(errno == ENOENT);
+    assert_exists("sl_src");
+    assert(unlink("sl_src") == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
 //==================================================================================================
 // Entry Point
 //==================================================================================================
@@ -176,6 +228,8 @@ void test_renameat_subdir(void)
     test_rename_across_subdirs();
     test_rename_replace_existing();
     test_rename_identity();
+    test_rename_dot_dotdot();
+    test_rename_slash_in_name();
 
     fprintf(stderr, "renameat subdir: all passed\n");
 }


### PR DESCRIPTION
Fix for nanvix/cpython#501.

`os.rename()` / `os.replace()` returned `EEXIST` when the destination already existed. POSIX requires replacing the target. The underlying rust-fatfs `rename` refuses to overwrite, so the VFS layer now removes the destination first after validating type compatibility (file↔dir mismatch → proper errno, non-empty dir → `ENOTEMPTY`, identity rename → no-op).

Non-atomic unlink+rename is documented; in practice unreachable on the in-memory FAT backend.

Adds C test covering subdirectory renames and replace-existing (`renameat_subdir.c`).