### PR TITLE
[vfs] Fix path edge case errno values

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -118,7 +118,7 @@ POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c ftruncate.c truncate.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
-	mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c
+	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's

--- a/src/libs/fat32/src/fat/filesystem.rs
+++ b/src/libs/fat32/src/fat/filesystem.rs
@@ -388,6 +388,25 @@ impl Fat {
         })
     }
 
+    /// Returns `true` if any proper ancestor of `path` exists but is not a
+    /// directory. Disambiguates fatfs's `InvalidPath` (which conflates "bad
+    /// path" with "non-directory component in the traversal") into a proper
+    /// `NotADirectory` for POSIX `ENOTDIR` semantics. Walks from the immediate
+    /// parent up to the root, stopping at the first existing non-directory.
+    pub fn has_non_directory_ancestor(&self, path: &str) -> bool {
+        let mut end: usize = path.len();
+        while let Some(slash) = path[..end].rfind('/') {
+            let prefix = &path[..slash];
+            if let Ok(st) = self.stat(prefix) {
+                if !st.is_dir {
+                    return true;
+                }
+            }
+            end = slash;
+        }
+        false
+    }
+
     /// Creates a directory.
     ///
     /// # Parameters
@@ -417,7 +436,13 @@ impl Fat {
                 return Err(Fat32Error::AlreadyExists);
             }
 
-            root.create_dir(path).map_err(map_fatfs_error)?;
+            root.create_dir(path)
+                .map_err(|e| match map_fatfs_error(e) {
+                    Fat32Error::InvalidPath if self.has_non_directory_ancestor(path) => {
+                        Fat32Error::NotADirectory
+                    },
+                    e => e,
+                })?;
             Ok(())
         })
     }

