### PR TITLE
Restore table-parity reporting in the benchmark site

### DIFF
--- a/www/bench/app.js
+++ b/www/bench/app.js
@@ -71,26 +71,53 @@ function formatDelta(val, base) {
  * Reports each series' *absolute* percentile plus its delta vs the previous
  * bar (for the PR bar, the previous bar is the dev baseline tip).
  */
-function percentileTooltip(p50Data, p95Delta, p99Delta) {
+function percentileTooltip(abs) {
   const names = ["p50", "p95", "p99"];
-  const abs = (i) => {
-    const p50 = p50Data[i];
-    if (p50 == null) return [null, null, null];
-    return [p50, p50 + p95Delta[i], p50 + p95Delta[i] + p99Delta[i]];
-  };
   return {
     callbacks: {
       label(ctx) {
         const i = ctx.dataIndex;
         const di = ctx.datasetIndex;
-        const a = abs(i)[di];
-        if (a == null) return "";
-        const prev = i > 0 ? abs(i - 1)[di] : null;
-        const d = prev != null ? ` (${formatDelta(a, prev)} vs prev)` : "";
-        return `${names[di]}: ${a.toLocaleString()} \u03bcs${d}`;
+        const a = abs(i);
+        if (!a || a[di] == null) return "";
+        const prev = i > 0 ? abs(i - 1) : null;
+        const p = prev ? prev[di] : null;
+        const d = p != null ? ` (${formatDelta(a[di], p)} vs prev)` : "";
+        return `${names[di]}: ${a[di].toLocaleString()} \u03bcs${d}`;
       },
     },
   };
+}
+
+/** Reconstruct absolute [p50, p95, p99] at bar index i from the stacked
+ * arrays, or null when the bar has no value. */
+function makeAbs(p50Data, p95Delta, p99Delta) {
+  return (i) => {
+    const p50 = p50Data[i];
+    if (p50 == null) return null;
+    return [p50, p50 + p95Delta[i], p50 + p95Delta[i] + p99Delta[i]];
+  };
+}
+
+/** Per-dataset [base, highlight] bar colors for the p50 / p95 / p99 stack. */
+const BAR_COLORS = [
+  ["#00adb5", "#00ffd5"],
+  ["#e2b93d", "#ffe066"],
+  ["#e94560", "#ff6b81"],
+];
+
+/** Highlight bar `idx` as the target: recolor bars and refresh the side
+ * table (captioned with the target commit; dev = the preceding bar). */
+function selectBar(chart, labels, table, abs, idx) {
+  if (idx < 0 || idx >= labels.length) return;
+  chart.data.datasets.forEach((ds, d) => {
+    ds.backgroundColor = labels.map((_, i) =>
+      i === idx ? BAR_COLORS[d][1] : BAR_COLORS[d][0]
+    );
+  });
+  chart.update("none");
+  const caption = abs(idx) ? `target: ${labels[idx]}` : "";
+  renderDeltaTable(table, caption, idx > 0 ? abs(idx - 1) : null, abs(idx));
 }
 
 let chartInstances = [];
@@ -102,8 +129,8 @@ function destroyCharts() {
 }
 
 /** Create a chart container with optional title, append to #charts.
- * Returns { canvas, table } where table is the side panel element. The
- * chart occupies ~2/3 of the row width and the table the remaining ~1/3. */
+ * Returns { canvas, table }: `table` is the side panel. The chart occupies
+ * ~2/3 of the row width and the table the remaining ~1/3. */
 function createCanvas(title) {
   const container = document.createElement("div");
   container.className = "chart-container";
@@ -125,14 +152,23 @@ function createCanvas(title) {
 
   body.appendChild(chartWrap);
   body.appendChild(table);
+
   container.appendChild(body);
   document.getElementById("charts").appendChild(container);
   return { canvas, table };
 }
 
-/** Render a dev/target/Δ comparison table into a side panel. `devVals` and
- * `tgtVals` are each [p50, p95, p99]; a null side renders as "—". */
-function renderDeltaTable(el, devVals, tgtVals) {
+/** Render a dev/target/Δ comparison table into a side panel, captioned with
+ * `caption`. `devVals` and `tgtVals` are each [p50, p95, p99]; a null side
+ * renders as "—". */
+function renderDeltaTable(el, caption, devVals, tgtVals) {
+  el.innerHTML = "";
+  if (caption) {
+    const cap = document.createElement("div");
+    cap.className = "chart-target";
+    cap.textContent = caption;
+    el.appendChild(cap);
+  }
   const names = ["p50", "p95", "p99"];
   const table = document.createElement("table");
   table.className = "bench-table";
@@ -206,31 +242,28 @@ function renderStandard(baseline, prRow, prCommit) {
   }
 
   const prIdx = prRow ? labels.length - 1 : -1;
-  const bgColor = (base, highlight) => labels.map((_, i) => i === prIdx ? highlight : base);
-
-  // Side table: dev (baseline tip) vs target (PR, or latest commit).
-  const toVals = (r) => (r ? [+r[1], +r[2], +r[3]] : null);
-  const lastBase = rows.length ? rows[rows.length - 1] : null;
-  const prevBase = rows.length > 1 ? rows[rows.length - 2] : null;
-  const tgtVals = prRow ? toVals(prRow) : toVals(lastBase);
-  const devVals = prRow ? toVals(lastBase) : toVals(prevBase);
-  renderDeltaTable(table, devVals, tgtVals);
+  const abs = makeAbs(p50Data, p95Delta, p99Delta);
+  // Default target: the PR bar, or the latest commit for history-only.
+  const defaultSel = prIdx >= 0 ? prIdx : labels.length - 1;
 
   const chart = new Chart(canvas, {
     type: "bar",
     data: {
       labels,
       datasets: [
-        { label: "p50", data: p50Data, backgroundColor: bgColor("#00adb5", "#00ffd5"), borderWidth: 0 },
-        { label: "p95 \u2212 p50", data: p95Delta, backgroundColor: bgColor("#e2b93d", "#ffe066"), borderWidth: 0 },
-        { label: "p99 \u2212 p95", data: p99Delta, backgroundColor: bgColor("#e94560", "#ff6b81"), borderWidth: 0 },
+        { label: "p50", data: p50Data, borderWidth: 0 },
+        { label: "p95 \u2212 p50", data: p95Delta, borderWidth: 0 },
+        { label: "p99 \u2212 p95", data: p99Delta, borderWidth: 0 },
       ],
     },
     options: {
       responsive: true,
+      onClick: (_evt, els) => {
+        if (els.length) selectBar(chart, labels, table, abs, els[0].index);
+      },
       plugins: {
         legend: { labels: { color: "#e0e0e0", font: { size: 11 } } },
-        tooltip: percentileTooltip(p50Data, p95Delta, p99Delta),
+        tooltip: percentileTooltip(abs),
       },
       scales: {
         x: { stacked: true, ticks: { color: "#888", font: { size: 9 }, maxRotation: 60 }, grid: { color: "#0f3460" } },
@@ -238,6 +271,7 @@ function renderStandard(baseline, prRow, prCommit) {
       },
     },
   });
+  selectBar(chart, labels, table, abs, defaultSel);
   chartInstances.push(chart);
 }
 
@@ -277,16 +311,6 @@ function renderSized(baseline, prRows, prCommit) {
     const commits = sizeRows.map((r) => r[0].slice(0, SHORT_SHA));
     const labels = hasPr ? [...commits, prCommit.slice(0, SHORT_SHA)] : commits;
 
-    // Side table: dev (baseline tip) vs target (PR, or latest commit).
-    const pr = prBySize[size];
-    const lastBase = sizeRows.length ? sizeRows[sizeRows.length - 1] : null;
-    const prevBase = sizeRows.length > 1 ? sizeRows[sizeRows.length - 2] : null;
-    const baseVals = (r) => (r ? [+r[2], +r[3], +r[4]] : null);
-    const prVals = pr ? [pr.p50, pr.p95, pr.p99] : null;
-    const tgtVals = hasPr ? prVals : baseVals(lastBase);
-    const devVals = hasPr ? baseVals(lastBase) : baseVals(prevBase);
-    renderDeltaTable(table, devVals, tgtVals);
-
     const p50Data = sizeRows.map((r) => +r[2]);
     const p95Delta = sizeRows.map((r) => +r[3] - +r[2]);
     const p99Delta = sizeRows.map((r) => +r[4] - +r[3]);
@@ -305,23 +329,27 @@ function renderSized(baseline, prRows, prCommit) {
     }
 
     const prIdx = hasPr ? labels.length - 1 : -1;
-    const bgColor = (base, highlight) => labels.map((_, i) => i === prIdx ? highlight : base);
+    const abs = makeAbs(p50Data, p95Delta, p99Delta);
+    const defaultSel = prIdx >= 0 ? prIdx : labels.length - 1;
 
     const chart = new Chart(canvas, {
       type: "bar",
       data: {
         labels,
         datasets: [
-          { label: "p50", data: p50Data, backgroundColor: bgColor("#00adb5", "#00ffd5"), borderWidth: 0 },
-          { label: "p95 \u2212 p50", data: p95Delta, backgroundColor: bgColor("#e2b93d", "#ffe066"), borderWidth: 0 },
-          { label: "p99 \u2212 p95", data: p99Delta, backgroundColor: bgColor("#e94560", "#ff6b81"), borderWidth: 0 },
+          { label: "p50", data: p50Data, borderWidth: 0 },
+          { label: "p95 \u2212 p50", data: p95Delta, borderWidth: 0 },
+          { label: "p99 \u2212 p95", data: p99Delta, borderWidth: 0 },
         ],
       },
       options: {
         responsive: true,
+        onClick: (_evt, els) => {
+          if (els.length) selectBar(chart, labels, table, abs, els[0].index);
+        },
         plugins: {
           legend: { labels: { color: "#e0e0e0", font: { size: 11 } } },
-          tooltip: percentileTooltip(p50Data, p95Delta, p99Delta),
+          tooltip: percentileTooltip(abs),
         },
         scales: {
           x: { stacked: true, ticks: { color: "#888", font: { size: 9 }, maxRotation: 60 }, grid: { color: "#0f3460" } },
@@ -329,6 +357,7 @@ function renderSized(baseline, prRows, prCommit) {
         },
       },
     });
+    selectBar(chart, labels, table, abs, defaultSel);
     chartInstances.push(chart);
   }
 }

--- a/www/bench/app.js
+++ b/www/bench/app.js
@@ -58,6 +58,41 @@ async function fetchBaseline(bench, runner, machine, arch) {
 const SHORT_SHA = 7;
 const MAX_BASELINE_COMMITS = 50;
 
+/** Signed percentage delta of val vs base, matching the old table's Δ. */
+function formatDelta(val, base) {
+  if (base == null || val == null || base === 0 || Number.isNaN(val) || Number.isNaN(base)) return "n/a";
+  const pct = (val / base) * 100 - 100;
+  const sign = pct >= 0 ? "+" : "\u2212";
+  return `${sign}${Math.abs(pct).toFixed(1)}%`;
+}
+
+/**
+ * Tooltip callbacks for a stacked percentile chart (p50, p95−p50, p99−p95).
+ * Reports each series' *absolute* percentile plus its delta vs the previous
+ * bar (for the PR bar, the previous bar is the dev baseline tip).
+ */
+function percentileTooltip(p50Data, p95Delta, p99Delta) {
+  const names = ["p50", "p95", "p99"];
+  const abs = (i) => {
+    const p50 = p50Data[i];
+    if (p50 == null) return [null, null, null];
+    return [p50, p50 + p95Delta[i], p50 + p95Delta[i] + p99Delta[i]];
+  };
+  return {
+    callbacks: {
+      label(ctx) {
+        const i = ctx.dataIndex;
+        const di = ctx.datasetIndex;
+        const a = abs(i)[di];
+        if (a == null) return "";
+        const prev = i > 0 ? abs(i - 1)[di] : null;
+        const d = prev != null ? ` (${formatDelta(a, prev)} vs prev)` : "";
+        return `${names[di]}: ${a.toLocaleString()} \u03bcs${d}`;
+      },
+    },
+  };
+}
+
 let chartInstances = [];
 
 function destroyCharts() {
@@ -122,15 +157,7 @@ function renderStandard(baseline, prRow, prCommit) {
       responsive: true,
       plugins: {
         legend: { labels: { color: "#e0e0e0", font: { size: 11 } } },
-        tooltip: {
-          callbacks: {
-            afterBody(items) {
-              const idx = items[0].dataIndex;
-              const total = p50Data[idx] + p95Delta[idx] + p99Delta[idx];
-              return `p99 total: ${total.toLocaleString()} \u03bcs`;
-            },
-          },
-        },
+        tooltip: percentileTooltip(p50Data, p95Delta, p99Delta),
       },
       scales: {
         x: { stacked: true, ticks: { color: "#888", font: { size: 9 }, maxRotation: 60 }, grid: { color: "#0f3460" } },
@@ -211,15 +238,7 @@ function renderSized(baseline, prRows, prCommit) {
         responsive: true,
         plugins: {
           legend: { labels: { color: "#e0e0e0", font: { size: 11 } } },
-          tooltip: {
-            callbacks: {
-              afterBody(items) {
-                const idx = items[0].dataIndex;
-                const total = p50Data[idx] + p95Delta[idx] + p99Delta[idx];
-                return `p99 total: ${total.toLocaleString()} \u03bcs`;
-              },
-            },
-          },
+          tooltip: percentileTooltip(p50Data, p95Delta, p99Delta),
         },
         scales: {
           x: { stacked: true, ticks: { color: "#888", font: { size: 9 }, maxRotation: 60 }, grid: { color: "#0f3460" } },
@@ -322,12 +341,12 @@ function renderVfs(baseline, prRows, prCommit) {
     // Index baseline by operation
     const baseByOp = {};
     for (const row of baseOps) {
-      baseByOp[row[2]] = { p50: +row[4], p95: +row[5], p99: +row[6] };
+      baseByOp[row[2]] = { p50: +row[4], p95: +row[5], p99: +row[6], samples: +row[3] };
     }
 
     const prByOp = {};
     for (const row of prOps) {
-      prByOp[row[2]] = { p50: +row[4], p95: +row[5], p99: +row[6] };
+      prByOp[row[2]] = { p50: +row[4], p95: +row[5], p99: +row[6], samples: +row[3] };
     }
 
     // Stacked deltas
@@ -372,6 +391,31 @@ function renderVfs(baseline, prRows, prCommit) {
         responsive: true,
         plugins: {
           legend: { labels: { color: "#e0e0e0", font: { size: 11 } } },
+          tooltip: {
+            callbacks: {
+              label(ctx) {
+                const op = ops[ctx.dataIndex];
+                const isPr = ctx.dataset.stack === "pr";
+                const src = isPr ? prByOp[op] : baseByOp[op];
+                if (!src) return "";
+                const di = ctx.datasetIndex % 3;
+                const name = ["p50", "p95", "p99"][di];
+                const a = [src.p50, src.p95, src.p99][di];
+                const who = hasPr ? (isPr ? "PR " : "dev ") : "";
+                let d = "";
+                if (isPr && baseByOp[op]) {
+                  const b = [baseByOp[op].p50, baseByOp[op].p95, baseByOp[op].p99][di];
+                  d = ` (${formatDelta(a, b)} vs dev)`;
+                }
+                return `${who}${name}: ${a.toLocaleString()} \u03bcs${d}`;
+              },
+              afterBody(items) {
+                const op = ops[items[0].dataIndex];
+                const src = prByOp[op] || baseByOp[op];
+                return src ? `samples: ${src.samples}` : "";
+              },
+            },
+          },
         },
         scales: {
           x: { stacked: true, ticks: { color: "#888" }, grid: { color: "#0f3460" } },

--- a/www/bench/app.js
+++ b/www/bench/app.js
@@ -101,7 +101,9 @@ function destroyCharts() {
   document.getElementById("charts").innerHTML = "";
 }
 
-/** Create a chart container with optional title, append to #charts, return canvas. */
+/** Create a chart container with optional title, append to #charts.
+ * Returns { canvas, table } where table is the side panel element. The
+ * chart occupies ~2/3 of the row width and the table the remaining ~1/3. */
 function createCanvas(title) {
   const container = document.createElement("div");
   container.className = "chart-container";
@@ -110,10 +112,73 @@ function createCanvas(title) {
     h.textContent = title;
     container.appendChild(h);
   }
+  const body = document.createElement("div");
+  body.className = "chart-body";
+
+  const chartWrap = document.createElement("div");
+  chartWrap.className = "chart-canvas";
   const canvas = document.createElement("canvas");
-  container.appendChild(canvas);
+  chartWrap.appendChild(canvas);
+
+  const table = document.createElement("div");
+  table.className = "chart-table";
+
+  body.appendChild(chartWrap);
+  body.appendChild(table);
+  container.appendChild(body);
   document.getElementById("charts").appendChild(container);
-  return canvas;
+  return { canvas, table };
+}
+
+/** Render a dev/target/Δ comparison table into a side panel. `devVals` and
+ * `tgtVals` are each [p50, p95, p99]; a null side renders as "—". */
+function renderDeltaTable(el, devVals, tgtVals) {
+  const names = ["p50", "p95", "p99"];
+  const table = document.createElement("table");
+  table.className = "bench-table";
+  table.innerHTML =
+    "<thead><tr><th></th><th>dev</th><th>target</th><th>\u0394</th></tr></thead>";
+  const tbody = document.createElement("tbody");
+  names.forEach((name, i) => {
+    const d = devVals ? devVals[i] : null;
+    const t = tgtVals ? tgtVals[i] : null;
+    const delta = formatDelta(t, d);
+    const neutral = delta === "n/a" || delta === "+0.0%" || delta === "\u22120.0%";
+    const cls = neutral ? "" : delta.startsWith("+") ? "delta-up" : "delta-down";
+    const tr = document.createElement("tr");
+    tr.innerHTML =
+      `<th>${name}</th>` +
+      `<td>${d == null ? "\u2014" : d.toLocaleString()}</td>` +
+      `<td>${t == null ? "\u2014" : t.toLocaleString()}</td>` +
+      `<td class="${cls}">${delta}</td>`;
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  el.appendChild(table);
+}
+
+/** Render a VFS operation table (operation, samples, p50, p95, p99) for the
+ * target series: PR values when present, else the latest baseline commit. */
+function renderVfsTable(el, ops, srcByOp) {
+  const table = document.createElement("table");
+  table.className = "bench-table";
+  table.innerHTML =
+    "<thead><tr><th>op</th><th>n</th><th>p50</th><th>p95</th><th>p99</th></tr></thead>";
+  const tbody = document.createElement("tbody");
+  for (const op of ops) {
+    const s = srcByOp[op];
+    const tr = document.createElement("tr");
+    const cell = (v) => (v == null ? "\u2014" : v.toLocaleString());
+    tr.innerHTML =
+      `<th>${op}</th>` +
+      `<td>${s ? s.samples : "\u2014"}</td>` +
+      `<td>${s ? cell(s.p50) : "\u2014"}</td>` +
+      `<td>${s ? cell(s.p95) : "\u2014"}</td>` +
+      `<td>${s ? cell(s.p99) : "\u2014"}</td>`;
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  el.appendChild(table);
 }
 
 /**
@@ -124,7 +189,7 @@ function createCanvas(title) {
  */
 function renderStandard(baseline, prRow, prCommit) {
   destroyCharts();
-  const canvas = createCanvas(null);
+  const { canvas, table } = createCanvas(null);
 
   const rows = baseline.rows.slice(-MAX_BASELINE_COMMITS);
   const commits = rows.map((r) => r[0].slice(0, SHORT_SHA));
@@ -142,6 +207,14 @@ function renderStandard(baseline, prRow, prCommit) {
 
   const prIdx = prRow ? labels.length - 1 : -1;
   const bgColor = (base, highlight) => labels.map((_, i) => i === prIdx ? highlight : base);
+
+  // Side table: dev (baseline tip) vs target (PR, or latest commit).
+  const toVals = (r) => (r ? [+r[1], +r[2], +r[3]] : null);
+  const lastBase = rows.length ? rows[rows.length - 1] : null;
+  const prevBase = rows.length > 1 ? rows[rows.length - 2] : null;
+  const tgtVals = prRow ? toVals(prRow) : toVals(lastBase);
+  const devVals = prRow ? toVals(lastBase) : toVals(prevBase);
+  renderDeltaTable(table, devVals, tgtVals);
 
   const chart = new Chart(canvas, {
     type: "bar",
@@ -197,12 +270,22 @@ function renderSized(baseline, prRows, prCommit) {
   }
 
   for (const size of sizes) {
-    const canvas = createCanvas(size);
+    const { canvas, table } = createCanvas(size);
 
     // Baseline history for this size (last N commits)
     const sizeRows = (baseBySize[size] || []).slice(-MAX_BASELINE_COMMITS);
     const commits = sizeRows.map((r) => r[0].slice(0, SHORT_SHA));
     const labels = hasPr ? [...commits, prCommit.slice(0, SHORT_SHA)] : commits;
+
+    // Side table: dev (baseline tip) vs target (PR, or latest commit).
+    const pr = prBySize[size];
+    const lastBase = sizeRows.length ? sizeRows[sizeRows.length - 1] : null;
+    const prevBase = sizeRows.length > 1 ? sizeRows[sizeRows.length - 2] : null;
+    const baseVals = (r) => (r ? [+r[2], +r[3], +r[4]] : null);
+    const prVals = pr ? [pr.p50, pr.p95, pr.p99] : null;
+    const tgtVals = hasPr ? prVals : baseVals(lastBase);
+    const devVals = hasPr ? baseVals(lastBase) : baseVals(prevBase);
+    renderDeltaTable(table, devVals, tgtVals);
 
     const p50Data = sizeRows.map((r) => +r[2]);
     const p95Delta = sizeRows.map((r) => +r[3] - +r[2]);
@@ -331,7 +414,7 @@ function renderVfs(baseline, prRows, prCommit) {
     : Object.keys(baseBySec);
 
   for (const sec of sections) {
-    const canvas = createCanvas(sec);
+    const { canvas, table } = createCanvas(sec);
     const prOps = prBySec[sec] || [];
     const baseOps = baseBySec[sec] || [];
 
@@ -348,6 +431,9 @@ function renderVfs(baseline, prRows, prCommit) {
     for (const row of prOps) {
       prByOp[row[2]] = { p50: +row[4], p95: +row[5], p99: +row[6], samples: +row[3] };
     }
+
+    // Side table: target values (PR when present, else latest baseline).
+    renderVfsTable(table, ops, hasPr ? prByOp : baseByOp);
 
     // Stacked deltas
     const devP50 = ops.map((o) => baseByOp[o]?.p50 ?? null);

--- a/www/bench/app.js
+++ b/www/bench/app.js
@@ -201,16 +201,21 @@ function renderVfsTable(el, ops, srcByOp) {
   table.innerHTML =
     "<thead><tr><th>op</th><th>n</th><th>p50</th><th>p95</th><th>p99</th></tr></thead>";
   const tbody = document.createElement("tbody");
+  const cell = (v) => (v == null || Number.isNaN(v) ? "\u2014" : v.toLocaleString());
   for (const op of ops) {
     const s = srcByOp[op];
     const tr = document.createElement("tr");
-    const cell = (v) => (v == null ? "\u2014" : v.toLocaleString());
-    tr.innerHTML =
-      `<th>${op}</th>` +
-      `<td>${s ? s.samples : "\u2014"}</td>` +
+    // op is untrusted (from the ?d= payload); set it via textContent, not
+    // innerHTML, to avoid injection. Numeric cells are safe.
+    const th = document.createElement("th");
+    th.textContent = op;
+    tr.appendChild(th);
+    const numCells =
+      `<td>${s ? cell(s.samples) : "\u2014"}</td>` +
       `<td>${s ? cell(s.p50) : "\u2014"}</td>` +
       `<td>${s ? cell(s.p95) : "\u2014"}</td>` +
       `<td>${s ? cell(s.p99) : "\u2014"}</td>`;
+    th.insertAdjacentHTML("afterend", numCells);
     tbody.appendChild(tr);
   }
   table.appendChild(tbody);

--- a/www/bench/app.js
+++ b/www/bench/app.js
@@ -58,7 +58,7 @@ async function fetchBaseline(bench, runner, machine, arch) {
 const SHORT_SHA = 7;
 const MAX_BASELINE_COMMITS = 50;
 
-/** Signed percentage delta of val vs base, matching the old table's Δ. */
+/** Signed percentage delta of val vs base (e.g. "+8.0%"), or "n/a". */
 function formatDelta(val, base) {
   if (base == null || val == null || base === 0 || Number.isNaN(val) || Number.isNaN(base)) return "n/a";
   const pct = (val / base) * 100 - 100;
@@ -107,8 +107,10 @@ const BAR_COLORS = [
 ];
 
 /** Highlight bar `idx` as the target: recolor bars and refresh the side
- * table (captioned with the target commit; dev = the preceding bar). */
-function selectBar(chart, labels, table, abs, idx) {
+ * table. Columns are always target | prior | Δ | dev | Δ, where prior is
+ * the preceding bar and dev is the dev tip (`devIdx`). Both are always shown
+ * for consistency (prior is "—" at the first bar; dev reads 0% at the tip). */
+function selectBar(chart, labels, table, abs, devIdx, idx) {
   if (idx < 0 || idx >= labels.length) return;
   chart.data.datasets.forEach((ds, d) => {
     ds.backgroundColor = labels.map((_, i) =>
@@ -116,8 +118,15 @@ function selectBar(chart, labels, table, abs, idx) {
     );
   });
   chart.update("none");
-  const caption = abs(idx) ? `target: ${labels[idx]}` : "";
-  renderDeltaTable(table, caption, idx > 0 ? abs(idx - 1) : null, abs(idx));
+
+  const target = abs(idx);
+  const caption = target ? `target: ${labels[idx]}` : "";
+  const priorIdx = idx - 1;
+  const baselines = [
+    { name: "prior", vals: priorIdx >= 0 ? abs(priorIdx) : null },
+    { name: "dev", vals: devIdx >= 0 ? abs(devIdx) : null },
+  ];
+  renderDeltaTable(table, caption, target, baselines);
 }
 
 let chartInstances = [];
@@ -158,10 +167,11 @@ function createCanvas(title) {
   return { canvas, table };
 }
 
-/** Render a dev/target/Δ comparison table into a side panel, captioned with
- * `caption`. `devVals` and `tgtVals` are each [p50, p95, p99]; a null side
- * renders as "—". */
-function renderDeltaTable(el, caption, devVals, tgtVals) {
+/** Render a comparison table into a side panel, captioned with `caption`.
+ * `target` is [p50,p95,p99] (or null). `baselines` is an ordered list of
+ * { name, vals } rendered target-first as: target | name | Δ | name | Δ ...
+ * A null value renders as "—". */
+function renderDeltaTable(el, caption, target, baselines) {
   el.innerHTML = "";
   if (caption) {
     const cap = document.createElement("div");
@@ -170,23 +180,36 @@ function renderDeltaTable(el, caption, devVals, tgtVals) {
     el.appendChild(cap);
   }
   const names = ["p50", "p95", "p99"];
+  const fmt = (v) => (v == null || Number.isNaN(v) ? "\u2014" : v.toLocaleString());
+  const deltaCell = (t, b) => {
+    const d = formatDelta(t, b);
+    const neutral = d === "n/a" || d === "+0.0%" || d === "\u22120.0%";
+    const cls = neutral ? "" : d.startsWith("+") ? "delta-up" : "delta-down";
+    return `<td class="${cls}">${d}</td>`;
+  };
+
   const table = document.createElement("table");
   table.className = "bench-table";
-  table.innerHTML =
-    "<thead><tr><th></th><th>dev</th><th>target</th><th>\u0394</th></tr></thead>";
+
+  // Header: target then each baseline (value + Δ).
+  let head = "<th></th><th>target</th>";
+  for (const b of baselines) head += `<th>${b.name}</th><th>\u0394</th>`;
+  const thead = document.createElement("thead");
+  const htr = document.createElement("tr");
+  htr.innerHTML = head;
+  thead.appendChild(htr);
+  table.appendChild(thead);
+
   const tbody = document.createElement("tbody");
   names.forEach((name, i) => {
-    const d = devVals ? devVals[i] : null;
-    const t = tgtVals ? tgtVals[i] : null;
-    const delta = formatDelta(t, d);
-    const neutral = delta === "n/a" || delta === "+0.0%" || delta === "\u22120.0%";
-    const cls = neutral ? "" : delta.startsWith("+") ? "delta-up" : "delta-down";
+    const t = target ? target[i] : null;
+    let row = `<th>${name}</th><td>${fmt(t)}</td>`;
+    for (const b of baselines) {
+      const bv = b.vals ? b.vals[i] : null;
+      row += `<td>${fmt(bv)}</td>` + deltaCell(t, bv);
+    }
     const tr = document.createElement("tr");
-    tr.innerHTML =
-      `<th>${name}</th>` +
-      `<td>${d == null ? "\u2014" : d.toLocaleString()}</td>` +
-      `<td>${t == null ? "\u2014" : t.toLocaleString()}</td>` +
-      `<td class="${cls}">${delta}</td>`;
+    tr.innerHTML = row;
     tbody.appendChild(tr);
   });
   table.appendChild(tbody);
@@ -248,6 +271,8 @@ function renderStandard(baseline, prRow, prCommit) {
 
   const prIdx = prRow ? labels.length - 1 : -1;
   const abs = makeAbs(p50Data, p95Delta, p99Delta);
+  // Dev tip = last baseline bar (before the PR bar, when present).
+  const devIdx = prRow ? labels.length - 2 : labels.length - 1;
   // Default target: the PR bar, or the latest commit for history-only.
   const defaultSel = prIdx >= 0 ? prIdx : labels.length - 1;
 
@@ -264,7 +289,7 @@ function renderStandard(baseline, prRow, prCommit) {
     options: {
       responsive: true,
       onClick: (_evt, els) => {
-        if (els.length) selectBar(chart, labels, table, abs, els[0].index);
+        if (els.length) selectBar(chart, labels, table, abs, devIdx, els[0].index);
       },
       plugins: {
         legend: { labels: { color: "#e0e0e0", font: { size: 11 } } },
@@ -276,7 +301,7 @@ function renderStandard(baseline, prRow, prCommit) {
       },
     },
   });
-  selectBar(chart, labels, table, abs, defaultSel);
+  selectBar(chart, labels, table, abs, devIdx, defaultSel);
   chartInstances.push(chart);
 }
 
@@ -335,6 +360,7 @@ function renderSized(baseline, prRows, prCommit) {
 
     const prIdx = hasPr ? labels.length - 1 : -1;
     const abs = makeAbs(p50Data, p95Delta, p99Delta);
+    const devIdx = hasPr ? labels.length - 2 : labels.length - 1;
     const defaultSel = prIdx >= 0 ? prIdx : labels.length - 1;
 
     const chart = new Chart(canvas, {
@@ -350,7 +376,7 @@ function renderSized(baseline, prRows, prCommit) {
       options: {
         responsive: true,
         onClick: (_evt, els) => {
-          if (els.length) selectBar(chart, labels, table, abs, els[0].index);
+          if (els.length) selectBar(chart, labels, table, abs, devIdx, els[0].index);
         },
         plugins: {
           legend: { labels: { color: "#e0e0e0", font: { size: 11 } } },
@@ -362,7 +388,7 @@ function renderSized(baseline, prRows, prCommit) {
         },
       },
     });
-    selectBar(chart, labels, table, abs, defaultSel);
+    selectBar(chart, labels, table, abs, devIdx, defaultSel);
     chartInstances.push(chart);
   }
 }

--- a/www/bench/style.css
+++ b/www/bench/style.css
@@ -59,7 +59,7 @@ main {
 
 #charts {
   width: 100%;
-  max-width: 1000px;
+  max-width: 1200px;
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -78,6 +78,39 @@ main {
   color: var(--muted);
   margin-bottom: 0.75rem;
 }
+
+.chart-body {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.chart-canvas { flex: 2 1 0; min-width: 0; }
+.chart-table { flex: 1 1 0; min-width: 0; overflow-x: auto; }
+
+@media (max-width: 700px) {
+  .chart-body { flex-direction: column; }
+}
+
+.bench-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.bench-table th,
+.bench-table td {
+  padding: 0.25rem 0.5rem;
+  text-align: right;
+  border-bottom: 1px solid var(--border);
+}
+
+.bench-table thead th { color: var(--muted); font-weight: 500; }
+.bench-table tbody th { text-align: left; color: var(--muted); font-weight: 500; }
+
+.delta-up { color: #ff6b81; }
+.delta-down { color: #00d5a0; }
 
 canvas { width: 100% !important; }
 

--- a/www/bench/style.css
+++ b/www/bench/style.css
@@ -88,6 +88,15 @@ main {
 .chart-canvas { flex: 2 1 0; min-width: 0; }
 .chart-table { flex: 1 1 0; min-width: 0; overflow-x: auto; }
 
+.chart-target {
+  font-size: 0.8rem;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.chart-target:empty { display: none; }
+
 @media (max-width: 700px) {
   .chart-body { flex-direction: column; }
 }


### PR DESCRIPTION
## Restore table-parity reporting in the benchmark site

The static benchmark site charted percentiles as stacked *increments* (`p50`,
`p95−p50`, `p99−p95`), so hovering a bar surfaced the delta (e.g. `10017`) where
the old markdown table printed the absolute value (`32859`), and there was no
Δ-vs-baseline anywhere. This makes the site report the same numbers the table
did, and adds an at-a-glance comparison view.

Scope is limited to `www/bench/` (renderer + styles); **no benchmark data or CI
plumbing is touched.**

### Changes

- **Absolute percentiles in tooltips.** Hover shows real `p50/p95/p99` plus a
  signed Δ vs the previous bar. VFS tooltips report Δ-vs-dev on the PR series and
  restore sample counts.
- **Side-by-side comparison table.** Each chart gets a `target | prior | Δ | dev
  | Δ` table (chart ~2/3, table ~1/3), mirroring the old table. VFS gets an
  `op / samples / p50 / p95 / p99` table.
- **Selectable target.** Clicking a bar makes it the table's target, highlights
  it, and captions it with the target commit. Default is the PR bar (or latest
  commit for history-only); recolor is animation-free.
- **Hardening.** VFS operation names (from the `?d=` payload) render via
  `textContent` to close an HTML-injection sink; `NaN` cells fall back to `—`.
