### PR TITLE
[vfs] writev/pwritev: return EINVAL on iovec length overflow

### DIFF
--- a/src/libs/libc_sys_uio/src/lib.rs
+++ b/src/libs/libc_sys_uio/src/lib.rs
@@ -23,7 +23,10 @@ use ::syscall::{
 };
 use ::syslog::trace_syscall;
 use sysapi::{
-    limits::IOV_MAX,
+    limits::{
+        IOV_MAX,
+        SSIZE_MAX,
+    },
     sys_types::{
         c_size_t,
         c_ssize_t,
@@ -40,7 +43,17 @@ use sysapi::{
 ///
 /// # Description
 ///
-/// Writes data to a file descriptor.
+/// Performs a positioned *gather* write: writes data from a list of `iovcnt` buffers
+/// (an `iovec` array) to the file referred to by `fd`, starting at `offset`, without
+/// changing the file offset. The buffers are written in array order.
+///
+/// # Standard
+///
+/// `pwritev()` is a BSD/Linux extension and is **not** specified by POSIX. Its semantics
+/// combine two POSIX functions: the scatter/gather behaviour of `writev()` and the
+/// positioned write of `pwrite()`.
+/// - `writev()`: <https://pubs.opengroup.org/onlinepubs/9799919799/functions/writev.html>
+/// - `pwrite()`: <https://pubs.opengroup.org/onlinepubs/9799919799/functions/write.html>
 ///
 /// # Parameters
 ///
@@ -51,8 +64,10 @@ use sysapi::{
 ///
 /// # Returns
 ///
-/// Upon successful completion, `pwritev()` returns the number of bytes written. Otherwise, it
-/// returns `-1` and sets `errno` to indicate the error.
+/// Returns a `c_ssize_t`:
+/// - On success: the number of bytes written (a non-negative `c_ssize_t`).
+/// - On failure: `-1`, with `errno` set to indicate the error. In particular, if the
+///   sum of the `iov_len` values overflows `SSIZE_MAX`, `errno` is set to `EINVAL`.
 ///
 /// # Safety
 ///
@@ -121,7 +136,7 @@ pub unsafe extern "C" fn pwritev(
             }
 
             // Copy data only if not running in dry-run mode.
-            total += if !dry_run {
+            let count: c_size_t = if !dry_run {
                 // Construct buffer from raw parts.
                 let buffer: &[u8] = slice::from_raw_parts(iov_base as *const u8, iov_len as usize);
                 // Write data and parse result.
@@ -138,6 +153,15 @@ pub unsafe extern "C" fn pwritev(
                 }
             } else {
                 iov_len as c_size_t
+            };
+
+            // Guard against ssize_t overflow (POSIX: EINVAL).
+            total = match total.checked_add(count) {
+                Some(sum) if sum <= SSIZE_MAX as c_size_t => sum,
+                _ => {
+                    ::syslog::warn!("pwritev(): iovec length overflows SSIZE_MAX");
+                    return Err(Error::new(ErrorCode::InvalidArgument, "iovec length overflow"));
+                },
             };
         }
 
@@ -405,7 +429,13 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssi
 ///
 /// # Description
 ///
-/// Writes data to a file descriptor.
+/// Performs a *gather* write: writes data from a list of `iovcnt` buffers (an `iovec`
+/// array) to the file referred to by `fd`, advancing the file offset. The buffers are
+/// written in array order, as if by a single `write()` of the concatenated data.
+///
+/// # Standard
+///
+/// `writev()`: <https://pubs.opengroup.org/onlinepubs/9799919799/functions/writev.html>
 ///
 /// # Parameters
 ///
@@ -415,8 +445,10 @@ pub unsafe extern "C" fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> c_ssi
 ///
 /// # Returns
 ///
-/// Upon successful completion, `writev()` returns the number of bytes written. Otherwise, it
-/// it returns `-1` and sets `errno` to indicate the error.
+/// Returns a `c_ssize_t`:
+/// - On success: the number of bytes written (a non-negative `c_ssize_t`).
+/// - On failure: `-1`, with `errno` set to indicate the error. In particular, if the
+///   sum of the `iov_len` values overflows `SSIZE_MAX`, `errno` is set to `EINVAL`.
 ///
 /// # Safety
 ///
@@ -479,7 +511,7 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
             }
 
             // Copy data only if not running in dry-run mode.
-            total += if !dry_run {
+            let count: c_size_t = if !dry_run {
                 // Construct buffer from raw parts.
                 let buffer: &[u8] = slice::from_raw_parts(iov_base as *const u8, iov_len as usize);
                 // Write data and parse result.
@@ -493,6 +525,15 @@ pub unsafe extern "C" fn writev(fd: c_int, iov: *const iovec, iovcnt: c_int) -> 
                 }
             } else {
                 iov_len as c_size_t
+            };
+
+            // Guard against ssize_t overflow (POSIX: EINVAL).
+            total = match total.checked_add(count) {
+                Some(sum) if sum <= SSIZE_MAX as c_size_t => sum,
+                _ => {
+                    ::syslog::warn!("writev(): iovec length overflows SSIZE_MAX");
+                    return Err(Error::new(ErrorCode::InvalidArgument, "iovec length overflow"));
+                },
             };
         }
 

--- a/src/tests/integration/test-c-file/pwritev.c
+++ b/src/tests/integration/test-c-file/pwritev.c
@@ -15,6 +15,7 @@
 //==================================================================================================
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <stdio.h>
@@ -90,6 +91,21 @@ void test_pwritev(void)
     assert(close(fd) == 0);
 
     // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    // Overflow: sum of iov_len exceeds SSIZE_MAX -> EINVAL.
+    fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    char scratch[1];
+    struct iovec big[2];
+    big[0].iov_base = scratch;
+    big[0].iov_len = SSIZE_MAX;
+    big[1].iov_base = scratch;
+    big[1].iov_len = 1;
+    errno = 0;
+    assert(pwritev(fd, big, 2, 0) == -1);
+    assert(errno == EINVAL);
+    assert(close(fd) == 0);
     assert(unlink(filename) == 0);
 
     fprintf(stderr, "passed\n");

--- a/src/tests/integration/test-c-file/writev.c
+++ b/src/tests/integration/test-c-file/writev.c
@@ -8,6 +8,7 @@
 //==================================================================================================
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <stdio.h>
@@ -76,6 +77,21 @@ void test_writev(void)
     assert(close(fd) == 0);
 
     // Remove the test file.
+    assert(unlink(filename) == 0);
+
+    // Overflow: sum of iov_len exceeds SSIZE_MAX -> EINVAL.
+    fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd != -1);
+    char scratch[1];
+    struct iovec big[2];
+    big[0].iov_base = scratch;
+    big[0].iov_len = SSIZE_MAX;
+    big[1].iov_base = scratch;
+    big[1].iov_len = 1;
+    errno = 0;
+    assert(writev(fd, big, 2) == -1);
+    assert(errno == EINVAL);
+    assert(close(fd) == 0);
     assert(unlink(filename) == 0);
 
     fprintf(stderr, "passed\n");


### PR DESCRIPTION
Resolves #3064.

`writev`/`pwritev` returned `ENOSPC` (28) instead of `EINVAL` (22) when the sum of `iov_len` values overflows `SSIZE_MAX`. `pwritev` also attempted the full overflowing write before failing (~55s).

Fix: guard the accumulated length against `SSIZE_MAX` in the dry-run pass, which runs before any real write — so we return `EINVAL` up front and short-circuit the slow path. `readv`/`preadv` left unchanged (out of scope; naturally bounded by file size).

Also added overflow C subtests to `test-c-file` (`writev.c`, `pwritev.c`) and documented the POSIX/BSD lineage + return types on both functions.

Unblocks cpython nskips #520/#521.

Verified against the full lifecycle (release build; `test-c-file` passes under nanvixd, writev/pwritev fast).