### PR TITLE
[uservm] Gate WHP vCPU Cancellation

### DIFF
--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -345,16 +345,16 @@ pub struct Vmm {
     /// delivery via the WHP LAPIC emulator. Not used for PIT emulation.
     partition_handle: windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE,
     /// Low-frequency host timer for pvclock updates. Calls
-    /// `WHvCancelRunVirtualProcessor` at 100Hz to force VM exits so the
-    /// VMM loop can update `system_time`. The LAPIC periodic timer
+    /// `WHvCancelRunVirtualProcessor` at 100Hz while a vCPU run is pending to force VM exits so
+    /// the VMM loop can update `system_time`. The LAPIC periodic timer
     /// handles actual 1kHz scheduling inside the WHP emulator (zero
     /// VM exits for timer delivery).
     timer: Arc<std::sync::Mutex<timer::Timer>>,
     /// Shared shutdown flag. When set to `true` from any thread, the VMM
     /// run loop will break on the next iteration.
     shutdown_flag: Arc<AtomicBool>,
-    /// Indicates that the vCPU is about to enter or is blocked in `WHvRunVirtualProcessor`.
-    run_pending: Arc<AtomicBool>,
+    /// Synchronizes cancellation with entry to and return from `WHvRunVirtualProcessor`.
+    run_state: Arc<RunState>,
     /// Wraps fields that don't require individual `Arc<Mutex<_>>`s.
     inner: Arc<Mutex<InteriorWhpHandle>>,
     /// Pvclock time base in nanoseconds. When restoring from a snapshot, this is set to
@@ -395,31 +395,84 @@ struct InteriorWhpHandle {
     snapshot_allowed: bool,
 }
 
-/// Clears the WHP run-pending flag whenever a vCPU entry attempt finishes or unwinds.
+/// Synchronizes cancellation with `WHvRunVirtualProcessor`.
+struct RunState {
+    /// Whether the vCPU is about to enter or is blocked in `WHvRunVirtualProcessor`.
+    pending: AtomicBool,
+    /// Serializes cancellation calls with transitions out of the pending state.
+    cancel_gate: std::sync::Mutex<()>,
+}
+
+impl RunState {
+    fn new() -> Self {
+        Self {
+            pending: AtomicBool::new(false),
+            cancel_gate: std::sync::Mutex::new(()),
+        }
+    }
+
+    fn lock_cancel_gate(&self) -> std::sync::MutexGuard<'_, ()> {
+        match self.cancel_gate.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn begin_run(&self) {
+        let _guard: std::sync::MutexGuard<'_, ()> = self.lock_cancel_gate();
+        self.pending.store(true, Ordering::SeqCst);
+    }
+
+    fn finish_run(&self) {
+        let _guard: std::sync::MutexGuard<'_, ()> = self.lock_cancel_gate();
+        self.pending.store(false, Ordering::SeqCst);
+    }
+
+    fn is_pending(&self) -> bool {
+        self.pending.load(Ordering::SeqCst)
+    }
+
+    /// Runs `cancel` only while a vCPU entry is pending. Holding `cancel_gate` until the call
+    /// returns ensures that once [`RunPendingGuard`] is dropped, no cancellation can overlap with
+    /// snapshot or teardown operations on the same WHP partition.
+    fn cancel_if_pending<F>(&self, cancel: F) -> bool
+    where
+        F: FnOnce(),
+    {
+        let _guard: std::sync::MutexGuard<'_, ()> = self.lock_cancel_gate();
+        if self.pending.load(Ordering::SeqCst) {
+            cancel();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Clears the WHP run-pending state whenever a vCPU entry attempt finishes or unwinds.
 struct RunPendingGuard<'a> {
-    run_pending: &'a AtomicBool,
+    run_state: &'a RunState,
 }
 
 impl<'a> RunPendingGuard<'a> {
-    fn new(run_pending: &'a AtomicBool) -> Self {
-        run_pending.store(true, Ordering::SeqCst);
-        Self { run_pending }
+    fn new(run_state: &'a RunState) -> Self {
+        run_state.begin_run();
+        Self { run_state }
     }
 }
 
 impl Drop for RunPendingGuard<'_> {
     fn drop(&mut self) {
-        self.run_pending.store(false, Ordering::SeqCst);
+        self.run_state.finish_run();
     }
 }
 
 /// Repeatedly requests cancellation until the pending or active WHP run finishes.
-fn cancel_while_run_pending<F>(run_pending: &AtomicBool, mut cancel: F)
+fn cancel_while_run_pending<F>(run_state: &RunState, mut cancel: F)
 where
     F: FnMut(),
 {
-    while run_pending.load(Ordering::SeqCst) {
-        cancel();
+    while run_state.cancel_if_pending(&mut cancel) {
         std::thread::sleep(std::time::Duration::from_millis(1));
     }
 }
@@ -693,8 +746,9 @@ impl Vmm {
         };
 
         let partition_handle = partition.handle();
+        let run_state: Arc<RunState> = Arc::new(RunState::new());
         let timer: Arc<std::sync::Mutex<timer::Timer>> =
-            Arc::new(std::sync::Mutex::new(timer::Timer::new(partition_handle)));
+            Arc::new(std::sync::Mutex::new(timer::Timer::new(partition_handle, run_state.clone())));
         let vmem: Arc<Mutex<VirtualMemory>> = Arc::new(Mutex::new(vmem));
         let vcpu: Arc<Mutex<VirtualProcessor>> = Arc::new(Mutex::new(vcpu));
 
@@ -712,7 +766,7 @@ impl Vmm {
             partition_handle,
             timer,
             shutdown_flag,
-            run_pending: Arc::new(AtomicBool::new(false)),
+            run_state,
             inner: Arc::new(Mutex::new(InteriorWhpHandle {
                 _partition: partition,
                 emulator,
@@ -877,6 +931,7 @@ impl Vmm {
                 let stop = profiler_stop.clone();
                 let pending = profiler_cancel_pending.clone();
                 let partition = self.partition_handle;
+                let run_state: Arc<RunState> = self.run_state.clone();
                 profiler_thread = Some(std::thread::spawn(move || {
                     unsafe { timer::timeBeginPeriod(1) };
                     // Target ~1 kHz sampling. Actual rate is approximate due to
@@ -887,13 +942,14 @@ impl Vmm {
                         if stop.load(Ordering::Relaxed) {
                             break;
                         }
-                        pending.store(true, Ordering::Release);
-                        unsafe {
-                            let _ =
-                                windows::Win32::System::Hypervisor::WHvCancelRunVirtualProcessor(
+                        run_state.cancel_if_pending(|| {
+                            pending.store(true, Ordering::Release);
+                            unsafe {
+                                let _ = windows::Win32::System::Hypervisor::WHvCancelRunVirtualProcessor(
                                     partition, 0, 0,
                                 );
-                        }
+                            }
+                        });
                     }
                     unsafe { timer::timeEndPeriod(1) };
                 }));
@@ -916,7 +972,7 @@ impl Vmm {
                 // boundary, either this check observes it or the shutdown callback observes
                 // `run_pending` and keeps canceling until the WHP call returns.
                 let run_pending_guard: RunPendingGuard<'_> =
-                    RunPendingGuard::new(self.run_pending.as_ref());
+                    RunPendingGuard::new(self.run_state.as_ref());
                 if self.shutdown_flag.load(Ordering::SeqCst) {
                     drop(run_pending_guard);
                     drop(locked_vcpu);
@@ -1471,14 +1527,14 @@ impl Vmm {
     pub fn request_shutdown(&self, _vcpu_tid: u64) {
         self.shutdown_flag.store(true, Ordering::SeqCst);
 
-        if self.run_pending.load(Ordering::SeqCst) {
+        if self.run_state.is_pending() {
             let inner: Arc<Mutex<InteriorWhpHandle>> = self.inner.clone();
             let partition_handle = self.partition_handle;
-            let run_pending: Arc<AtomicBool> = self.run_pending.clone();
+            let run_state: Arc<RunState> = self.run_state.clone();
             let vcpu: Arc<Mutex<VirtualProcessor>> = self.vcpu.clone();
             let _cancel_worker: std::thread::JoinHandle<()> = std::thread::spawn(move || {
                 let mut error_logged: bool = false;
-                cancel_while_run_pending(run_pending.as_ref(), || {
+                cancel_while_run_pending(run_state.as_ref(), || {
                     // SAFETY: `inner` and `vcpu` keep the WHP partition and virtual processor
                     // alive until this worker exits.
                     unsafe {
@@ -1614,8 +1670,8 @@ impl Vmm {
     ///
     async fn handle_shutdown(&mut self, exit_status: u16) {
         // Mark the IKC notifier as shut down so that any pending or future notify() calls from
-        // the memory thread will skip the WHvCancelRunVirtualProcessor API call. This prevents
-        // STATUS_ACCESS_VIOLATION crashes when the vCPU is no longer running.
+        // the memory thread will skip the WHvRequestInterrupt API call. This prevents
+        // STATUS_ACCESS_VIOLATION crashes after the vCPU is no longer running.
         self.ikc_notifier.mark_shutdown();
 
         // Power-off vCPU.
@@ -1715,23 +1771,35 @@ mod tests {
 
     #[test]
     fn run_pending_guard_tracks_vcpu_entry() {
-        let run_pending: AtomicBool = AtomicBool::new(false);
+        let run_state: RunState = RunState::new();
         {
-            let _guard: RunPendingGuard<'_> = RunPendingGuard::new(&run_pending);
-            assert!(run_pending.load(Ordering::SeqCst));
+            let _guard: RunPendingGuard<'_> = RunPendingGuard::new(&run_state);
+            assert!(run_state.is_pending());
         }
-        assert!(!run_pending.load(Ordering::SeqCst));
+        assert!(!run_state.is_pending());
+    }
+
+    #[test]
+    fn cancellation_is_skipped_outside_vcpu_entry() {
+        let run_state: RunState = RunState::new();
+        let mut attempts: usize = 0;
+
+        let cancelled: bool = run_state.cancel_if_pending(|| attempts += 1);
+
+        assert!(!cancelled);
+        assert_eq!(attempts, 0);
     }
 
     #[test]
     fn cancellation_retries_until_run_finishes() {
-        let run_pending: AtomicBool = AtomicBool::new(true);
+        let run_state: RunState = RunState::new();
+        run_state.begin_run();
         let mut attempts: usize = 0;
 
-        cancel_while_run_pending(&run_pending, || {
+        cancel_while_run_pending(&run_state, || {
             attempts += 1;
             if attempts == 2 {
-                run_pending.store(false, Ordering::SeqCst);
+                run_state.pending.store(false, Ordering::SeqCst);
             }
         });
 

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -970,7 +970,7 @@ impl Vmm {
 
                 // Publish intent before the final shutdown check. If shutdown races with this
                 // boundary, either this check observes it or the shutdown callback observes
-                // `run_pending` and keeps canceling until the WHP call returns.
+                // `run_state` as pending and keeps canceling until the WHP call returns.
                 let run_pending_guard: RunPendingGuard<'_> =
                     RunPendingGuard::new(self.run_state.as_ref());
                 if self.shutdown_flag.load(Ordering::SeqCst) {
@@ -1768,6 +1768,7 @@ impl Vmm {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ::std::sync::atomic::AtomicUsize;
 
     #[test]
     fn run_pending_guard_tracks_vcpu_entry() {
@@ -1791,18 +1792,49 @@ mod tests {
     }
 
     #[test]
-    fn cancellation_retries_until_run_finishes() {
-        let run_state: RunState = RunState::new();
+    fn cancellation_runs_under_cancel_gate() {
+        // The crash fixed here came from cancellation overlapping snapshot/teardown. This locks in
+        // the invariant that prevents it: the cancel closure runs while `cancel_gate` is held, so
+        // it is mutually exclusive with `finish_run`. A cross-thread `try_lock` on the held gate
+        // must fail for the whole closure.
+        let run_state: Arc<RunState> = Arc::new(RunState::new());
         run_state.begin_run();
-        let mut attempts: usize = 0;
 
-        cancel_while_run_pending(&run_state, || {
-            attempts += 1;
-            if attempts == 2 {
-                run_state.pending.store(false, Ordering::SeqCst);
-            }
+        let mut gate_held_during_cancel: bool = false;
+        run_state.cancel_if_pending(|| {
+            let probe: Arc<RunState> = run_state.clone();
+            gate_held_during_cancel =
+                std::thread::spawn(move || probe.cancel_gate.try_lock().is_err())
+                    .join()
+                    .expect("prober thread panicked");
         });
 
-        assert_eq!(attempts, 2);
+        assert!(gate_held_during_cancel, "cancel closure must run while holding cancel_gate");
+    }
+
+    #[test]
+    fn cancellation_retries_until_run_finishes() {
+        let run_state: Arc<RunState> = Arc::new(RunState::new());
+        let attempts: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        let guard: RunPendingGuard<'_> = RunPendingGuard::new(run_state.as_ref());
+
+        let worker_state: Arc<RunState> = run_state.clone();
+        let worker_attempts: Arc<AtomicUsize> = attempts.clone();
+        let worker: std::thread::JoinHandle<()> = std::thread::spawn(move || {
+            cancel_while_run_pending(worker_state.as_ref(), || {
+                worker_attempts.fetch_add(1, Ordering::SeqCst);
+            });
+        });
+
+        while attempts.load(Ordering::SeqCst) < 2 {
+            std::thread::yield_now();
+        }
+
+        // Ends the run through `cancel_gate`, exactly as the VMM loop does.
+        drop(guard);
+        worker.join().expect("cancel worker panicked");
+
+        assert!(attempts.load(Ordering::SeqCst) >= 2);
+        assert!(!run_state.is_pending());
     }
 }

--- a/src/uservm/src/vmm/microvm/whp/mod.rs
+++ b/src/uservm/src/vmm/microvm/whp/mod.rs
@@ -857,7 +857,7 @@ impl Vmm {
         // Deferred slightly to avoid interfering with the first VP entry.
         // Uses a dedicated `AtomicBool` flag so only profiler-driven cancels
         // trigger sampling (not pvclock or other `Interrupted` exits).
-        let profiler_cancel_pending = Arc::new(AtomicBool::new(false));
+        let profiler_sample_pending = Arc::new(AtomicBool::new(false));
         let profiler_stop = Arc::new(AtomicBool::new(false));
         let mut profiler_thread: Option<std::thread::JoinHandle<()>> = None;
         let mut profiler_timer_started: bool = false;
@@ -929,7 +929,7 @@ impl Vmm {
                 && exit_count > PROFILER_START_DELAY_EXITS
             {
                 let stop = profiler_stop.clone();
-                let pending = profiler_cancel_pending.clone();
+                let sample_pending = profiler_sample_pending.clone();
                 let partition = self.partition_handle;
                 let run_state: Arc<RunState> = self.run_state.clone();
                 profiler_thread = Some(std::thread::spawn(move || {
@@ -943,7 +943,7 @@ impl Vmm {
                             break;
                         }
                         run_state.cancel_if_pending(|| {
-                            pending.store(true, Ordering::Release);
+                            sample_pending.store(true, Ordering::Release);
                             unsafe {
                                 let _ = windows::Win32::System::Hypervisor::WHvCancelRunVirtualProcessor(
                                     partition, 0, 0,
@@ -994,7 +994,7 @@ impl Vmm {
 
                 // Guest profiler: read registers only when our profiler timer fired.
                 let regs = if self.guest_profiler.is_some()
-                    && profiler_cancel_pending.swap(false, Ordering::Acquire)
+                    && profiler_sample_pending.swap(false, Ordering::Acquire)
                     && matches!(ctx.reason_ref(), VirtualProcessorExitReasonRef::Interrupted)
                 {
                     locked_vcpu.get_profile_regs().ok()

--- a/src/uservm/src/vmm/microvm/whp/timer.rs
+++ b/src/uservm/src/vmm/microvm/whp/timer.rs
@@ -8,6 +8,7 @@
 // Imports
 //==================================================================================================
 
+use super::RunState;
 use ::log::trace;
 use ::std::{
     sync::{
@@ -48,7 +49,7 @@ unsafe extern "system" {
 /// 1 kHz) handles all timer interrupts inside the WHP LAPIC emulator.
 ///
 /// The timer thread fires at a low frequency (100 Hz) and calls
-/// `WHvCancelRunVirtualProcessor` to cause a `Canceled` exit. The VMM
+/// `WHvCancelRunVirtualProcessor` when a vCPU run is pending to cause a `Canceled` exit. The VMM
 /// loop uses these exits to update `system_time` on the pvclock page.
 ///
 /// The inter-tick wait is **interruptible**: the thread waits on a
@@ -62,6 +63,8 @@ unsafe extern "system" {
 pub struct Timer {
     /// WHP partition handle (for `WHvCancelRunVirtualProcessor`).
     partition: WHV_PARTITION_HANDLE,
+    /// State that limits cancellation to an active or pending vCPU run.
+    run_state: Arc<RunState>,
     /// Shared stop flag (`true` once the timer should exit) and the
     /// [`Condvar`] used to wake the timer thread promptly on stop.
     stop: Arc<(Mutex<bool>, Condvar)>,
@@ -80,9 +83,10 @@ unsafe impl Sync for Timer {}
 
 impl Timer {
     /// Creates a new timer for the given WHP partition. The timer is initially stopped.
-    pub fn new(partition: WHV_PARTITION_HANDLE) -> Self {
+    pub(super) fn new(partition: WHV_PARTITION_HANDLE, run_state: Arc<RunState>) -> Self {
         Self {
             partition,
+            run_state,
             stop: Arc::new((Mutex::new(false), Condvar::new())),
             thread: None,
         }
@@ -90,8 +94,8 @@ impl Timer {
 
     /// Starts the timer thread with the given period in microseconds.
     ///
-    /// Each tick calls `WHvCancelRunVirtualProcessor` to force a VM exit
-    /// so the VMM loop can update pvclock. No guest interrupt is injected.
+    /// Each tick cancels a pending vCPU run to force a VM exit so the VMM loop can update pvclock.
+    /// No guest interrupt is injected.
     pub fn start(&mut self, period_us: u64) {
         if self.thread.is_some() {
             return;
@@ -107,6 +111,7 @@ impl Timer {
 
         let stop: Arc<(Mutex<bool>, Condvar)> = self.stop.clone();
         let partition: WHV_PARTITION_HANDLE = self.partition;
+        let run_state: Arc<RunState> = self.run_state.clone();
         let period: Duration = Duration::from_micros(period_us);
 
         self.thread = Some(thread::spawn(move || {
@@ -131,12 +136,14 @@ impl Timer {
                 }
                 // Period elapsed: release the lock while cancelling so `stop()` can proceed.
                 drop(guard);
-                // SAFETY: `partition` is a valid WHP partition handle that outlives
-                // the timer thread (the Vmm struct owns both).
-                unsafe {
-                    let _: Result<(), windows::core::Error> =
-                        WHvCancelRunVirtualProcessor(partition, 0, 0);
-                }
+                run_state.cancel_if_pending(|| {
+                    // SAFETY: `partition` is a valid WHP partition handle that outlives
+                    // the timer thread (the Vmm struct owns both).
+                    unsafe {
+                        let _: Result<(), windows::core::Error> =
+                            WHvCancelRunVirtualProcessor(partition, 0, 0);
+                    }
+                });
                 stopped = lock.lock().unwrap();
             }
 


### PR DESCRIPTION
## Summary

Fixes a Windows Hypervisor Platform (WHP) race that crashed the UserVM host process with `STATUS_ACCESS_VIOLATION` (`0xC0000005`), observed as a failing `Windows Benchmark (microvm)` `snapshot-restore` job.

The pvclock and guest-profiler host timers called `WHvCancelRunVirtualProcessor` unconditionally at 100 Hz / 1 kHz. After `WHvRunVirtualProcessor` returned, the VMM loop could be saving snapshot/register state or powering off the vCPU while a timer tick cancelled the same partition concurrently — a native WHP API race that faulted the process. Only the explicit shutdown path was previously guarded; the periodic cancellers were not.

## What changed

- Replace the bare `run_pending` `AtomicBool` with a `RunState` that pairs the pending flag with a `cancel_gate` mutex. `cancel_if_pending` runs the cancel closure only while a run is pending and holds the gate until it returns, so once `RunPendingGuard` is dropped no cancellation can still be in flight.
- Route the pvclock timer, guest-profiler timer, and shutdown worker through `cancel_if_pending`, skipping the WHP call entirely outside a vCPU entry.
- Thread `RunState` into `timer::Timer` and narrow its constructor to `pub(super)`.
- Rename the profiler marker `profiler_cancel_pending` -> `profiler_sample_pending` to reflect that it records a requested stack sample, not generic cancellation.

## Tests

- `cancellation_is_skipped_outside_vcpu_entry` — cancel closure not invoked when not pending.
- `cancellation_runs_under_cancel_gate` — deterministically proves the cancel closure runs while `cancel_gate` is held (cross-thread `try_lock` fails for the whole closure), so cancellation is mutually exclusive with `finish_run`.
- Validated locally: `format-check-uservm`, `rust-lint-check-uservm`, `test-uservm` (57 passed), release/profiler build, and the exact 100-iteration `snapshot-restore` benchmark (exit 0).

## Note

The native access violation itself is an inherently non-deterministic timing race against the live WHP FFI and cannot be reproduced in a unit test; the added tests guard the synchronization invariant that prevents it.