--- a/src/libs/vfs/src/fd/open.rs
+++ b/src/libs/vfs/src/fd/open.rs
@@ -87,6 +87,11 @@ pub fn stat(cwd: &str, path: &str) -> Result<VfsStat, Fat32Error> {
 /// # Returns
 ///
 /// A [`VfsFileHandle`] on success, or a [`Fat32Error`] on error.
+///
+/// # References
+///
+/// - [POSIX open()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/open.html)
+/// - [POSIX pathname resolution (trailing slash rule)](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html)
 pub fn open(cwd: &str, path: &str, flags: c_int) -> Result<VfsFileHandle, Fat32Error> {
     // Handle O_DIRECTORY or paths that resolve to directories.
     // POSIX allows opening directories with O_RDONLY for fchdir()/getdents().
@@ -100,6 +105,19 @@ pub fn open(cwd: &str, path: &str, flags: c_int) -> Result<VfsFileHandle, Fat32E
     }
 
     // Auto-detect directories even without O_DIRECTORY flag.
+    // POSIX: trailing slash forces directory semantics. If path ends with
+    // '/' the target must be an existing directory; otherwise fail.
+    if path.ends_with('/') {
+        match stat(cwd, path) {
+            Ok(info) if info.is_dir() => {
+                let normalized: String = filesystem::normalize(cwd, path)?;
+                return Ok(VfsFileHandle::Directory(DirectoryHandle::new(normalized)));
+            },
+            Ok(_) => return Err(Fat32Error::NotADirectory),
+            Err(e) => return Err(e),
+        }
+    }
+
     if let Ok(info) = stat(cwd, path) {
         if info.is_dir() {
             let normalized: String = filesystem::normalize(cwd, path)?;

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -35,6 +35,7 @@ use ::alloc::{
     vec::Vec,
 };
 use ::fat32::{
+    Fat,
     Fat32Error,
     FatFile,
 };
@@ -125,8 +126,15 @@ pub(crate) fn stat(cwd: &str, path: &str) -> Result<Stat, Fat32Error> {
 ///
 /// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized.
 /// - [`Fat32Error::ReadOnly`] if the mount is read-only.
-/// - [`Fat32Error::AlreadyExists`] if directory already exists.
+/// - [`Fat32Error::AlreadyExists`] if path already exists (file or directory).
 /// - [`Fat32Error::NotFound`] if parent directory doesn't exist.
+/// - [`Fat32Error::NotADirectory`] if a path component is not a directory.
+/// - [`Fat32Error::InvalidPath`] if the last component is not a valid FAT filename
+///   (e.g. contains unsupported characters) and every ancestor is a directory.
+///
+/// # References
+///
+/// - [POSIX mkdir()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkdir.html)
 pub(crate) fn mkdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;
 
@@ -139,7 +147,24 @@ pub(crate) fn mkdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
 
     state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
-        mount.fat_mut().mkdir(&relative_path)
+        let fat = mount.fat_mut();
+
+        // If path already exists (file or dir), return AlreadyExists.
+        if fat.stat(&relative_path).is_ok() {
+            return Err(Fat32Error::AlreadyExists);
+        }
+
+        // Attempt mkdir; on InvalidPath, check if any ancestor is a non-directory.
+        match fat.mkdir(&relative_path) {
+            Ok(()) => Ok(()),
+            Err(Fat32Error::InvalidPath) => {
+                if has_non_directory_ancestor(fat, &relative_path) {
+                    return Err(Fat32Error::NotADirectory);
+                }
+                Err(Fat32Error::InvalidPath)
+            },
+            Err(e) => Err(e),
+        }
     })
 }
 
@@ -402,6 +427,29 @@ fn check_writable(mount_idx: usize) -> Result<(), Fat32Error> {
     Ok(())
 }
 
+/// Walks every proper ancestor prefix of `path` (from the immediate parent
+/// up to the mount root) looking for one that exists but is not a
+/// directory. Used to disambiguate fatfs's `InvalidPath` (which conflates
+/// "bad path" with "non-directory component in the traversal") into a
+/// proper `NotADirectory` for POSIX ENOTDIR semantics.
+///
+/// Returns `true` as soon as an existing non-directory ancestor is found.
+/// Returns `false` if every ancestor either doesn't exist or is a
+/// directory (the caller should then fall back to the original error).
+fn has_non_directory_ancestor(fat: &Fat, path: &str) -> bool {
+    let mut end: usize = path.len();
+    while let Some(slash) = path[..end].rfind('/') {
+        let prefix = &path[..slash];
+        if let Ok(st) = fat.stat(prefix) {
+            if !st.is_dir {
+                return true;
+            }
+        }
+        end = slash;
+    }
+    false
+}
+
 /// Opens a file with specific options.
 ///
 /// # Parameters
@@ -449,6 +497,11 @@ pub(crate) fn open_with_options(
     // references that the previous implementation created.
     let (fat_file, mount_path) = state::with_vfs_mut(|vfs| {
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
+
+        // If any ancestor component is a regular file, return ENOTDIR.
+        if has_non_directory_ancestor(mount.fat(), &relative_path) {
+            return Err(Fat32Error::NotADirectory);
+        }
         let mount_path: String = String::from(mount.path());
 
         let fat_file = if create_new {

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -35,7 +35,6 @@ use ::alloc::{
     vec::Vec,
 };
 use ::fat32::{
-    Fat,
     Fat32Error,
     FatFile,
 };
@@ -154,17 +153,7 @@ pub(crate) fn mkdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
             return Err(Fat32Error::AlreadyExists);
         }
 
-        // Attempt mkdir; on InvalidPath, check if any ancestor is a non-directory.
-        match fat.mkdir(&relative_path) {
-            Ok(()) => Ok(()),
-            Err(Fat32Error::InvalidPath) => {
-                if has_non_directory_ancestor(fat, &relative_path) {
-                    return Err(Fat32Error::NotADirectory);
-                }
-                Err(Fat32Error::InvalidPath)
-            },
-            Err(e) => Err(e),
-        }
+        fat.mkdir(&relative_path)
     })
 }
 
@@ -427,29 +416,6 @@ fn check_writable(mount_idx: usize) -> Result<(), Fat32Error> {
     Ok(())
 }
 
-/// Walks every proper ancestor prefix of `path` (from the immediate parent
-/// up to the mount root) looking for one that exists but is not a
-/// directory. Used to disambiguate fatfs's `InvalidPath` (which conflates
-/// "bad path" with "non-directory component in the traversal") into a
-/// proper `NotADirectory` for POSIX ENOTDIR semantics.
-///
-/// Returns `true` as soon as an existing non-directory ancestor is found.
-/// Returns `false` if every ancestor either doesn't exist or is a
-/// directory (the caller should then fall back to the original error).
-fn has_non_directory_ancestor(fat: &Fat, path: &str) -> bool {
-    let mut end: usize = path.len();
-    while let Some(slash) = path[..end].rfind('/') {
-        let prefix = &path[..slash];
-        if let Ok(st) = fat.stat(prefix) {
-            if !st.is_dir {
-                return true;
-            }
-        }
-        end = slash;
-    }
-    false
-}
-
 /// Opens a file with specific options.
 ///
 /// # Parameters
@@ -499,7 +465,7 @@ pub(crate) fn open_with_options(
         let mount = vfs.get_mount_mut(mount_idx).ok_or(Fat32Error::NotFound)?;
 
         // If any ancestor component is a regular file, return ENOTDIR.
-        if has_non_directory_ancestor(mount.fat(), &relative_path) {
+        if mount.fat().has_non_directory_ancestor(&relative_path) {
             return Err(Fat32Error::NotADirectory);
         }
         let mount_path: String = String::from(mount.path());

--- a/src/libs/vfs/src/mount/vfs.rs
+++ b/src/libs/vfs/src/mount/vfs.rs
@@ -136,11 +136,17 @@ impl Vfs {
     ///
     /// # Errors
     ///
-    /// Returns [`Fat32Error::InvalidPath`] if the path is empty or if a relative `path` is
-    /// anchored to a `cwd` that is not absolute. `..` at the root clamps to the root, per POSIX.
+    /// Returns [`Fat32Error::NotFound`] if the path is empty. Returns
+    /// [`Fat32Error::InvalidPath`] if a relative `path` is anchored to a `cwd` that is not
+    /// absolute. `..` at the root clamps to the root, per POSIX.
+    ///
+    /// # References
+    ///
+    /// - [POSIX Base Definitions, Chapter 4 — Pathname Resolution](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html)
+    /// - [POSIX open() — `ENOENT` for empty path](https://pubs.opengroup.org/onlinepubs/9799919799/functions/open.html)
     pub fn normalize_path(&self, path: &str, cwd: &str) -> Result<String, Fat32Error> {
         if path.is_empty() {
-            return Err(Fat32Error::InvalidPath);
+            return Err(Fat32Error::NotFound);
         }
 
         let abs_path: String = if path.starts_with('/') {
@@ -176,9 +182,9 @@ impl Vfs {
     ///
     /// # Errors
     ///
-    /// Returns [`Fat32Error::NotFound`] if no mount matches the path. Returns
-    /// [`Fat32Error::InvalidPath`] if `path` fails to normalize (empty path, or a `cwd`
-    /// that is not absolute; see [`Vfs::normalize_path`]).
+    /// Returns [`Fat32Error::NotFound`] if no mount matches the path, or if `path` is empty
+    /// (propagated from [`Vfs::normalize_path`]). Returns [`Fat32Error::InvalidPath`] if
+    /// `path` fails to normalize (a `cwd` that is not absolute; see [`Vfs::normalize_path`]).
     pub fn resolve(&mut self, path: &str, cwd: &str) -> Result<(usize, String), Fat32Error> {
         let normalized: String = self.normalize_path(path, cwd)?;
 
@@ -359,7 +365,7 @@ mod tests {
     fn normalize_empty_path() {
         let vfs: Vfs = Vfs::new();
         let result = vfs.normalize_path("", "/");
-        assert_eq!(result.unwrap_err(), Fat32Error::InvalidPath, "empty path should fail");
+        assert_eq!(result.unwrap_err(), Fat32Error::NotFound, "empty path should fail");
     }
 
     /// Tests normalizing root path.

--- a/src/libs/vfs/src/path.rs
+++ b/src/libs/vfs/src/path.rs
@@ -72,6 +72,10 @@ impl ResolvedPath {
 /// using this dirfd will resolve against the stale path. A future protocol
 /// extension could support `*at()` operations relative to a remote directory
 /// FD on the host side to provide stable POSIX-like dirfd semantics.
+///
+/// # References
+///
+/// - [POSIX openat()/`*at()` family — dirfd and `AT_FDCWD` semantics](https://pubs.opengroup.org/onlinepubs/9799919799/functions/openat.html)
 pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<ResolvedPath> {
     use ::sysapi::fcntl::atflags::AT_FDCWD;
 

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -81,6 +81,9 @@ extern void test_mkdirat(void);
 // Tests whether we can create a directory.
 extern void test_mkdir(void);
 
+// Tests path edge case errno values.
+extern void test_path_errno(void);
+
 // Tests whether `mkfifo()` reports that FIFO special files are unsupported.
 extern void test_mkfifo(void);
 

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -142,6 +142,7 @@ int main(int argc, const char *argv[])
     test_unlinkat();   // requires open() and close().
     test_mkdirat();    // requires stat() and unlinkat().
     test_mkdir();      // requires stat() and unlinkat().
+    test_path_errno(); // path edge case errno values.
     test_mkfifo();     // mkfifo() is unsupported; verifies it fails with ENOTSUP.
     test_mknod();      // mknod() is unsupported; verifies it fails with ENOTSUP.
     test_umask_ramfs(); // tests umask(), open(), close(), stat(), and unlink() on RAMFS.

--- a/src/tests/integration/test-c-file/path_errno.c
+++ b/src/tests/integration/test-c-file/path_errno.c
@@ -147,30 +147,6 @@ static void test_open_trailing_slash_on_file(void)
 }
 
 //==================================================================================================
-// Empty path tests
-//==================================================================================================
-
-// stat("") should fail with ENOENT, not EINVAL.
-static void test_stat_empty_path(void)
-{
-    fprintf(stderr, "  stat empty path -> ENOENT ... ");
-    struct stat st;
-    assert(stat("", &st) == -1);
-    assert(errno == ENOENT);
-    fprintf(stderr, "passed\n");
-}
-
-// open("", O_DIRECTORY) should fail with ENOENT (scandir repro).
-static void test_opendir_empty_path(void)
-{
-    fprintf(stderr, "  opendir empty path -> ENOENT ... ");
-    int fd = open("", O_RDONLY | O_DIRECTORY);
-    assert(fd == -1);
-    assert(errno == ENOENT);
-    fprintf(stderr, "passed\n");
-}
-
-//==================================================================================================
 // Entry Point
 //==================================================================================================
 
@@ -187,8 +163,6 @@ void test_path_errno(void)
     test_copyfile_nonexistent_dir();
     test_open_trailing_slash_nonexistent();
     test_open_trailing_slash_on_file();
-    test_stat_empty_path();
-    test_opendir_empty_path();
 
     fprintf(stderr, "path errno: all passed\n");
 }

--- a/src/tests/integration/test-c-file/path_errno.c
+++ b/src/tests/integration/test-c-file/path_errno.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+/*
+ * Tests that VFS operations return correct errno for path edge cases.
+ */
+
+//==================================================================================================
+// Configuration
+//==================================================================================================
+
+#define _POSIX_C_SOURCE 200809L
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Helpers
+//==================================================================================================
+
+static void create_file(const char *path)
+{
+    int fd = open(path, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(close(fd) == 0);
+}
+
+//==================================================================================================
+// mkdir errno tests
+//==================================================================================================
+
+// mkdir('/') should fail with EEXIST.
+static void test_mkdir_root(void)
+{
+    fprintf(stderr, "  mkdir root -> EEXIST ... ");
+    assert(mkdir("/", S_IRWXU) == -1);
+    assert(errno == EEXIST);
+    fprintf(stderr, "passed\n");
+}
+
+// mkdir(existing_file) should fail with EEXIST.
+static void test_mkdir_over_file(void)
+{
+    fprintf(stderr, "  mkdir over file -> EEXIST ... ");
+    create_file("pe_file");
+    assert(mkdir("pe_file", S_IRWXU) == -1);
+    assert(errno == EEXIST);
+    assert(unlink("pe_file") == 0);
+    fprintf(stderr, "passed\n");
+}
+
+// mkdir(file/child) should fail with ENOTDIR.
+static void test_mkdir_under_file(void)
+{
+    fprintf(stderr, "  mkdir under file -> ENOTDIR ... ");
+    create_file("pe_base");
+    assert(mkdir("pe_base/child", S_IRWXU) == -1);
+    assert(errno == ENOTDIR);
+    assert(unlink("pe_base") == 0);
+    fprintf(stderr, "passed\n");
+}
+
+// mkdir(file/child/grandchild) should fail with ENOTDIR even though the
+// non-directory component (file) is not the immediate parent.
+static void test_mkdir_under_file_deep(void)
+{
+    fprintf(stderr, "  mkdir under file (deep) -> ENOTDIR ... ");
+    create_file("pe_deep");
+    assert(mkdir("pe_deep/child/grandchild", S_IRWXU) == -1);
+    assert(errno == ENOTDIR);
+    assert(unlink("pe_deep") == 0);
+    fprintf(stderr, "passed\n");
+}
+
+//==================================================================================================
+// open errno tests
+//==================================================================================================
+
+// open(file/child, O_CREAT) should fail with ENOTDIR.
+static void test_open_under_file(void)
+{
+    fprintf(stderr, "  open under file -> ENOTDIR ... ");
+    create_file("pe_obase");
+    int fd = open("pe_obase/child", O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd == -1);
+    assert(errno == ENOTDIR);
+    assert(unlink("pe_obase") == 0);
+    fprintf(stderr, "passed\n");
+}
+
+// open(nonexistent_dir/file, O_CREAT) should fail with ENOENT.
+static void test_open_nonexistent_parent(void)
+{
+    fprintf(stderr, "  open nonexistent parent -> ENOENT ... ");
+    int fd = open("pe_nodir/file", O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd == -1);
+    assert(errno == ENOENT);
+    fprintf(stderr, "passed\n");
+}
+
+// open(nonexistent_dir/file, O_WRONLY|O_CREAT|O_TRUNC) should fail with ENOENT.
+// Matches shutil.copyfile destination open pattern.
+static void test_copyfile_nonexistent_dir(void)
+{
+    fprintf(stderr, "  copyfile nonexistent dir -> ENOENT ... ");
+    int fd = open("pe_nodir2/dst", O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    assert(fd == -1);
+    assert(errno == ENOENT);
+    fprintf(stderr, "passed\n");
+}
+
+// open("nonexistent/", O_CREAT) — trailing slash forces dir semantics → ENOENT.
+static void test_open_trailing_slash_nonexistent(void)
+{
+    fprintf(stderr, "  open trailing slash nonexistent -> ENOENT ... ");
+    int fd = open("pe_nosuch/", O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    assert(fd == -1);
+    assert(errno == ENOENT);
+    fprintf(stderr, "passed\n");
+}
+
+// open("existing_file/", O_RDONLY) — trailing slash on file → ENOTDIR.
+static void test_open_trailing_slash_on_file(void)
+{
+    fprintf(stderr, "  open trailing slash on file -> ENOTDIR ... ");
+    // Use a non-empty file to exercise the zero-copy read path.
+    int fd = open("pe_tslash", O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    assert(write(fd, "data", 4) == 4);
+    assert(close(fd) == 0);
+
+    fd = open("pe_tslash/", O_RDONLY);
+    assert(fd == -1);
+    assert(errno == ENOTDIR);
+    assert(unlink("pe_tslash") == 0);
+    fprintf(stderr, "passed\n");
+}
+
+//==================================================================================================
+// Empty path tests
+//==================================================================================================
+
+// stat("") should fail with ENOENT, not EINVAL.
+static void test_stat_empty_path(void)
+{
+    fprintf(stderr, "  stat empty path -> ENOENT ... ");
+    struct stat st;
+    assert(stat("", &st) == -1);
+    assert(errno == ENOENT);
+    fprintf(stderr, "passed\n");
+}
+
+// open("", O_DIRECTORY) should fail with ENOENT (scandir repro).
+static void test_opendir_empty_path(void)
+{
+    fprintf(stderr, "  opendir empty path -> ENOENT ... ");
+    int fd = open("", O_RDONLY | O_DIRECTORY);
+    assert(fd == -1);
+    assert(errno == ENOENT);
+    fprintf(stderr, "passed\n");
+}
+
+//==================================================================================================
+// Entry Point
+//==================================================================================================
+
+void test_path_errno(void)
+{
+    fprintf(stderr, "testing path errno ...\n");
+
+    test_mkdir_root();
+    test_mkdir_over_file();
+    test_mkdir_under_file();
+    test_mkdir_under_file_deep();
+    test_open_under_file();
+    test_open_nonexistent_parent();
+    test_copyfile_nonexistent_dir();
+    test_open_trailing_slash_nonexistent();
+    test_open_trailing_slash_on_file();
+    test_stat_empty_path();
+    test_opendir_empty_path();
+
+    fprintf(stderr, "path errno: all passed\n");
+}


### PR DESCRIPTION
Fixes #3069.

Five POSIX errno corrections in the VFS path handling:

- `mkdir(existing_file)` → EEXIST (was EINVAL)
- `mkdir(file/child)` / `open(file/child, O_CREAT)` → ENOTDIR (was EINVAL)
- `stat("")` / `open("")` / `scandir("")` → ENOENT (was EINVAL)
- `open("path/", O_CREAT)` where target does not exist → ENOENT (was silent file creation)
- `open("file/", O_RDONLY)` → ENOTDIR (was success via zero-copy fast path)

Root causes: `normalize_path` returned `InvalidPath` for empty strings (should be `NotFound`); `vfs_resolve_path` concatenated empty paths onto cwd before normalize could reject them; fatfs maps unrelated failures to `InvalidInput`; trailing slashes were silently stripped losing directory-semantics information.