### PR TITLE
[vfs] POSIX errno for *at path resolution

### DIFF
--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -413,8 +413,9 @@ pub(crate) fn handle_fstatat_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.path) else {
-        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    let resolved = match vfs_resolve_path(request.dirfd, &request.path) {
+        Ok(r) => r,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
     };
 
     if hostfs::is_hostfs_path(resolved.as_str()) {
@@ -471,8 +472,9 @@ pub(crate) fn handle_chdir_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let Some(resolved) = vfs_resolve_path(AT_FDCWD, &request.path) else {
-        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    let resolved = match vfs_resolve_path(AT_FDCWD, &request.path) {
+        Ok(r) => r,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
     };
 
     if hostfs::is_hostfs_path(resolved.as_str()) {
@@ -754,8 +756,9 @@ pub(crate) fn handle_openat_with_hostfs(
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
     request.mode = ::vfs::fd::vfs_apply_umask(request.mode);
-    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
-        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    let resolved = match vfs_resolve_path(request.dirfd, &request.pathname) {
+        Ok(r) => r,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
     };
 
     if hostfs::is_hostfs_path(resolved.as_str()) {
@@ -796,11 +799,13 @@ pub(crate) fn handle_renameat_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let Some(old_resolved) = vfs_resolve_path(request.olddirfd, &request.oldpath) else {
-        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    let old_resolved = match vfs_resolve_path(request.olddirfd, &request.oldpath) {
+        Ok(r) => r,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
     };
-    let Some(new_resolved) = vfs_resolve_path(request.newdirfd, &request.newpath) else {
-        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    let new_resolved = match vfs_resolve_path(request.newdirfd, &request.newpath) {
+        Ok(r) => r,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
     };
     let old_is_hostfs: bool = hostfs::is_hostfs_path(old_resolved.as_str());
     let new_is_hostfs: bool = hostfs::is_hostfs_path(new_resolved.as_str());
@@ -847,8 +852,9 @@ pub(crate) fn handle_unlinkat_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
-        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    let resolved = match vfs_resolve_path(request.dirfd, &request.pathname) {
+        Ok(r) => r,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
     };
 
     if hostfs::is_hostfs_path(resolved.as_str()) {
@@ -900,8 +906,9 @@ pub(crate) fn handle_mkdirat_with_hostfs(
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
     request.mode = ::vfs::fd::vfs_apply_umask(request.mode);
-    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.pathname) else {
-        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    let resolved = match vfs_resolve_path(request.dirfd, &request.pathname) {
+        Ok(r) => r,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
     };
 
     if hostfs::is_hostfs_path(resolved.as_str()) {
@@ -943,8 +950,9 @@ pub(crate) fn handle_symlinkat_with_hostfs(
     let source: ThreadIdentifier = response_context.source_tid();
     // Routing key is `linkpath` (where the symlink will live). `target` is an opaque
     // string stored verbatim by the host and intentionally not consulted here.
-    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.linkpath) else {
-        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    let resolved = match vfs_resolve_path(request.dirfd, &request.linkpath) {
+        Ok(r) => r,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
     };
 
     if hostfs::is_hostfs_path(resolved.as_str()) {
@@ -984,8 +992,9 @@ pub(crate) fn handle_readlinkat_with_hostfs(
 ) -> Option<Vec<Message>> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source: ThreadIdentifier = response_context.source_tid();
-    let Some(resolved) = vfs_resolve_path(request.dirfd, &request.path) else {
-        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    let resolved = match vfs_resolve_path(request.dirfd, &request.path) {
+        Ok(r) => r,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
     };
 
     if hostfs::is_hostfs_path(resolved.as_str()) {

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -993,11 +993,11 @@ pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
 ///
 /// # Errors
 ///
-/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` cannot be resolved (for
-/// example, when it is not a VFS directory file descriptor). The `dirfd` is
-/// never silently ignored.
+/// Returns [`Fat32Error::InvalidFd`] (POSIX `EBADF`) if `dirfd` is not an open
+/// descriptor, or [`Fat32Error::NotADirectory`] (POSIX `ENOTDIR`) if it is not a
+/// directory. An empty `path` returns [`Fat32Error::NotFound`] (POSIX `ENOENT`).
 pub fn vfs_openat(dirfd: c_int, path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
-    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path)?;
     vfs_open_resolved(resolved, flags)
 }
 
@@ -1394,15 +1394,15 @@ pub fn vfs_stat(path: &str, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
 ///
 /// # Errors
 ///
-/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` cannot be resolved (for
-/// example, when it is not a VFS directory file descriptor). The `dirfd` is
-/// never silently ignored.
+/// Returns [`Fat32Error::InvalidFd`] (POSIX `EBADF`) if `dirfd` is not an open
+/// descriptor, or [`Fat32Error::NotADirectory`] (POSIX `ENOTDIR`) if it is not a
+/// directory. An empty `path` returns [`Fat32Error::NotFound`] (POSIX `ENOENT`).
 pub fn vfs_fstatat(
     dirfd: c_int,
     path: &str,
     buf: &mut ::sysapi::sys_stat::stat,
 ) -> Result<(), Fat32Error> {
-    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path)?;
     vfs_stat_resolved(resolved, buf)
 }
 
@@ -1440,11 +1440,11 @@ pub fn vfs_mkdir(path: &str) -> Result<(), Fat32Error> {
 ///
 /// # Errors
 ///
-/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` cannot be resolved (for
-/// example, when it is not a VFS directory file descriptor). The `dirfd` is
-/// never silently ignored.
+/// Returns [`Fat32Error::InvalidFd`] (POSIX `EBADF`) if `dirfd` is not an open
+/// descriptor, or [`Fat32Error::NotADirectory`] (POSIX `ENOTDIR`) if it is not a
+/// directory. An empty `path` returns [`Fat32Error::NotFound`] (POSIX `ENOENT`).
 pub fn vfs_mkdirat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
-    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path)?;
     vfs_mkdir_resolved(resolved)
 }
 
@@ -1845,11 +1845,11 @@ pub fn vfs_access(path: &str) -> Result<(), Fat32Error> {
 ///
 /// # Errors
 ///
-/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` cannot be resolved (for
-/// example, when it is not a VFS directory file descriptor). The `dirfd` is
-/// never silently ignored.
+/// Returns [`Fat32Error::InvalidFd`] (POSIX `EBADF`) if `dirfd` is not an open
+/// descriptor, or [`Fat32Error::NotADirectory`] (POSIX `ENOTDIR`) if it is not a
+/// directory. An empty `path` returns [`Fat32Error::NotFound`] (POSIX `ENOENT`).
 pub fn vfs_accessat(dirfd: c_int, path: &str) -> Result<(), Fat32Error> {
-    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path)?;
     vfs_access(resolved.as_str())
 }
 
@@ -1953,7 +1953,9 @@ pub fn vfs_getdents(
 ///
 /// # Errors
 ///
-/// Returns [`Fat32Error::InvalidArgument`] if a dirfd cannot be resolved.
+/// Returns [`Fat32Error::InvalidFd`] (POSIX `EBADF`) if a dirfd is not an open
+/// descriptor, or [`Fat32Error::NotADirectory`] (POSIX `ENOTDIR`) if it is not a
+/// directory. An empty path returns [`Fat32Error::NotFound`] (POSIX `ENOENT`).
 /// Returns a [`Fat32Error`] if the paths are on different mounts, the old path does not exist,
 /// or the new path already exists.
 pub fn vfs_renameat(
@@ -1962,8 +1964,8 @@ pub fn vfs_renameat(
     newdirfd: c_int,
     newpath: &str,
 ) -> Result<(), Fat32Error> {
-    let old_resolved = vfs_resolve_path(olddirfd, oldpath).ok_or(Fat32Error::InvalidArgument)?;
-    let new_resolved = vfs_resolve_path(newdirfd, newpath).ok_or(Fat32Error::InvalidArgument)?;
+    let old_resolved = vfs_resolve_path(olddirfd, oldpath)?;
+    let new_resolved = vfs_resolve_path(newdirfd, newpath)?;
     vfs_rename_resolved(old_resolved, new_resolved)
 }
 
@@ -1990,11 +1992,13 @@ pub fn vfs_rename_resolved(
 ///
 /// # Errors
 ///
-/// Returns [`Fat32Error::InvalidArgument`] if `dirfd` cannot be resolved.
+/// Returns [`Fat32Error::InvalidFd`] (POSIX `EBADF`) if `dirfd` is not an open
+/// descriptor, or [`Fat32Error::NotADirectory`] (POSIX `ENOTDIR`) if it is not a
+/// directory. An empty `path` returns [`Fat32Error::NotFound`] (POSIX `ENOENT`).
 /// Returns a [`Fat32Error`] if the path does not exist, the directory is not empty (when removing
 /// a directory), or the path refers to a directory but `AT_REMOVEDIR` is not set.
 pub fn vfs_unlinkat(dirfd: c_int, path: &str, flags: c_int) -> Result<(), Fat32Error> {
-    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path)?;
     vfs_unlink_resolved(resolved, flags)
 }
 
@@ -2076,7 +2080,7 @@ pub fn vfs_fchmodat(
     _mode: ::sysapi::sys_types::mode_t,
     _flag: c_int,
 ) -> Result<(), Fat32Error> {
-    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path)?;
     // Verify that the target exists using the VFS-level stat for consistent semantics.
     filesystem::stat(&current_cwd(), resolved.as_str()).map(|_| ())
 }
@@ -2105,7 +2109,7 @@ pub fn vfs_fchownat(
     _group: gid_t,
     _flag: c_int,
 ) -> Result<(), Fat32Error> {
-    let resolved = vfs_resolve_path(dirfd, path).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, path)?;
     // Verify that the target exists using the VFS-level stat for consistent semantics.
     filesystem::stat(&current_cwd(), resolved.as_str()).map(|_| ())
 }
@@ -2137,7 +2141,7 @@ pub fn vfs_utimensat(
     if flags != 0 {
         return Err(Fat32Error::InvalidArgument);
     }
-    let resolved = vfs_resolve_path(dirfd, pathname).ok_or(Fat32Error::InvalidArgument)?;
+    let resolved = vfs_resolve_path(dirfd, pathname)?;
     // Verify that the target exists using the VFS-level stat for consistent semantics.
     filesystem::stat(&current_cwd(), resolved.as_str()).map(|_| ())
 }

--- a/src/libs/vfs/src/path.rs
+++ b/src/libs/vfs/src/path.rs
@@ -24,6 +24,7 @@ use ::alloc::{
     format,
     string::String,
 };
+use ::fat32::Fat32Error;
 use ::sysapi::ffi::c_int;
 
 //==================================================================================================
@@ -62,8 +63,10 @@ impl ResolvedPath {
 /// working directory. If `dirfd` is a directory descriptor, the path is resolved
 /// relative to that directory's path.
 ///
-/// Returns `None` if `dirfd` is neither `AT_FDCWD` nor a directory descriptor of the current
-/// process, indicating that VFS cannot handle this request, or if `path` is empty.
+/// Returns [`Fat32Error::NotFound`] if `path` is empty (POSIX `ENOENT`).
+/// Returns [`Fat32Error::InvalidFd`] if `dirfd` is not an open descriptor of the current process
+/// (POSIX `EBADF`), or [`Fat32Error::NotADirectory`] if it is an open descriptor that does not
+/// refer to a directory (POSIX `ENOTDIR`).
 ///
 /// # Limitations
 ///
@@ -76,41 +79,41 @@ impl ResolvedPath {
 /// # References
 ///
 /// - [POSIX openat()/`*at()` family — dirfd and `AT_FDCWD` semantics](https://pubs.opengroup.org/onlinepubs/9799919799/functions/openat.html)
-pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Option<ResolvedPath> {
+pub fn vfs_resolve_path(dirfd: c_int, path: &str) -> Result<ResolvedPath, Fat32Error> {
     use ::sysapi::fcntl::atflags::AT_FDCWD;
 
     // An empty path names nothing. Anchoring one would silently yield the base
-    // directory, so reject it here rather than resolve to the cwd.
+    // directory, so reject it here with ENOENT rather than resolve to the cwd.
     if path.is_empty() {
-        return None;
+        return Err(Fat32Error::NotFound);
     }
 
     // Absolute paths are always resolved directly (dirfd ignored per POSIX).
     if path.starts_with('/') {
-        return Some(ResolvedPath(String::from(path)));
+        return Ok(ResolvedPath(String::from(path)));
     }
 
     // Relative path with AT_FDCWD: resolve against VFS cwd.
     if dirfd == AT_FDCWD {
         if !crate::state::is_initialized() {
-            return None;
+            return Err(Fat32Error::InvalidArgument);
         }
         let cwd: String = current_cwd();
-        return Some(ResolvedPath(join(&cwd, path)));
+        return Ok(ResolvedPath(join(&cwd, path)));
     }
 
     // Relative path with a directory descriptor: resolve against that directory. Validity is the
-    // slot's handle type, not the descriptor number — a non-directory or absent descriptor yields
-    // `None` below rather than being pre-screened by a number range.
-    let file: OpenFile = entry_arc(dirfd).ok()?;
+    // slot's handle type, not the descriptor number — an absent descriptor is `EBADF` and a
+    // non-directory descriptor is `ENOTDIR`, per POSIX.
+    let file: OpenFile = entry_arc(dirfd).map_err(|_| Fat32Error::InvalidFd)?;
     let guard = file.lock();
     let dir_path: &str = match &guard.handle {
         VfsFileHandle::Directory(dh) => dh.path(),
-        VfsFileHandle::HostFs(hh) if hh.is_dir() => hh.path()?,
-        _ => return None, // fd is not a directory
+        VfsFileHandle::HostFs(hh) if hh.is_dir() => hh.path().ok_or(Fat32Error::InvalidFd)?,
+        _ => return Err(Fat32Error::NotADirectory), // fd is not a directory
     };
 
-    Some(ResolvedPath(join(dir_path, path)))
+    Ok(ResolvedPath(join(dir_path, path)))
 }
 
 //==================================================================================================

--- a/src/tests/integration/test-rust-mount-test/src/dirfd_reject.rs
+++ b/src/tests/integration/test-rust-mount-test/src/dirfd_reject.rs
@@ -5,7 +5,7 @@
 //!
 //! When a relative path is paired with a `dirfd` that cannot be resolved to a VFS
 //! directory (for example, a regular-file descriptor), vfsd must reject the request
-//! with `EINVAL` (`InvalidArgument`) instead of silently dropping the `dirfd` and
+//! with `ENOTDIR` (`InvalidDirectory`) instead of silently dropping the `dirfd` and
 //! resolving the path against the current working directory.
 //!
 //! These tests cover the five operations whose hostfs handlers perform this
@@ -44,22 +44,23 @@ pub fn test() -> Result<(), Error> {
     test_invalid_dirfd_rejected()
 }
 
-/// Asserts that a result is the expected `EINVAL` rejection, panicking otherwise.
+/// Asserts that a result is the expected `ENOTDIR` rejection, panicking otherwise.
 fn expect_reject<T>(op: &str, result: Result<T, Error>) {
     match result {
         Ok(_) => {
             panic!(
-                "dirfd-reject: {op} with a non-directory dirfd must fail with EINVAL, but it \
+                "dirfd-reject: {op} with a non-directory dirfd must fail with ENOTDIR, but it \
                  succeeded"
             );
         },
-        Err(e) if e.code == ErrorCode::InvalidArgument => {
-            ::syslog::info!("mount-test: [PASS] {op} rejects a non-directory dirfd with EINVAL");
+        Err(e) if e.code == ErrorCode::InvalidDirectory => {
+            ::syslog::info!("mount-test: [PASS] {op} rejects a non-directory dirfd with ENOTDIR");
         },
         Err(e) => {
             let code: ErrorCode = e.code;
             panic!(
-                "dirfd-reject: {op} with a non-directory dirfd must fail with EINVAL, got {code:?}"
+                "dirfd-reject: {op} with a non-directory dirfd must fail with ENOTDIR, got \
+                 {code:?}"
             );
         },
     }
@@ -82,17 +83,17 @@ fn test_invalid_dirfd_rejected() -> Result<(), Error> {
         Ok(stray) => {
             let _ = ::syscall::unistd::close(stray);
             panic!(
-                "dirfd-reject: openat with a non-directory dirfd must fail with EINVAL, but it \
+                "dirfd-reject: openat with a non-directory dirfd must fail with ENOTDIR, but it \
                  succeeded"
             );
         },
-        Err(e) if e.code == ErrorCode::InvalidArgument => {
-            ::syslog::info!("mount-test: [PASS] openat rejects a non-directory dirfd with EINVAL");
+        Err(e) if e.code == ErrorCode::InvalidDirectory => {
+            ::syslog::info!("mount-test: [PASS] openat rejects a non-directory dirfd with ENOTDIR");
         },
         Err(e) => {
             let code: ErrorCode = e.code;
             panic!(
-                "dirfd-reject: openat with a non-directory dirfd must fail with EINVAL, got \
+                "dirfd-reject: openat with a non-directory dirfd must fail with ENOTDIR, got \
                  {code:?}"
             );
         },
@@ -104,7 +105,7 @@ fn test_invalid_dirfd_rejected() -> Result<(), Error> {
     expect_reject("fstatat", ::syscall::sys::stat::fstatat(file_fd, "reject-stat.txt", &mut st, 0));
 
     // symlinkat and readlinkat previously reported "not supported" for an
-    // unresolvable dirfd; they must now report EINVAL like the other operations.
+    // unresolvable dirfd; they must now report ENOTDIR like the other operations.
     expect_reject(
         "symlinkat",
         ::syscall::unistd::symlinkat("target.txt", file_fd, "reject-link.lnk"),

--- a/src/tests/integration/test-rust-vfs-test/src/main.rs
+++ b/src/tests/integration/test-rust-vfs-test/src/main.rs
@@ -1035,7 +1035,7 @@ fn test_resolve_path() -> Result<(), Error> {
 
     // Absolute path: dirfd should be ignored.
     let resolved = vfs_resolve_path(0, "/rp/sub/file.txt")
-        .ok_or(Error::new(ErrorCode::InvalidArgument, "absolute resolve failed"))?;
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "absolute resolve failed"))?;
     if resolved.as_str() != "/rp/sub/file.txt" {
         return Err(Error::new(ErrorCode::InvalidArgument, "absolute path mismatch"));
     }
@@ -1043,7 +1043,7 @@ fn test_resolve_path() -> Result<(), Error> {
     // AT_FDCWD: resolve relative to VFS cwd.
     vfs::chdir("/rp").map_err(|e| fat_err(e, "chdir /rp failed"))?;
     let resolved_cwd = vfs_resolve_path(AT_FDCWD, "sub")
-        .ok_or(Error::new(ErrorCode::InvalidArgument, "AT_FDCWD resolve failed"))?;
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "AT_FDCWD resolve failed"))?;
     if resolved_cwd.as_str() != "/rp/sub" {
         return Err(Error::new(ErrorCode::InvalidArgument, "AT_FDCWD path mismatch"));
     }
@@ -1052,22 +1052,22 @@ fn test_resolve_path() -> Result<(), Error> {
     let dir_fd: i32 = vfs::fd::vfs_open("/rp/sub", file_creation_flags::O_DIRECTORY)
         .map_err(|e| fat_err(e, "vfs_open /rp/sub O_DIRECTORY"))?;
     let resolved_dir = vfs_resolve_path(dir_fd, "nested.txt")
-        .ok_or(Error::new(ErrorCode::InvalidArgument, "dirfd resolve failed"))?;
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "dirfd resolve failed"))?;
     if resolved_dir.as_str() != "/rp/sub/nested.txt" {
         return Err(Error::new(ErrorCode::InvalidArgument, "dirfd path mismatch"));
     }
 
-    // A descriptor with no slot should return None. Under the flat namespace this is determined by
+    // A descriptor with no slot should not resolve. Under the flat namespace this is determined by
     // the slot's handle type, not a number range: close the directory fd so it is absent, then it
     // no longer resolves.
     vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir fd"))?;
-    if vfs_resolve_path(dir_fd, "file.txt").is_some() {
-        return Err(Error::new(ErrorCode::InvalidArgument, "absent fd should return None"));
+    if vfs_resolve_path(dir_fd, "file.txt").is_ok() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "absent fd should not resolve"));
     }
 
-    // An empty path names nothing, so it must not resolve to the cwd.
-    if vfs_resolve_path(AT_FDCWD, "").is_some() {
-        return Err(Error::new(ErrorCode::InvalidArgument, "empty path should return None"));
+    // An empty path names nothing, so it must fail with ENOENT rather than resolve to the cwd.
+    if vfs_resolve_path(AT_FDCWD, "").is_ok() {
+        return Err(Error::new(ErrorCode::InvalidArgument, "empty path should not resolve"));
     }
 
     // Clean up.
@@ -1342,11 +1342,11 @@ fn test_openat() -> Result<(), Error> {
                 "openat with a non-directory dirfd must fail instead of resolving against the cwd",
             ));
         },
-        Err(vfs::Fat32Error::InvalidArgument) => {},
+        Err(vfs::Fat32Error::NotADirectory) => {},
         Err(e) => {
             return Err(fat_err(
                 e,
-                "openat with a non-directory dirfd must fail with EINVAL, not another error",
+                "openat with a non-directory dirfd must fail with ENOTDIR, not another error",
             ));
         },
     }
@@ -1416,11 +1416,11 @@ fn test_mkdirat() -> Result<(), Error> {
                 "mkdirat with a non-directory dirfd must fail instead of resolving against the cwd",
             ));
         },
-        Err(vfs::Fat32Error::InvalidArgument) => {},
+        Err(vfs::Fat32Error::NotADirectory) => {},
         Err(e) => {
             return Err(fat_err(
                 e,
-                "mkdirat with a non-directory dirfd must fail with EINVAL, not another error",
+                "mkdirat with a non-directory dirfd must fail with ENOTDIR, not another error",
             ));
         },
     }
@@ -1502,11 +1502,11 @@ fn test_accessat() -> Result<(), Error> {
                  cwd",
             ));
         },
-        Err(vfs::Fat32Error::InvalidArgument) => {},
+        Err(vfs::Fat32Error::NotADirectory) => {},
         Err(e) => {
             return Err(fat_err(
                 e,
-                "accessat with a non-directory dirfd must fail with EINVAL, not another error",
+                "accessat with a non-directory dirfd must fail with ENOTDIR, not another error",
             ));
         },
     }
@@ -1594,11 +1594,11 @@ fn test_fstatat() -> Result<(), Error> {
                 "fstatat with a non-directory dirfd must fail instead of resolving against the cwd",
             ));
         },
-        Err(vfs::Fat32Error::InvalidArgument) => {},
+        Err(vfs::Fat32Error::NotADirectory) => {},
         Err(e) => {
             return Err(fat_err(
                 e,
-                "fstatat with a non-directory dirfd must fail with EINVAL, not another error",
+                "fstatat with a non-directory dirfd must fail with ENOTDIR, not another error",
             ));
         },
     }


### PR DESCRIPTION

Closes #3093. Depends on #3068.

## What

`vfs_resolve_path` returned `Option`, so every caller collapsed a failed
resolve into a single `EINVAL`. That flattened three distinct POSIX errors
into one wrong one. The concrete repro: `stat("")` returned `EINVAL` where
POSIX requires `ENOENT` (surfaced by the `path_errno` suite in `test-c-file`).

`vfs_resolve_path` now returns `Result<ResolvedPath, Fat32Error>` and each
failure carries its own errno:

| Case                     | Before  | After            |
| ------------------------ | ------- | ---------------- |
| empty `path`             | EINVAL  | `ENOENT`         |
| `dirfd` not open         | EINVAL  | `EBADF`          |
| `dirfd` not a directory  | EINVAL  | `ENOTDIR`        |

The typed error is threaded through the nine hostfs `*at` handlers (via
`fat32_to_error_code`) and the ten `fd` wrappers, which now just `?` it.

## Contract change worth review

`test-rust-mount-test`'s `dirfd_reject` module previously **documented**
`EINVAL` as the deliberate result for a non-directory `dirfd`. This reverses
that call in favor of POSIX `ENOTDIR`; the module and the `test-rust-vfs-test`
guards are updated to match. If that `EINVAL` was load-bearing somewhere I
can't see, flag it here.

Builds on #3042, which first made `vfs_resolve_path("")` stop resolving to the
cwd (it returned `None`); this turns that `None` into the right errno.

## Verification

Verified against the full lifecycle on the rebased branch:

- unit tests (host `vfs`/`fat32`), standalone `run-nanvix-tests`, and the
  ported `run-posix-tests` C suites all pass;
- `test-c-file`/`path_errno` now green (`stat("") -> ENOENT`).

`run-kernel-tests` fails identically on a clean tree (uservm boot in this
environment) and is unrelated — the `kernel` crate has no `vfs`/`fat32`
dependency.
