### PR TITLE
[sys] Add Thread-Termination Scheduling ABI

### DIFF
--- a/src/daemons/memd/src/main.rs
+++ b/src/daemons/memd/src/main.rs
@@ -142,13 +142,25 @@ pub fn main() {
                     Ok(false) => continue,
                     Err(e) => ::syslog::error!("failed to handle ipc request (error={:?})", e),
                 },
-                MessageType::Interrupt => unreachable!("should not receive interrupts"),
-                MessageType::Ikc => unreachable!("should not receive ikc messages"),
+                MessageType::Interrupt => {
+                    ::syslog::warn!("received unexpected interrupt, ignoring");
+                    continue;
+                },
+                MessageType::Ikc => {
+                    ::syslog::warn!("received unexpected ikc message, ignoring");
+                    continue;
+                },
                 MessageType::ProcessTerminationEvent => {
-                    unreachable!("should not receive process termination events")
+                    ::syslog::warn!("received unexpected process termination event, ignoring");
+                    continue;
                 },
                 MessageType::ProcessCreationEvent => {
-                    unreachable!("should not receive process creation events")
+                    ::syslog::warn!("received unexpected process creation event, ignoring");
+                    continue;
+                },
+                MessageType::ThreadTerminationEvent => {
+                    ::syslog::warn!("received unexpected thread termination event, ignoring");
+                    continue;
                 },
                 MessageType::PullResponse => {
                     ::syslog::error!("received unexpected pull response, ignoring");

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -424,6 +424,9 @@ pub fn main() {
                 MessageType::ProcessCreationEvent => {
                     ::syslog::warn!("received unexpected process creation event, ignoring");
                 },
+                MessageType::ThreadTerminationEvent => {
+                    ::syslog::warn!("received unexpected thread termination event, ignoring");
+                },
                 MessageType::PullResponse => {
                     ::syslog::warn!("received unexpected pull response, ignoring");
                 },

--- a/src/kernel/src/event/manager/test.rs
+++ b/src/kernel/src/event/manager/test.rs
@@ -1231,6 +1231,38 @@ fn test_event_tokens_are_stable_until_commit() -> bool {
 ///
 /// # Description
 ///
+/// Verifies that one class-wide scheduling owner is eligible for every scheduling event.
+///
+/// # Returns
+///
+/// `true` if one owner receives every scheduling-event mask bit and a non-owner receives none,
+/// otherwise `false`.
+///
+fn test_scheduling_owner_mask_includes_all_events() -> bool {
+    let mut inner: EventManagerInner = make_inner();
+    inner.scheduling_owner = Some(test_pid());
+
+    let owner_masks: EventMasks = inner.event_masks(test_pid());
+    for event in SchedulingEvent::VALUES {
+        let event_mask: usize = 1usize << usize::from(event);
+        if owner_masks.scheduling & event_mask == 0 {
+            error!("scheduling owner mask omitted event: {:?}", event);
+            return false;
+        }
+    }
+
+    let non_owner: ProcessIdentifier = ProcessIdentifier::from(1001);
+    if inner.event_masks(non_owner).scheduling != 0 {
+        error!("non-owner received scheduling event eligibility");
+        return false;
+    }
+
+    true
+}
+
+///
+/// # Description
+///
 /// Verifies that a receive attempt refreshes scheduling ownership acquired while the receiver was
 /// blocked. The first attempt models the receiver before registration; the second models its retry
 /// after the registration wakeup.
@@ -1783,6 +1815,7 @@ pub fn test() -> bool {
     passed &= run_test!(test_each_call_delivers_a_single_interrupt);
     passed &= run_test!(test_selection_seam_combines_events_and_mailbox);
     passed &= run_test!(test_event_tokens_are_stable_until_commit);
+    passed &= run_test!(test_scheduling_owner_mask_includes_all_events);
     passed &= run_test!(test_receive_refreshes_scheduling_ownership);
     passed &= run_test!(test_all_service_classes_receive_bounded_service);
     passed &= run_test!(test_masked_event_classes_do_not_block_mailbox);

--- a/src/kernel/src/pm/test.rs
+++ b/src/kernel/src/pm/test.rs
@@ -227,7 +227,10 @@ fn test_event_guard_matching_follows_ownership_scope() -> bool {
 
     let creation: Event = Event::Scheduling(SchedulingEvent::ProcessCreation);
     let termination: Event = Event::Scheduling(SchedulingEvent::ProcessTermination);
-    if !event_guard_matches(&creation, &termination) {
+    let thread_termination: Event = Event::Scheduling(SchedulingEvent::ThreadTermination);
+    if !event_guard_matches(&creation, &termination)
+        || !event_guard_matches(&creation, &thread_termination)
+    {
         error!("scheduling events did not match their class-wide ownership guard");
         return false;
     }

--- a/src/libs/proc/src/daemon/mod.rs
+++ b/src/libs/proc/src/daemon/mod.rs
@@ -46,6 +46,7 @@ use ::sys::{
         ProcessRole,
         ProcessTerminationInfo,
         SchedulingEvent,
+        ThreadTerminationInfo,
     },
     ipc::{
         Message,
@@ -92,6 +93,8 @@ enum LifecycleMessage {
     ProcessCreation(ProcessCreationInfo),
     /// A process terminated.
     ProcessTermination(ProcessTerminationInfo),
+    /// A thread terminated.
+    ThreadTermination(ThreadTerminationInfo),
 }
 
 ///
@@ -279,6 +282,14 @@ fn parse_lifecycle_message(message: &Message) -> Result<Option<LifecycleMessage>
                 raw_info,
             ))))
         },
+        MessageType::ThreadTerminationEvent => {
+            authenticate_lifecycle_message(message)?;
+            let raw_info: [u8; ::core::mem::size_of::<ThreadTerminationInfo>()] =
+                lifecycle_payload(message, "invalid thread termination event payload")?;
+            Ok(Some(LifecycleMessage::ThreadTermination(ThreadTerminationInfo::from_ne_bytes(
+                raw_info,
+            ))))
+        },
         _ => Ok(None),
     }
 }
