### PR TITLE
[libc] Fix NULL times in the utime family to set current time

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -118,7 +118,7 @@ POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c ftruncate.c truncate.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
-	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c
+	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c utimensat.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's

--- a/src/libs/libc_sys_stat/src/lib.rs
+++ b/src/libs/libc_sys_stat/src/lib.rs
@@ -175,6 +175,26 @@ pub unsafe extern "C" fn fchmodat(
     }
 }
 
+/// Resolves a raw `times` pointer into an owned `[timespec; 2]`.
+///
+/// A NULL pointer maps to `UTIME_NOW` for both entries, per POSIX ("set both
+/// timestamps to the current time"). A non-NULL pointer must reference exactly
+/// two elements; otherwise [`None`] is returned.
+///
+/// # Safety
+///
+/// The caller must ensure a non-NULL `times` points to two valid `timespec`s.
+unsafe fn resolve_times(times: *const timespec) -> Option<[timespec; 2]> {
+    if times.is_null() {
+        let now: timespec = timespec {
+            tv_sec: 0,
+            tv_nsec: sys_stat::UTIME_NOW,
+        };
+        return Some([now; 2]);
+    }
+    slice::from_raw_parts(times, 2).try_into().ok()
+}
+
 ///
 /// # Description
 ///
@@ -203,25 +223,17 @@ pub unsafe extern "C" fn fchmodat(
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn futimens(fd: c_int, times: *const timespec) -> c_int {
-    // Check if `times` is invalid.
-    if times.is_null() {
-        ::syslog::warn!("futimens(): fd={}, times={:p}", fd, times);
-        *__errno_location() = ErrorCode::InvalidArgument.get();
-        return -1;
-    }
-
-    // Attempt to convert `times` to a reference to an array of two elements.
-    let times: &[timespec; 2] = match slice::from_raw_parts(times, 2).try_into() {
-        Ok(array) => array,
-        Err(_) => {
-            ::syslog::warn!("futimens(): invalid times array");
+    let times: [timespec; 2] = match resolve_times(times) {
+        Some(times) => times,
+        None => {
+            ::syslog::warn!("futimens(): invalid times array (fd={})", fd);
             *__errno_location() = ErrorCode::InvalidArgument.get();
             return -1;
         },
     };
 
     // Attempt to set the access and modification times and parse the result.
-    match stat::futimens(fd, times) {
+    match stat::futimens(fd, &times) {
         Ok(()) => 0,
         Err(error) => {
             ::syslog::warn!("futimens(): failed (fd={}, times={:?}, error={:?})", fd, times, error);
@@ -537,28 +549,13 @@ pub unsafe extern "C" fn utimensat(
         },
     };
 
-    // Check if `times` is invalid.
-    if times.is_null() {
-        ::syslog::warn!(
-            "utimensat(): invalid times (dirfd={}, pathname={:?}, times={:p}, flags={})",
-            dirfd,
-            pathname,
-            times,
-            flags
-        );
-        *__errno_location() = ErrorCode::InvalidArgument.get();
-        return -1;
-    }
-
-    // Attempt to convert `times` to a reference to an array of two elements.
-    let times: &[timespec; 2] = match slice::from_raw_parts(times, 2).try_into() {
-        Ok(array) => array,
-        Err(_) => {
+    let times: [timespec; 2] = match resolve_times(times) {
+        Some(times) => times,
+        None => {
             ::syslog::warn!(
-                "futimens(): invalid times array (dirfd={}, pathname={:?}, times={:p}, flags={})",
+                "utimensat(): invalid times array (dirfd={}, pathname={:?}, flags={})",
                 dirfd,
                 pathname,
-                times,
                 flags
             );
             *__errno_location() = ErrorCode::InvalidArgument.get();
@@ -566,7 +563,7 @@ pub unsafe extern "C" fn utimensat(
         },
     };
 
-    match stat::utimensat(dirfd, pathname, times, flags) {
+    match stat::utimensat(dirfd, pathname, &times, flags) {
         Ok(_) => 0,
         Err(error) => {
             ::syslog::warn!(

--- a/src/libs/libc_sys_time/src/utimes.rs
+++ b/src/libs/libc_sys_time/src/utimes.rs
@@ -61,11 +61,10 @@ unsafe extern "C" {
 #[unsafe(no_mangle)]
 #[trace_syscall]
 pub unsafe extern "C" fn utimes(filename: *const c_char, times: *const timeval) -> c_int {
-    // Check if `times` is invalid.
+    // A NULL `times` means "set both timestamps to the current time" per POSIX.
+    // Forward the NULL down to utimensat(), which handles it.
     if times.is_null() {
-        ::syslog::warn!("utimes(): invalid times (filename={:?}, times={:?})", filename, times);
-        *__errno_location() = ErrorCode::InvalidArgument.get();
-        return -1;
+        return utimensat(AT_FDCWD, filename, ::core::ptr::null(), 0);
     }
 
     // Attempt to convert `times`.

--- a/src/libs/libc_utime/src/lib.rs
+++ b/src/libs/libc_utime/src/lib.rs
@@ -12,7 +12,6 @@
 //==================================================================================================
 
 mod bindings {
-    use ::sys::error::ErrorCode;
     use ::sysapi::{
         fcntl::atflags::AT_FDCWD,
         ffi::{
@@ -23,7 +22,6 @@ mod bindings {
         time::timespec,
         utime::utimbuf,
     };
-    use ::syscall::errno::__errno_location;
     use ::syslog::trace_syscall;
 
     unsafe extern "C" {
@@ -64,11 +62,10 @@ mod bindings {
     #[unsafe(no_mangle)]
     #[trace_syscall]
     pub unsafe extern "C" fn utime(filename: *const c_char, times: *const utimbuf) -> c_int {
-        // Check if `times` is invalid.
+        // A NULL `times` means "set both timestamps to the current time" per POSIX.
+        // Forward the NULL down to utimensat(), which handles it.
         if times.is_null() {
-            ::syslog::warn!("utime(): invalid times (filename={:?}, times={:?})", filename, times);
-            *__errno_location() = ErrorCode::InvalidArgument.get();
-            return -1;
+            return utimensat(AT_FDCWD, filename, ::core::ptr::null(), 0);
         }
 
         // Attempt to convert `times`.

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -2142,6 +2142,11 @@ pub fn vfs_utimensat(
         return Err(Fat32Error::InvalidArgument);
     }
     let resolved = vfs_resolve_path(dirfd, pathname)?;
+    // POSIX TODO: NULL/UTIME_NOW times need write access, owner match, or privilege.
+    // See https://pubs.opengroup.org/onlinepubs/9799919799/functions/utimensat.html
+    // Nanvix is single-user, so owner and privilege always hold — the check
+    // reduces to writability. Enforce via check_writable when timestamp
+    // persistence lands.
     // Verify that the target exists using the VFS-level stat for consistent semantics.
     filesystem::stat(&current_cwd(), resolved.as_str()).map(|_| ())
 }

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -140,6 +140,7 @@ extern void test_umask_ramfs(void);
 
 // Tests whether we can change file access and modification times.
 extern void test_utimensat(void);
+extern void test_utimensat_now(void);
 
 // Tests whether we can update file timestamps with `utimes()`.
 extern void test_utimes(void);

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -152,6 +152,8 @@ int main(int argc, const char *argv[])
     test_getcwd();
     test_chdir(); // requires getcwd().
     test_fchdir();
+    // NULL times returns success even on FAT32 (timestamps are ignored).
+    test_utimensat_now();
 #ifndef __NANVIX_STANDALONE__
     // FAT32 timestamps, permissions, and ownership are no-ops that fail assertions.
     test_utimensat();

--- a/src/tests/integration/test-c-file/utimensat.c
+++ b/src/tests/integration/test-c-file/utimensat.c
@@ -19,10 +19,11 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <string.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
+#include <utime.h>
 
 //==================================================================================================
 // Standalone Functions
@@ -60,6 +61,29 @@ void test_utimensat(void)
     assert(st.st_mtime == times[1].tv_sec);
 
     // Clean up.
+    assert(close(fd) == 0);
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests whether the time-setting calls accept a NULL `times` (set to current
+// time). NULL returns success even on FAT32, where timestamps are ignored.
+void test_utimensat_now(void)
+{
+    fprintf(stderr, "testing NULL times (set to now) ... ");
+
+    const char *filename = "testfile_now.tmp";
+
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+
+    // A NULL `times` means "set both timestamps to the current time".
+    assert(utimensat(AT_FDCWD, filename, NULL, 0) == 0);
+    assert(futimens(fd, NULL) == 0);
+    assert(utimes(filename, NULL) == 0);
+    assert(utime(filename, NULL) == 0);
+
     assert(close(fd) == 0);
     assert(unlink(filename) == 0);
 


### PR DESCRIPTION
Closes #3066

## What
`utimensat`, `futimens`, `utimes`, and `utime` all rejected a NULL `times` pointer with `EINVAL`. POSIX specifies NULL means "set both access and modification times to the current time." This broke cpython's `os.utime(path, times=None)` (nanvix/cpython#529), affecting `test_os::test_utime_current` / `test_utime_current_old`.

Distinct from the FAT mtime-not-persisted issue (cpython#514) — this is purely the syscalls rejecting a valid NULL argument.

## Change
- Extracted a shared `resolve_times()` helper mapping NULL → `UTIME_NOW` for both entries; `utimensat` and `futimens` use it.
- `utimes`/`utime` forward NULL down to the fixed `utimensat` (they are thin adapters that convert their struct type to `timespec` then call `utimensat`).
- Added a repro asserting NULL succeeds for all four.

## Verification
Verified against the full lifecycle; the `test-c-file` POSIX suite passes and traces confirm NULL converts to `UTIME_NOW`.