@@ -395,10 +406,9 @@ impl ProcessDaemon {
         ::sys::kcall::pm::__kcall_capctl(Capability::ProcessManagement, true)?;
 
         // Subscribe to scheduling events. Scheduling events are owned as a single class: a single
-        // registration claims ownership of every scheduling event, so this one call subscribes the
-        // daemon to both process-termination and process-creation events. The kernel publishes a
-        // creation event whenever a process forks a child, which the daemon uses to record the
-        // parent/child relationship without the parent having to register the child explicitly.
+        // registration claims ownership of every scheduling event. The kernel publishes a creation
+        // event whenever a process forks a child, which the daemon uses to record the parent/child
+        // relationship without the parent having to register the child explicitly.
         ::syslog::info!("subscribing to scheduling events...");
         ::sys::kcall::event::__kcall_evctrl(
             Event::Scheduling(SchedulingEvent::ProcessTermination),
@@ -467,7 +477,9 @@ impl ProcessDaemon {
             },
             // Consumed by the lifecycle parser above. Ignored rather than asserted, so that a
             // regression in the parser cannot take the process manager down.
-            MessageType::ProcessTerminationEvent | MessageType::ProcessCreationEvent => {
+            MessageType::ProcessTerminationEvent
+            | MessageType::ProcessCreationEvent
+            | MessageType::ThreadTerminationEvent => {
                 ::syslog::error!("lifecycle message escaped the lifecycle parser, ignoring");
             },
         }
@@ -488,6 +500,9 @@ impl ProcessDaemon {
             LifecycleMessage::ProcessTermination(info) => {
                 self.handle_process_termination_event(info)
             },
+            // Thread-termination cleanup is activated once bounded lifecycle delivery and its
+            // consumer are available. Until then, authenticated events are intentionally dormant.
+            LifecycleMessage::ThreadTermination(_info) => Ok(None),
         }
     }
 
@@ -2648,6 +2663,69 @@ mod tests {
     }
 
     #[test]
+    fn normal_mode_decodes_thread_termination_without_mutating_state() {
+        let pid: ProcessIdentifier = ProcessIdentifier::from(10);
+        let info: ThreadTerminationInfo = ThreadTerminationInfo::new(
+            pid,
+            ThreadIdentifier::from(11),
+            ExitStatus::from(0x0102_0304_u32),
+        );
+        let message: Message = lifecycle_message(
+            MessageSender::KERNEL,
+            MessageType::ThreadTerminationEvent,
+            info.to_ne_bytes(),
+        );
+        let mut daemon: ManuallyDrop<ProcessDaemon> =
+            process_daemon(&[(pid, Some(process_identity(0)))]);
+        let context: ResponseContext = response_context(pid);
+        daemon.blocked.push(BlockedWaiter {
+            waiter: pid,
+            selector: WaitSelector::Any,
+            response_context: context,
+        });
+
+        let parsed: Option<LifecycleMessage> = parse_lifecycle_message(&message)
+            .expect("kernel thread termination message should be decoded");
+        let status: Option<i32> = daemon.handle_message(message);
+
+        assert_eq!(parsed, Some(LifecycleMessage::ThreadTermination(info)));
+        assert_eq!(status, None, "thread termination should not trigger shutdown");
+        assert!(daemon.processes.contains_key(&pid), "thread event should not change registry");
+        assert_eq!(daemon.blocked.len(), 1, "thread event should not release blocked waits");
+        assert_eq!(daemon.blocked[0].response_context, context);
+    }
+
+    #[test]
+    fn normal_mode_rejects_forged_thread_termination_message() {
+        let pid: ProcessIdentifier = ProcessIdentifier::from(10);
+        let info: ThreadTerminationInfo =
+            ThreadTerminationInfo::new(pid, ThreadIdentifier::from(11), ExitStatus::ok());
+        let message: Message = lifecycle_message(
+            MessageSender::new(ProcessIdentifier::from(20), ThreadIdentifier::from(21)),
+            MessageType::ThreadTerminationEvent,
+            info.to_ne_bytes(),
+        );
+        let mut daemon: ManuallyDrop<ProcessDaemon> =
+            process_daemon(&[(pid, Some(process_identity(0)))]);
+        let context: ResponseContext = response_context(pid);
+        daemon.blocked.push(BlockedWaiter {
+            waiter: pid,
+            selector: WaitSelector::Any,
+            response_context: context,
+        });
+
+        let error: Error = parse_lifecycle_message(&message)
+            .expect_err("non-kernel lifecycle message should be rejected");
+        let status: Option<i32> = daemon.handle_message(message);
+
+        assert_eq!(error.code, ErrorCode::PermissionDenied);
+        assert_eq!(status, None, "forged thread termination should not trigger shutdown");
+        assert!(daemon.processes.contains_key(&pid), "forged thread event should be ignored");
+        assert_eq!(daemon.blocked.len(), 1, "forged thread event should not release blocked waits");
+        assert_eq!(daemon.blocked[0].response_context, context);
+    }
+
+    #[test]
     fn shutdown_mode_ignores_valid_process_creation_message() {
         let pid: ProcessIdentifier = ProcessIdentifier::from(10);
         let child: ProcessIdentifier = ProcessIdentifier::from(11);
@@ -2734,6 +2812,29 @@ mod tests {
 
         assert_eq!(error.code, ErrorCode::PermissionDenied);
         assert!(daemon.processes.contains_key(&pid), "forged termination should be ignored");
+    }
+
+    #[test]
+    fn shutdown_mode_ignores_valid_thread_termination_message() {
+        let pid: ProcessIdentifier = ProcessIdentifier::from(10);
+        let info: ThreadTerminationInfo = ThreadTerminationInfo::new(
+            pid,
+            ThreadIdentifier::from(11),
+            ExitStatus::from(0x0102_0304_u32),
+        );
+        let message: Message = lifecycle_message(
+            MessageSender::KERNEL,
+            MessageType::ThreadTerminationEvent,
+            info.to_ne_bytes(),
+        );
+        let mut daemon: ManuallyDrop<ProcessDaemon> =
+            process_daemon(&[(pid, Some(process_identity(0)))]);
+
+        daemon.handle_shutdown_message(&message);
+
+        // Deregistering the owning process here would end the shutdown drain before the process
+        // actually terminated.
+        assert!(daemon.processes.contains_key(&pid), "thread event should not deregister process");
     }
 
     #[test]

--- a/src/libs/sys/src/sys/event/mod.rs
+++ b/src/libs/sys/src/sys/event/mod.rs
@@ -129,3 +129,22 @@ impl From<SchedulingEvent> for Event {
         Event::Scheduling(ev)
     }
 }
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_termination_round_trips_through_event_conversions() {
+        let event: Event = Event::Scheduling(SchedulingEvent::ThreadTermination);
+        let raw_u32: u32 = u32::from(event);
+        let raw_usize: usize = usize::from(event);
+
+        assert_eq!(Event::try_from(raw_u32).expect("valid u32 event should parse"), event);
+        assert_eq!(Event::try_from(raw_usize).expect("valid usize event should parse"), event);
+    }
+}

--- a/src/libs/sys/src/sys/event/scheduling/event.rs
+++ b/src/libs/sys/src/sys/event/scheduling/event.rs
@@ -26,6 +26,8 @@ pub enum SchedulingEvent {
     ProcessTermination,
     /// Process creation.
     ProcessCreation,
+    /// Thread termination.
+    ThreadTermination,
 }
 
 //==================================================================================================
@@ -34,11 +36,14 @@ pub enum SchedulingEvent {
 
 impl SchedulingEvent {
     /// Number of scheduling events.
-    pub const NUMBER_EVENTS: usize = 2;
+    pub const NUMBER_EVENTS: usize = 3;
 
     /// Scheduling events.
-    pub const VALUES: [Self; Self::NUMBER_EVENTS] =
-        [Self::ProcessTermination, Self::ProcessCreation];
+    pub const VALUES: [Self; Self::NUMBER_EVENTS] = [
+        Self::ProcessTermination,
+        Self::ProcessCreation,
+        Self::ThreadTermination,
+    ];
 }
 
 impl From<SchedulingEvent> for u32 {
@@ -54,6 +59,7 @@ impl TryFrom<u32> for SchedulingEvent {
         match raw {
             0 => Ok(Self::ProcessTermination),
             1 => Ok(Self::ProcessCreation),
+            2 => Ok(Self::ThreadTermination),
             _ => Err(Error::new(ErrorCode::InvalidArgument, "invalid scheduling event identifier")),
         }
     }
@@ -70,5 +76,54 @@ impl TryFrom<usize> for SchedulingEvent {
 
     fn try_from(raw: usize) -> Result<Self, Self::Error> {
         Self::try_from(raw as u32)
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::alloc::format;
+
+    #[test]
+    fn scheduling_event_discriminants_are_stable() {
+        assert_eq!(u32::from(SchedulingEvent::ProcessTermination), 0);
+        assert_eq!(u32::from(SchedulingEvent::ProcessCreation), 1);
+        assert_eq!(u32::from(SchedulingEvent::ThreadTermination), 2);
+    }
+
+    #[test]
+    fn scheduling_events_round_trip_through_numeric_conversions() {
+        for event in SchedulingEvent::VALUES {
+            let raw_u32: u32 = u32::from(event);
+            let raw_usize: usize = usize::from(event);
+
+            assert_eq!(
+                SchedulingEvent::try_from(raw_u32)
+                    .expect("valid u32 scheduling event should parse"),
+                event
+            );
+            assert_eq!(
+                SchedulingEvent::try_from(raw_usize)
+                    .expect("valid usize scheduling event should parse"),
+                event
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_scheduling_event_discriminants_are_rejected() {
+        assert!(SchedulingEvent::try_from(SchedulingEvent::NUMBER_EVENTS as u32).is_err());
+        assert!(SchedulingEvent::try_from(SchedulingEvent::NUMBER_EVENTS).is_err());
+        assert!(SchedulingEvent::try_from(u32::MAX).is_err());
+        assert!(SchedulingEvent::try_from(usize::MAX).is_err());
+    }
+
+    #[test]
+    fn thread_termination_scheduling_event_is_formatted() {
+        assert_eq!(format!("{:?}", SchedulingEvent::ThreadTermination), "ThreadTermination");
     }
 }

--- a/src/libs/sys/src/sys/event/scheduling/mod.rs
+++ b/src/libs/sys/src/sys/event/scheduling/mod.rs
@@ -8,6 +8,7 @@
 mod creation;
 mod event;
 mod termination;
+mod thread_termination;
 
 //==================================================================================================
 // Exports
@@ -16,3 +17,4 @@ mod termination;
 pub use creation::*;
 pub use event::*;
 pub use termination::*;
+pub use thread_termination::*;

--- a/src/libs/sys/src/sys/event/scheduling/thread_termination.rs
+++ b/src/libs/sys/src/sys/event/scheduling/thread_termination.rs
@@ -1,0 +1,165 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::{
+    ipc::Message,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
+    ExitStatus,
+};
+use ::core::{
+    fmt::Debug,
+    mem,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+///
+/// # Description
+///
+/// This structure packs information about the termination of a thread.
+///
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct ThreadTerminationInfo {
+    /// Identifier of the process that owns the terminated thread.
+    pub pid: ProcessIdentifier,
+    /// Identifier of the thread that terminated.
+    pub tid: ThreadIdentifier,
+    /// Exit status of the thread that terminated.
+    pub status: ExitStatus,
+}
+::static_assert::assert_eq_size!(ThreadTerminationInfo, 12);
+::static_assert::assert_eq_align!(ThreadTerminationInfo, 4);
+::static_assert::assert_eq!(mem::size_of::<ThreadTerminationInfo>() <= Message::PAYLOAD_SIZE);
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl ThreadTerminationInfo {
+    ///
+    /// # Description
+    ///
+    /// Creates a new [`ThreadTerminationInfo`] with the given information.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the process that owns the terminated thread.
+    /// - `tid`: Identifier of the thread that terminated.
+    /// - `status`: Exit status of the thread that terminated.
+    ///
+    /// # Returns
+    ///
+    /// The new [`ThreadTerminationInfo`].
+    ///
+    pub fn new(pid: ProcessIdentifier, tid: ThreadIdentifier, status: ExitStatus) -> Self {
+        Self { pid, tid, status }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the memory representation of the target [`ThreadTerminationInfo`] as a byte array
+    /// in native byte order.
+    ///
+    /// # Returns
+    ///
+    /// The memory representation of the target [`ThreadTerminationInfo`] as a byte array in native
+    /// byte order.
+    ///
+    pub fn to_ne_bytes(self) -> [u8; mem::size_of::<ThreadTerminationInfo>()] {
+        let mut bytes: [u8; mem::size_of::<ThreadTerminationInfo>()] =
+            [0; mem::size_of::<ThreadTerminationInfo>()];
+
+        let mut offset: usize = 0;
+        bytes[offset..offset + mem::size_of::<ProcessIdentifier>()]
+            .copy_from_slice(&self.pid.to_ne_bytes());
+        offset += mem::size_of::<ProcessIdentifier>();
+
+        bytes[offset..offset + mem::size_of::<ThreadIdentifier>()]
+            .copy_from_slice(&self.tid.to_ne_bytes());
+        offset += mem::size_of::<ThreadIdentifier>();
+
+        bytes[offset..offset + mem::size_of::<ExitStatus>()]
+            .copy_from_slice(&self.status.to_ne_bytes());
+
+        bytes
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Creates a new [`ThreadTerminationInfo`] from a byte array in native byte order.
+    ///
+    /// # Parameters
+    ///
+    /// - `bytes`: The byte array in native byte order.
+    ///
+    /// # Returns
+    ///
+    /// The new [`ThreadTerminationInfo`].
+    ///
+    pub fn from_ne_bytes(bytes: [u8; mem::size_of::<ThreadTerminationInfo>()]) -> Self {
+        ::static_assert::assert_eq_size!(ProcessIdentifier, 4);
+        ::static_assert::assert_eq_size!(ThreadIdentifier, 4);
+        ::static_assert::assert_eq_size!(ExitStatus, 4);
+
+        let mut offset: usize = 0;
+        let pid: ProcessIdentifier = ProcessIdentifier::from_ne_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ]);
+        offset += mem::size_of::<ProcessIdentifier>();
+
+        let tid: ThreadIdentifier = ThreadIdentifier::from_ne_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ]);
+        offset += mem::size_of::<ThreadIdentifier>();
+
+        let status: ExitStatus = ExitStatus::from_ne_bytes(&[
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ]);
+
+        Self { pid, tid, status }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_termination_info_round_trip() {
+        // Each field carries a distinct value, so a field that the native-endian layout drops or
+        // overlaps is caught rather than masked by a zero byte pattern.
+        for status in [ExitStatus::ok(), ExitStatus::from(0x0102_0304_u32)] {
+            let info: ThreadTerminationInfo = ThreadTerminationInfo::new(
+                ProcessIdentifier::from(5),
+                ThreadIdentifier::from(7),
+                status,
+            );
+
+            assert_eq!(ThreadTerminationInfo::from_ne_bytes(info.to_ne_bytes()), info);
+        }
+    }
+}

--- a/src/libs/sys/src/sys/ipc/typ.rs
+++ b/src/libs/sys/src/sys/ipc/typ.rs
@@ -40,6 +40,8 @@ pub enum MessageType {
     PullResponse = 6,
     /// The message encodes information about a process creation event.
     ProcessCreationEvent = 7,
+    /// The message encodes information about a thread termination event.
+    ThreadTerminationEvent = 8,
 }
 ::static_assert::assert_eq_size!(MessageType, 1);
 
@@ -69,6 +71,7 @@ impl MessageType {
             MessageType::Ikc => [5],
             MessageType::PullResponse => [6],
             MessageType::ProcessCreationEvent => [7],
+            MessageType::ThreadTerminationEvent => [8],
         }
     }
 
@@ -95,6 +98,7 @@ impl MessageType {
             [5] => Ok(MessageType::Ikc),
             [6] => Ok(MessageType::PullResponse),
             [7] => Ok(MessageType::ProcessCreationEvent),
+            [8] => Ok(MessageType::ThreadTerminationEvent),
             _ => Err(Error::new(ErrorCode::InvalidMessage, "invalid message type")),
         }
     }
@@ -110,6 +114,54 @@ impl fmt::Debug for MessageType {
             MessageType::Ikc => write!(f, "inter-kernel communication"),
             MessageType::PullResponse => write!(f, "pull response"),
             MessageType::ProcessCreationEvent => write!(f, "process creation event"),
+            MessageType::ThreadTerminationEvent => write!(f, "thread termination event"),
         }
+    }
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::alloc::format;
+
+    #[test]
+    fn message_type_discriminants_round_trip() {
+        let cases: [(MessageType, u8); 8] = [
+            (MessageType::Interrupt, 1),
+            (MessageType::Exception, 2),
+            (MessageType::Ipc, 3),
+            (MessageType::ProcessTerminationEvent, 4),
+            (MessageType::Ikc, 5),
+            (MessageType::PullResponse, 6),
+            (MessageType::ProcessCreationEvent, 7),
+            (MessageType::ThreadTerminationEvent, 8),
+        ];
+
+        for (message_type, raw) in cases {
+            assert_eq!(message_type.to_bytes(), [raw]);
+            assert_eq!(
+                MessageType::try_from_bytes([raw]).expect("valid message type should parse"),
+                message_type
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_message_type_discriminants_are_rejected() {
+        assert!(MessageType::try_from_bytes([0]).is_err());
+        assert!(MessageType::try_from_bytes([9]).is_err());
+        assert!(MessageType::try_from_bytes([u8::MAX]).is_err());
+    }
+
+    #[test]
+    fn thread_termination_message_type_is_formatted() {
+        assert_eq!(
+            format!("{:?}", MessageType::ThreadTerminationEvent),
+            "thread termination event"
+        );
     }
 }


### PR DESCRIPTION
## What

Introduces the dormant thread-termination scheduling ABI so the kernel and `procd` can identify a terminated thread (process, thread, and status) without depending on the private process-management IPC protocol. Discriminants are appended, no kernel path produces the event yet, and every exhaustive consumer builds and handles the new variant safely.

Closes #3051. This is PR 4 of 8: after merge the ABI is available and every exhaustive consumer builds, but the kernel never produces `ThreadTerminationEvent` and `procd` performs no waiter cleanup for it. This dormant state is intentional.

## Why

Kernel production of thread events is gated on later work (bounded lifecycle delivery and a ready `procd` consumer). Landing the ABI first keeps the enum discriminants and message wire format stable across the series without renumbering, and lets every exhaustive consumer compile against the new variant before any producer exists.

## Changes

**Libraries**
- Append `SchedulingEvent::ThreadTermination` and `MessageType::ThreadTerminationEvent` without renumbering existing discriminants; update `VALUES`, `NUMBER_EVENTS`, numeric conversions, and `Debug` formatting.
- Add `ThreadTerminationInfo` (`pid`, `tid`, `status`) with native-endian serialization plus size/alignment and `Message::PAYLOAD_SIZE` static assertions, exported through the scheduling-event module.
- Extend `procd`'s authenticated lifecycle parser to decode the new type as an intentionally dormant event, mutating no blocked waiters or registry state.

**Daemons**
- Handle the appended `MessageType` in `memd` and `vfsd` by logging and ignoring rather than panicking, so a forged message cannot reach an `unreachable!()` arm.

**Tests**
- Cover discriminant stability, numeric/formatting round-trips, invalid-discriminant rejection, and `ThreadTerminationInfo` serialization.
- Add `procd` normal-mode and shutdown-mode cases proving authenticated events leave state untouched and forged events are rejected.
- Assert in-kernel that the class-wide scheduling owner's mask covers every scheduling event without a second `evctrl()` registration.

## Validation

- `format-check`, `lint-check`, `check-kernel check-guest-rlibs check-guest-binaries`
- `run-unit-tests`, `run-kernel-tests`, `run-nanvix-tests`
