### PR TITLE
[kernel] Preallocate lifecycle delivery cap

### DIFF
--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -158,6 +158,7 @@ pub fn kcall_handler() -> ExitStatus {
         let info = pm!().release_process_termination(termination);
         info!("harvested zombie process: pid={:?}, status={:?}", info.pid, info.status);
     }
+    pm!().dispose_lifecycle();
 
     status
 }

--- a/src/kernel/src/pm/mod.rs
+++ b/src/kernel/src/pm/mod.rs
@@ -161,7 +161,7 @@ pub fn init(root: Vmem) -> Result<(), Error> {
     // Initialize the thread manager.
     info!("initializing the thread manager...");
     let (kernel, tm): (ReadyThread, ThreadManager) = thread::init();
-    ProcessManager::init(interrupt_capable, kernel, root, tm);
+    ProcessManager::init(interrupt_capable, kernel, root, tm)?;
 
     #[cfg(feature = "test")]
     {

--- a/src/kernel/src/pm/process/manager/delivery.rs
+++ b/src/kernel/src/pm/process/manager/delivery.rs
@@ -12,11 +12,21 @@ mod delivery_sequence;
 //==================================================================================================
 
 pub(crate) use self::delivery_sequence::DeliverySequence;
-use crate::pm::process::{
-    LifecycleCreationReservation,
-    LifecycleTerminationCredit,
+use crate::{
+    mm::{
+        try_box,
+        try_vec_with_capacity,
+    },
+    pm::process::{
+        LifecycleCreationCredit,
+        LifecycleCreationReservation,
+        LifecycleTerminationCredit,
+    },
 };
-use ::alloc::collections::VecDeque;
+use ::alloc::{
+    boxed::Box,
+    vec::Vec,
+};
 use ::core::mem;
 use ::sys::{
     error::{
@@ -42,6 +52,25 @@ use ::sys::{
 ::static_assert::assert_eq!(mem::size_of::<ProcessTerminationInfo>() <= Message::PAYLOAD_SIZE);
 ::static_assert::assert_eq!(mem::size_of::<ProcessCreationInfo>() <= Message::PAYLOAD_SIZE);
 
+/// Number of process-creation reservations. This is the depth of the undelivered-creation buffer:
+/// it bounds how many processes may be created while the lifecycle consumer is stalled, not how many
+/// may be live.
+const PROCESS_CREATION_RESERVATIONS: usize = ::config::kernel::MAX_PROCESSES;
+
+/// Number of process-termination reservations. This must be at least the maximum number of live
+/// processes, because each one holds a credit from creation until its termination record is
+/// delivered. The excess over that bound is undelivered-termination buffer depth.
+const PROCESS_TERMINATION_RESERVATIONS: usize = ::config::kernel::MAX_PROCESSES;
+
+/// Number of lifecycle records that may be queued. Thread lifecycle records are not produced in
+/// this change, so the global thread limit does not consume queue capacity. Every admitted process
+/// owns at most one creation reservation and one eventual termination reservation.
+const LIFECYCLE_CAPACITY: usize =
+    match PROCESS_CREATION_RESERVATIONS.checked_add(PROCESS_TERMINATION_RESERVATIONS) {
+        Some(capacity) => capacity,
+        None => panic!("process lifecycle capacity overflow"),
+    };
+
 //==================================================================================================
 // Lifecycle Notification
 //==================================================================================================
@@ -49,9 +78,9 @@ use ::sys::{
 /// Lifecycle record stored in the ordered delivery broker.
 enum LifecycleNotification {
     /// Process-creation record.
-    Creation(ProcessCreationInfo),
+    Creation(ProcessCreationInfo, LifecycleCreationCredit),
     /// Process-termination record.
-    Termination(ProcessTerminationInfo),
+    Termination(ProcessTerminationInfo, LifecycleTerminationCredit),
 }
 
 impl LifecycleNotification {
@@ -71,12 +100,12 @@ impl LifecycleNotification {
     fn to_message(&self, owner: ProcessIdentifier) -> Message {
         let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
         let message_type: MessageType = match self {
-            Self::Creation(info) => {
+            Self::Creation(info, _) => {
                 let info_bytes = info.to_ne_bytes();
                 payload[0..info_bytes.len()].copy_from_slice(&info_bytes);
                 MessageType::ProcessCreationEvent
             },
-            Self::Termination(info) => {
+            Self::Termination(info, _) => {
                 let info_bytes = info.to_ne_bytes();
                 payload[0..info_bytes.len()].copy_from_slice(&info_bytes);
                 MessageType::ProcessTerminationEvent
@@ -94,8 +123,336 @@ impl LifecycleNotification {
 }
 
 //==================================================================================================
+// Lifecycle Reservation Pool
+//==================================================================================================
+
+/// Fixed-capacity reservation pool embedded in the delivery broker. Reservations carry no identity
+/// because the credit types are linear and constructible only through [`DeliveryBroker`], so a
+/// credit can be neither forged nor released twice.
+struct LifecycleReservationPool<const CAPACITY: usize> {
+    /// Number of reserved slots.
+    in_use: usize,
+}
+
+impl<const CAPACITY: usize> LifecycleReservationPool<CAPACITY> {
+    ///
+    /// # Description
+    ///
+    /// Creates a fully available reservation pool.
+    ///
+    /// # Returns
+    ///
+    /// A reservation pool with no reserved slots.
+    ///
+    const fn new() -> Self {
+        Self { in_use: 0 }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reserves one slot when capacity is available.
+    ///
+    /// # Returns
+    ///
+    /// `true` if a slot was reserved, otherwise `false`.
+    ///
+    fn try_reserve(&mut self) -> bool {
+        if self.in_use >= CAPACITY {
+            return false;
+        }
+        self.in_use += 1;
+        true
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Releases one reserved slot.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if no slot is currently reserved.
+    ///
+    fn release(&mut self) {
+        self.in_use = match self.in_use.checked_sub(1) {
+            Some(in_use) => in_use,
+            None => unreachable!("lifecycle reservation was released twice"),
+        };
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reports how many slots are reserved.
+    ///
+    /// # Returns
+    ///
+    /// The number of reserved slots.
+    ///
+    #[cfg(feature = "test")]
+    fn in_use(&self) -> usize {
+        self.in_use
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Releases every reservation.
+    ///
+    /// # Returns
+    ///
+    /// The number of reservations that were retained before the release.
+    ///
+    fn release_all(&mut self) -> usize {
+        mem::take(&mut self.in_use)
+    }
+}
+
+//==================================================================================================
+// Lifecycle Queue
+//==================================================================================================
+
+/// Lifecycle record and its delivery sequence.
+type LifecycleRecord = (DeliverySequence, LifecycleNotification);
+
+/// Number of lifecycle records stored in each independently allocated queue chunk, derived so that
+/// a chunk fills the kernel heap's largest slab.
+const LIFECYCLE_QUEUE_CHUNK_CAPACITY: usize =
+    ::config::kernel::MAX_SLAB_SIZE / mem::size_of::<Option<LifecycleRecord>>();
+
+::static_assert::assert_eq!(LIFECYCLE_QUEUE_CHUNK_CAPACITY >= 1);
+
+/// Number of queue chunks required to hold every lifecycle reservation.
+const LIFECYCLE_QUEUE_CHUNKS: usize = LIFECYCLE_CAPACITY.div_ceil(LIFECYCLE_QUEUE_CHUNK_CAPACITY);
+
+/// Slab-sized portion of the preallocated lifecycle queue.
+struct LifecycleQueueChunk {
+    /// Record slots owned by this chunk.
+    records: [Option<LifecycleRecord>; LIFECYCLE_QUEUE_CHUNK_CAPACITY],
+}
+
+impl LifecycleQueueChunk {
+    ///
+    /// # Description
+    ///
+    /// Creates an empty lifecycle queue chunk.
+    ///
+    /// # Returns
+    ///
+    /// A chunk whose record slots are all vacant.
+    ///
+    fn new() -> Self {
+        Self {
+            records: [const { None }; LIFECYCLE_QUEUE_CHUNK_CAPACITY],
+        }
+    }
+}
+
+::static_assert::assert_eq!(
+    mem::size_of::<LifecycleQueueChunk>() <= ::config::kernel::MAX_SLAB_SIZE
+);
+::static_assert::assert_eq!(
+    LIFECYCLE_QUEUE_CHUNKS * mem::size_of::<Box<LifecycleQueueChunk>>()
+        <= ::config::kernel::MAX_SLAB_SIZE
+);
+
+/// Fixed-capacity ring whose backing chunks are fully allocated during kernel initialization.
+struct LifecycleQueue {
+    /// Preallocated queue chunks. Each chunk is boxed separately so every allocation fits the
+    /// kernel heap's maximum slab size.
+    #[allow(clippy::vec_box)]
+    chunks: Vec<Box<LifecycleQueueChunk>>,
+    /// Logical index of the oldest record.
+    head: usize,
+    /// Number of records currently stored.
+    len: usize,
+}
+
+impl LifecycleQueue {
+    ///
+    /// # Description
+    ///
+    /// Fallibly preallocates every chunk of an empty lifecycle queue.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, an empty lifecycle queue with all backing chunks allocated. Otherwise, an
+    /// error is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if any queue chunk cannot be allocated.
+    ///
+    fn new() -> Result<Self, Error> {
+        let mut chunks: Vec<Box<LifecycleQueueChunk>> =
+            try_vec_with_capacity(LIFECYCLE_QUEUE_CHUNKS)?;
+        for _ in 0..LIFECYCLE_QUEUE_CHUNKS {
+            chunks.push(try_box(LifecycleQueueChunk::new())?);
+        }
+
+        Ok(Self {
+            chunks,
+            head: 0,
+            len: 0,
+        })
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reports how many records are buffered.
+    ///
+    /// # Returns
+    ///
+    /// The number of buffered records.
+    ///
+    #[cfg(feature = "test")]
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Reports whether no records are buffered.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the queue is empty, otherwise `false`.
+    ///
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the slot that backs a ring index.
+    ///
+    /// # Parameters
+    ///
+    /// - `index`: Ring index whose backing slot is resolved.
+    ///
+    /// # Returns
+    ///
+    /// A shared reference to the backing slot.
+    ///
+    fn slot(&self, index: usize) -> &Option<LifecycleRecord> {
+        &self.chunks[index / LIFECYCLE_QUEUE_CHUNK_CAPACITY].records
+            [index % LIFECYCLE_QUEUE_CHUNK_CAPACITY]
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns the slot that backs a ring index, for mutation.
+    ///
+    /// # Parameters
+    ///
+    /// - `index`: Ring index whose backing slot is resolved.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the backing slot.
+    ///
+    fn slot_mut(&mut self, index: usize) -> &mut Option<LifecycleRecord> {
+        &mut self.chunks[index / LIFECYCLE_QUEUE_CHUNK_CAPACITY].records
+            [index % LIFECYCLE_QUEUE_CHUNK_CAPACITY]
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Returns a shared reference to the oldest record.
+    ///
+    /// # Returns
+    ///
+    /// The oldest buffered record, or [`None`] if the queue is empty.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the queue is non-empty but its head slot is vacant, which indicates
+    /// a broken ring invariant.
+    ///
+    fn front(&self) -> Option<&LifecycleRecord> {
+        if self.is_empty() {
+            return None;
+        }
+        match self.slot(self.head) {
+            Some(record) => Some(record),
+            None => unreachable!("lifecycle queue head is vacant"),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Appends a record without allocating.
+    ///
+    /// # Parameters
+    ///
+    /// - `record`: Record to append at the tail of the queue.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the preallocated queue is full or its tail slot is occupied, which
+    /// indicates a broken ring invariant.
+    ///
+    fn push_back(&mut self, record: LifecycleRecord) {
+        if self.len >= LIFECYCLE_CAPACITY {
+            unreachable!("preallocated lifecycle queue is full");
+        }
+
+        let tail: usize = (self.head + self.len) % LIFECYCLE_CAPACITY;
+        let slot: &mut Option<LifecycleRecord> = self.slot_mut(tail);
+        if slot.is_some() {
+            unreachable!("lifecycle queue tail is occupied");
+        }
+        *slot = Some(record);
+        self.len += 1;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Removes and returns the oldest record.
+    ///
+    /// # Returns
+    ///
+    /// The oldest buffered record, or [`None`] if the queue is empty.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the queue is non-empty but its head slot is vacant, which indicates
+    /// a broken ring invariant.
+    ///
+    fn pop_front(&mut self) -> Option<LifecycleRecord> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let head: usize = self.head;
+        self.head = (self.head + 1) % LIFECYCLE_CAPACITY;
+        self.len -= 1;
+        match self.slot_mut(head).take() {
+            Some(record) => Some(record),
+            None => unreachable!("lifecycle queue head is vacant"),
+        }
+    }
+}
+
+//==================================================================================================
 // Delivery Broker
 //==================================================================================================
+
+/// Accounting for lifecycle state disposed during terminal shutdown.
+pub(super) struct LifecycleDisposal {
+    /// Queued records discarded without being delivered.
+    pub(super) undelivered_records: usize,
+    /// Reservations still retained outside queued records.
+    pub(super) retained_reservations: usize,
+}
 
 ///
 /// # Description
@@ -108,41 +465,41 @@ pub(super) struct DeliveryBroker {
     /// Sequence number to allocate to the next committed item.
     next_sequence: Option<DeliverySequence>,
     /// Lifecycle records in production-sequence order.
-    lifecycle: VecDeque<(DeliverySequence, LifecycleNotification)>,
-    /// Creation reservations that have not yet been committed or canceled.
-    pending_creations: usize,
-    /// Capacity credits reserved for future terminations of live processes.
-    termination_credits: usize,
+    lifecycle: LifecycleQueue,
+    /// Capacity reserved by pending or queued process-creation records.
+    creation_reservations: LifecycleReservationPool<PROCESS_CREATION_RESERVATIONS>,
+    /// Capacity reserved by live processes or queued process-termination records.
+    termination_reservations: LifecycleReservationPool<PROCESS_TERMINATION_RESERVATIONS>,
     /// Does the lifecycle owner need a deferred wakeup attempt?
     lifecycle_wakeup_pending: bool,
-}
-
-impl Default for DeliveryBroker {
-    ///
-    /// # Description
-    ///
-    /// Creates an empty delivery broker whose first allocatable delivery sequence is zero.
-    ///
-    /// # Returns
-    ///
-    /// An empty delivery broker with no reserved lifecycle capacity or pending wakeup request.
-    ///
-    fn default() -> Self {
-        Self {
-            next_sequence: Some(DeliverySequence::new(0)),
-            lifecycle: VecDeque::new(),
-            pending_creations: 0,
-            termination_credits: 0,
-            lifecycle_wakeup_pending: false,
-        }
-    }
+    /// Has terminal shutdown disposal already run?
+    disposed: bool,
 }
 
 impl DeliveryBroker {
-    /// Maximum lifecycle capacity consumed by buffered records, pending creations, and termination
-    /// credits. A pending creation consumes two slots until it becomes one buffered creation and one
-    /// termination credit.
-    const LIFECYCLE_CAPACITY: usize = 2 * ::config::kernel::MAX_PROCESSES;
+    ///
+    /// # Description
+    ///
+    /// Creates an empty delivery broker with preallocated lifecycle storage.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, an empty delivery broker is returned. Otherwise, an error is returned.
+    ///
+    pub(super) fn new() -> Result<Self, Error> {
+        let lifecycle: LifecycleQueue = LifecycleQueue::new().inspect_err(|error| {
+            error!("failed to preallocate process lifecycle queue (error={error:?})");
+        })?;
+
+        Ok(Self {
+            next_sequence: Some(DeliverySequence::new(0)),
+            lifecycle,
+            creation_reservations: LifecycleReservationPool::new(),
+            termination_reservations: LifecycleReservationPool::new(),
+            lifecycle_wakeup_pending: false,
+            disposed: false,
+        })
+    }
 
     ///
     /// # Description
@@ -194,22 +551,13 @@ impl DeliveryBroker {
     ///
     /// # Returns
     ///
-    /// The number of lifecycle slots committed or reserved, or [`None`] if the accounting
-    /// overflows.
+    /// The number of lifecycle slots committed or reserved, or [`None`] if accounting overflows.
     ///
-    fn capacity_in_use(&self) -> Option<usize> {
-        self.pending_creations
-            .checked_mul(2)?
-            .checked_add(self.termination_credits)?
-            .checked_add(self.lifecycle.len())
-    }
-
-    /// Reports whether the used lifecycle capacity leaves room for a creation reservation.
-    fn creation_capacity_available(capacity_in_use: usize) -> bool {
-        matches!(
-            capacity_in_use.checked_add(2),
-            Some(required_capacity) if required_capacity <= Self::LIFECYCLE_CAPACITY
-        )
+    #[cfg(feature = "test")]
+    pub(super) fn capacity_in_use(&self) -> Option<usize> {
+        self.creation_reservations
+            .in_use()
+            .checked_add(self.termination_reservations.in_use())
     }
 
     ///
@@ -222,31 +570,31 @@ impl DeliveryBroker {
     /// Upon success, a creation reservation is returned. Otherwise, an error is returned instead.
     ///
     pub(super) fn try_reserve_creation(&mut self) -> Result<LifecycleCreationReservation, Error> {
-        let capacity_in_use: usize = match self.capacity_in_use() {
-            Some(capacity) if Self::creation_capacity_available(capacity) => capacity,
-            _ => {
-                let reason: &str = "process lifecycle queue cannot reserve a creation record";
-                error!("{reason}");
-                return Err(Error::new(ErrorCode::OutOfMemory, reason));
-            },
-        };
-        let required_capacity: usize = capacity_in_use + 2;
-
-        // Reserve the backing storage needed by all outstanding credits. Commits therefore cannot
-        // allocate or fail after process-manager state starts changing.
-        let additional_capacity: usize = required_capacity - self.lifecycle.len();
-        if self
-            .lifecycle
-            .try_reserve_exact(additional_capacity)
-            .is_err()
-        {
-            let reason: &str = "process lifecycle queue allocation failed";
-            error!("{reason}");
-            return Err(Error::new(ErrorCode::OutOfMemory, reason));
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
+        if !self.creation_reservations.try_reserve() {
+            return Err(Self::reservation_error());
+        }
+        if !self.termination_reservations.try_reserve() {
+            self.creation_reservations.release();
+            return Err(Self::reservation_error());
         }
 
-        self.pending_creations += 1;
         Ok(LifecycleCreationReservation::new())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Builds the deterministic lifecycle-capacity backpressure error.
+    ///
+    /// # Returns
+    ///
+    /// An [`ErrorCode::OutOfMemory`] error describing exhausted lifecycle capacity.
+    ///
+    fn reservation_error() -> Error {
+        let reason: &str = "process lifecycle capacity exhausted";
+        error!("{reason}");
+        Error::new(ErrorCode::OutOfMemory, reason)
     }
 
     ///
@@ -256,10 +604,12 @@ impl DeliveryBroker {
     ///
     /// # Parameters
     ///
-    /// - `_reservation`: Reservation to cancel.
+    /// - `reservation`: Reservation to cancel.
     ///
     pub(super) fn cancel_creation(&mut self, _reservation: LifecycleCreationReservation) {
-        self.pending_creations -= 1;
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
+        self.creation_reservations.release();
+        self.termination_reservations.release();
     }
 
     ///
@@ -269,7 +619,7 @@ impl DeliveryBroker {
     ///
     /// # Parameters
     ///
-    /// - `_reservation`: Reservation that supplies capacity for this creation and its termination.
+    /// - `reservation`: Reservation that supplies capacity for this creation and its termination.
     /// - `info`: The process-creation record to queue.
     ///
     /// # Returns
@@ -278,16 +628,16 @@ impl DeliveryBroker {
     ///
     pub(super) fn commit_creation(
         &mut self,
-        _reservation: LifecycleCreationReservation,
+        reservation: LifecycleCreationReservation,
         info: ProcessCreationInfo,
     ) -> LifecycleTerminationCredit {
-        self.pending_creations -= 1;
-        self.termination_credits += 1;
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
+        let (creation_credit, termination_credit) = reservation.into_credits();
         let sequence: DeliverySequence = self.allocate_sequence();
         self.lifecycle
-            .push_back((sequence, LifecycleNotification::Creation(info)));
+            .push_back((sequence, LifecycleNotification::Creation(info, creation_credit)));
         self.lifecycle_wakeup_pending = true;
-        LifecycleTerminationCredit::new()
+        termination_credit
     }
 
     ///
@@ -297,25 +647,26 @@ impl DeliveryBroker {
     ///
     /// # Parameters
     ///
-    /// - `_credit`: Capacity credit reserved when the process was created.
+    /// - `credit`: Capacity credit reserved when the process was created.
     /// - `info`: The process-termination record to queue.
     ///
     pub(super) fn commit_termination(
         &mut self,
-        _credit: LifecycleTerminationCredit,
+        credit: LifecycleTerminationCredit,
         info: ProcessTerminationInfo,
     ) {
-        self.termination_credits -= 1;
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
         let sequence: DeliverySequence = self.allocate_sequence();
         self.lifecycle
-            .push_back((sequence, LifecycleNotification::Termination(info)));
+            .push_back((sequence, LifecycleNotification::Termination(info, credit)));
         self.lifecycle_wakeup_pending = true;
     }
 
     /// Releases a termination credit when the process terminates without producing a lifecycle
     /// record.
     pub(super) fn release_termination(&mut self, _credit: LifecycleTerminationCredit) {
-        self.termination_credits -= 1;
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
+        self.termination_reservations.release();
     }
 
     ///
@@ -438,12 +789,69 @@ impl DeliveryBroker {
     /// record. Such a token indicates a kernel invariant violation under serialized delivery.
     ///
     pub(super) fn commit_lifecycle(&mut self, sequence: DeliverySequence) {
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
         assert!(self.lifecycle_token_is_current(sequence), "stale lifecycle delivery token");
-        if self.lifecycle.pop_front().is_none() {
-            unreachable!("lifecycle delivery token identifies a missing record");
-        }
+        let (_, notification): LifecycleRecord = match self.lifecycle.pop_front() {
+            Some(record) => record,
+            None => unreachable!("lifecycle delivery token identifies a missing record"),
+        };
+        self.release_notification(notification);
         if self.lifecycle.is_empty() {
             self.lifecycle_wakeup_pending = false;
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Releases the reservation transferred into a queued lifecycle record.
+    ///
+    /// # Parameters
+    ///
+    /// - `notification`: Lifecycle record whose reservation is released.
+    ///
+    fn release_notification(&mut self, notification: LifecycleNotification) {
+        match notification {
+            LifecycleNotification::Creation(..) => self.creation_reservations.release(),
+            LifecycleNotification::Termination(..) => self.termination_reservations.release(),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Disposes all lifecycle state during terminal shutdown. Queued records are removed as
+    /// undelivered and release the exact reservations they own. Any reservation that remains in a
+    /// pending creation or live process is then released because no further lifecycle transition
+    /// can occur after this terminal operation.
+    ///
+    /// # Returns
+    ///
+    /// Disposal accounting that distinguishes undelivered records from externally retained
+    /// reservations.
+    ///
+    pub(super) fn dispose(&mut self) -> LifecycleDisposal {
+        assert!(!self.disposed, "lifecycle delivery was already disposed");
+        self.disposed = true;
+
+        let mut undelivered_records: usize = 0;
+        while let Some((_, notification)) = self.lifecycle.pop_front() {
+            self.release_notification(notification);
+            undelivered_records += 1;
+        }
+        self.lifecycle_wakeup_pending = false;
+
+        let creation_reservations: usize = self.creation_reservations.release_all();
+        let termination_reservations: usize = self.termination_reservations.release_all();
+        let retained_reservations: usize =
+            match creation_reservations.checked_add(termination_reservations) {
+                Some(reservations) => reservations,
+                None => unreachable!("lifecycle disposal accounting overflow"),
+            };
+
+        LifecycleDisposal {
+            undelivered_records,
+            retained_reservations,
         }
     }
 
@@ -513,6 +921,7 @@ mod test {
     use super::{
         DeliveryBroker,
         DeliverySequence,
+        LIFECYCLE_CAPACITY,
     };
     use crate::pm::process::{
         LifecycleCreationReservation,
@@ -527,6 +936,25 @@ mod test {
         pm::ProcessIdentifier,
         ExitStatus,
     };
+
+    ///
+    /// # Description
+    ///
+    /// Creates a lifecycle broker for an in-kernel test.
+    ///
+    /// # Returns
+    ///
+    /// The broker fixture, or [`None`] if it could not be created.
+    ///
+    fn new_broker() -> Option<DeliveryBroker> {
+        match DeliveryBroker::new() {
+            Ok(broker) => Some(broker),
+            Err(error) => {
+                error!("failed to create lifecycle broker fixture (error={error:?})");
+                None
+            },
+        }
+    }
 
     ///
     /// # Description
@@ -559,7 +987,9 @@ mod test {
     /// `true` if terminal sequence allocation is accepted exactly once, otherwise `false`.
     ///
     fn test_delivery_sequence_exhaustion_is_detected() -> bool {
-        let mut broker: DeliveryBroker = DeliveryBroker::default();
+        let Some(mut broker) = new_broker() else {
+            return false;
+        };
         broker.set_next_sequence(DeliverySequence::new(u64::MAX));
         if broker.try_allocate_sequence() != Some(DeliverySequence::new(u64::MAX)) {
             error!("delivery broker did not allocate the terminal sequence value");
@@ -576,41 +1006,16 @@ mod test {
     ///
     /// # Description
     ///
-    /// Verifies lifecycle capacity across reservation, commit, dequeue, and reuse transitions.
+    /// Verifies lifecycle reservation ownership across cancel, commit, dequeue, and reuse.
     ///
     /// # Returns
     ///
-    /// `true` if lifecycle capacity remains correct across all transitions, otherwise `false`.
+    /// `true` if every ownership transition releases the expected reservations, otherwise `false`.
     ///
-    fn test_lifecycle_capacity_accounting_is_stateful() -> bool {
-        let mut broker: DeliveryBroker = DeliveryBroker::default();
-        let lifecycle_capacity: usize = 2 * ::config::kernel::MAX_PROCESSES;
-        if !DeliveryBroker::creation_capacity_available(lifecycle_capacity - 2) {
-            error!("lifecycle creation capacity exhausted too early");
+    fn test_lifecycle_reservation_ownership_is_stateful() -> bool {
+        let Some(mut broker) = new_broker() else {
             return false;
-        }
-        if DeliveryBroker::creation_capacity_available(lifecycle_capacity - 1) {
-            error!("lifecycle capacity exceeded its configured bound");
-            return false;
-        }
-
-        broker.pending_creations = ::config::kernel::MAX_PROCESSES;
-        match broker.try_reserve_creation() {
-            Err(error) if error.code == ::sys::error::ErrorCode::OutOfMemory => {},
-            Err(error) => {
-                error!("capacity rejection returned the wrong error (error={error:?})");
-                return false;
-            },
-            Ok(_) => {
-                error!("lifecycle broker accepted a reservation beyond capacity");
-                return false;
-            },
-        }
-        if broker.pending_creations != ::config::kernel::MAX_PROCESSES {
-            error!("rejected lifecycle reservation changed broker accounting");
-            return false;
-        }
-        broker.pending_creations = 0;
+        };
 
         let first: LifecycleCreationReservation = match broker.try_reserve_creation() {
             Ok(reservation) => reservation,
@@ -679,11 +1084,221 @@ mod test {
         true
     }
 
+    /// Verifies a failed termination reservation rolls back the creation slot acquired first.
+    fn test_termination_reservation_failure_rolls_back_creation() -> bool {
+        let Some(mut broker) = new_broker() else {
+            return false;
+        };
+        for _ in 0..::config::kernel::MAX_PROCESSES {
+            if !broker.termination_reservations.try_reserve() {
+                error!("termination pool exhausted too early");
+                return false;
+            }
+        }
+        if broker.creation_reservations.in_use() != 0
+            || broker.termination_reservations.in_use() != ::config::kernel::MAX_PROCESSES
+        {
+            error!("termination-only pressure produced incorrect reservation accounting");
+            return false;
+        }
+
+        match broker.try_reserve_creation() {
+            Err(error) if error.code == ::sys::error::ErrorCode::OutOfMemory => {},
+            Err(error) => {
+                error!("termination-pool rejection returned wrong error (error={error:?})");
+                return false;
+            },
+            Ok(_) => {
+                error!("creation succeeded despite an exhausted termination pool");
+                return false;
+            },
+        }
+        if broker.creation_reservations.in_use() != 0
+            || broker.termination_reservations.in_use() != ::config::kernel::MAX_PROCESSES
+        {
+            error!("failed termination reservation leaked its provisional creation slot");
+            return false;
+        }
+
+        if broker.termination_reservations.release_all() != ::config::kernel::MAX_PROCESSES {
+            error!("termination-pool fixture released an unexpected reservation count");
+            return false;
+        }
+        broker.capacity_in_use() == Some(0)
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Verifies deterministic backpressure and recovery while the lifecycle consumer is stalled.
+    /// Every admitted process immediately terminates, proving that termination enqueue remains
+    /// infallible even as both preallocated reservation pools and the queue become full. The test
+    /// then drains and refills part of the queue to exercise ring wraparound before releasing all
+    /// capacity through transactional dequeue.
+    ///
+    /// # Returns
+    ///
+    /// `true` if capacity backpressures, wraps, drains, and becomes reusable, otherwise `false`.
+    ///
+    fn test_stalled_lifecycle_consumer_backpressures_and_recovers() -> bool {
+        let Some(mut broker) = new_broker() else {
+            return false;
+        };
+        let pid: ProcessIdentifier = ProcessIdentifier::from(1);
+        let creation: ProcessCreationInfo =
+            ProcessCreationInfo::new(pid, ProcessIdentifier::KERNEL, ProcessRole::User);
+        let termination: ProcessTerminationInfo = ProcessTerminationInfo::new(
+            pid,
+            ExitStatus::ok(),
+            ProcessIdentifier::KERNEL,
+            ProcessRole::User,
+        );
+
+        for _ in 0..::config::kernel::MAX_PROCESSES {
+            let reservation: LifecycleCreationReservation = match broker.try_reserve_creation() {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    error!("lifecycle capacity exhausted too early (error={error:?})");
+                    return false;
+                },
+            };
+            let credit: LifecycleTerminationCredit = broker.commit_creation(reservation, creation);
+            broker.commit_termination(credit, termination);
+        }
+
+        if broker.capacity_in_use() != Some(LIFECYCLE_CAPACITY)
+            || broker.lifecycle.len() != LIFECYCLE_CAPACITY
+        {
+            error!("stalled lifecycle consumer did not retain all reserved records");
+            return false;
+        }
+        match broker.try_reserve_creation() {
+            Err(error) if error.code == ::sys::error::ErrorCode::OutOfMemory => {},
+            Err(error) => {
+                error!("lifecycle backpressure returned the wrong error (error={error:?})");
+                return false;
+            },
+            Ok(_) => {
+                error!("lifecycle creation exceeded preallocated capacity");
+                return false;
+            },
+        }
+        if broker.capacity_in_use() != Some(LIFECYCLE_CAPACITY) {
+            error!("rejected lifecycle reservation changed pool accounting");
+            return false;
+        }
+
+        let refill_processes: usize = ::config::kernel::MAX_PROCESSES / 2;
+        for _ in 0..2 * refill_processes {
+            if !commit_lifecycle(&mut broker) {
+                error!("lifecycle queue drained before the requested partial dequeue");
+                return false;
+            }
+        }
+        for _ in 0..refill_processes {
+            let reservation: LifecycleCreationReservation = match broker.try_reserve_creation() {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    error!("drained lifecycle capacity was not reusable (error={error:?})");
+                    return false;
+                },
+            };
+            let credit: LifecycleTerminationCredit = broker.commit_creation(reservation, creation);
+            broker.commit_termination(credit, termination);
+        }
+        if broker.capacity_in_use() != Some(LIFECYCLE_CAPACITY) {
+            error!("wrapped lifecycle queue did not return to full capacity");
+            return false;
+        }
+
+        while commit_lifecycle(&mut broker) {}
+        if broker.capacity_in_use() != Some(0) || broker.has_lifecycle() {
+            error!("transactional lifecycle drain did not release every reservation");
+            return false;
+        }
+        let recovered: LifecycleCreationReservation = match broker.try_reserve_creation() {
+            Ok(reservation) => reservation,
+            Err(error) => {
+                error!("lifecycle creation did not recover after drain (error={error:?})");
+                return false;
+            },
+        };
+        broker.cancel_creation(recovered);
+        broker.capacity_in_use() == Some(0)
+    }
+
+    /// Verifies terminal disposal releases queued and externally retained reservations separately.
+    fn test_lifecycle_shutdown_disposal_accounts_undelivered_state() -> bool {
+        let Some(mut broker) = new_broker() else {
+            return false;
+        };
+        let pid: ProcessIdentifier = ProcessIdentifier::from(1);
+        let creation: ProcessCreationInfo =
+            ProcessCreationInfo::new(pid, ProcessIdentifier::KERNEL, ProcessRole::User);
+        let termination: ProcessTerminationInfo = ProcessTerminationInfo::new(
+            pid,
+            ExitStatus::ok(),
+            ProcessIdentifier::KERNEL,
+            ProcessRole::User,
+        );
+
+        let live_reservation: LifecycleCreationReservation = match broker.try_reserve_creation() {
+            Ok(reservation) => reservation,
+            Err(error) => {
+                error!("failed to reserve live-process fixture (error={error:?})");
+                return false;
+            },
+        };
+        let _live_termination_credit: LifecycleTerminationCredit =
+            broker.commit_creation(live_reservation, creation);
+
+        let terminated_reservation: LifecycleCreationReservation =
+            match broker.try_reserve_creation() {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    error!("failed to reserve terminated-process fixture (error={error:?})");
+                    return false;
+                },
+            };
+        let terminated_credit: LifecycleTerminationCredit =
+            broker.commit_creation(terminated_reservation, creation);
+        broker.commit_termination(terminated_credit, termination);
+
+        let _pending_reservation: LifecycleCreationReservation = match broker.try_reserve_creation()
+        {
+            Ok(reservation) => reservation,
+            Err(error) => {
+                error!("failed to reserve pending-process fixture (error={error:?})");
+                return false;
+            },
+        };
+        let disposal = broker.dispose();
+        if disposal.undelivered_records != 3 || disposal.retained_reservations != 3 {
+            error!(
+                "lifecycle shutdown disposal reported incorrect accounting (undelivered={}, \
+                 retained={})",
+                disposal.undelivered_records, disposal.retained_reservations
+            );
+            return false;
+        }
+        if broker.capacity_in_use() != Some(0)
+            || broker.has_lifecycle()
+            || broker.take_lifecycle_wakeup_request()
+        {
+            error!("lifecycle shutdown disposal retained broker state");
+            return false;
+        }
+        true
+    }
+
     /// Runs all delivery broker in-kernel tests.
     pub(super) fn test() -> bool {
         let mut passed: bool = true;
         passed &= run_test!(test_delivery_sequence_exhaustion_is_detected);
-        passed &= run_test!(test_lifecycle_capacity_accounting_is_stateful);
+        passed &= run_test!(test_lifecycle_reservation_ownership_is_stateful);
+        passed &= run_test!(test_termination_reservation_failure_rolls_back_creation);
+        passed &= run_test!(test_stalled_lifecycle_consumer_backpressures_and_recovers);
+        passed &= run_test!(test_lifecycle_shutdown_disposal_accounts_undelivered_state);
         passed
     }
 }

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -23,7 +23,10 @@ mod test;
 // Imports
 //==================================================================================================
 
-use self::delivery::DeliveryBroker;
+use self::delivery::{
+    DeliveryBroker,
+    LifecycleDisposal,
+};
 use crate::{
     event::EventOwnership,
     hal::{
@@ -74,6 +77,7 @@ use crate::{
             },
             HarvestedProcess,
             LifecycleCreationReservation,
+            LifecycleTerminationCredit,
         },
         sync::{
             condvar::Condvar,
@@ -146,9 +150,6 @@ use ::sys::{
     ExitStatus,
 };
 use ::type_safe::NonEmptyVecDeque;
-
-#[cfg(feature = "test")]
-use crate::pm::process::LifecycleTerminationCredit;
 
 //==================================================================================================
 // Exports
@@ -236,6 +237,9 @@ pub struct ProcessManager {
     number_buffered_messages: usize,
     /// Broker for ordered delivery-domain items.
     delivery: DeliveryBroker,
+    /// Injects one process-creation preparation failure after lifecycle capacity is reserved.
+    #[cfg(feature = "test")]
+    fail_next_lifecycle_creation: bool,
     /// Detached-thread zombies whose reaping was deferred because their
     /// `ContextInformation` was still needed by an in-progress context switch.
     deferred_reap: Vec<(ProcessIdentifier, ZombieThread)>,
@@ -256,14 +260,90 @@ pub struct ProcessManager {
     daemon_pids: Vec<(&'static str, ProcessIdentifier)>,
 }
 
+/// A process built during the fallible phase of creation, held in a queue node that was allocated
+/// there so the commit phase can install the termination credit and enqueue it without allocating.
+struct PreparedProcess {
+    node: LinkedList<RunnableProcess>,
+}
+
+impl PreparedProcess {
+    ///
+    /// # Description
+    ///
+    /// Moves a newly built process into its own queue node.
+    ///
+    /// # Parameters
+    ///
+    /// - `process`: Process to hold in the prepared queue node.
+    ///
+    /// # Returns
+    ///
+    /// A prepared process wrapping `process` in a single queue node.
+    ///
+    fn new(process: RunnableProcess) -> Self {
+        let mut node: LinkedList<RunnableProcess> = LinkedList::new();
+        node.push_back(process);
+        Self { node }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Installs the capacity credit reserved for this process's termination record.
+    ///
+    /// # Parameters
+    ///
+    /// - `credit`: The capacity credit to install for the process's future termination record.
+    ///
+    fn install_termination_credit(&mut self, credit: LifecycleTerminationCredit) {
+        match self.node.front_mut() {
+            Some(process) => process.install_termination_credit(credit),
+            None => unreachable!("prepared process node is empty"),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Appends this process to a queue of ready processes.
+    ///
+    /// # Parameters
+    ///
+    /// - `ready`: Queue of ready processes to append onto.
+    ///
+    fn enqueue(mut self, ready: &mut LinkedList<RunnableProcess>) {
+        ready.append(&mut self.node);
+    }
+}
+
 impl ProcessManager {
-    /// Initializes the process manager.
+    ///
+    /// # Description
+    ///
+    /// Initializes the process manager and preallocates process lifecycle delivery capacity.
+    ///
+    /// # Parameters
+    ///
+    /// - `interrupt_capable`: Indicates whether the process manager is interrupt capable.
+    /// - `kernel`: Kernel process.
+    /// - `root`: Root virtual memory.
+    /// - `tm`: Thread manager.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the initialized process manager is returned. Otherwise, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if lifecycle delivery capacity cannot be preallocated.
+    ///
     pub fn new(
         interrupt_capable: bool,
         kernel: ReadyThread,
         root: Vmem,
         tm: ThreadManager,
-    ) -> Self {
+    ) -> Result<Self, Error> {
+        let delivery: DeliveryBroker = DeliveryBroker::new()?;
         let kernel: RunnableProcess = RunnableProcess::new_kernel(
             ProcessIdentifier::KERNEL,
             ProcessIdentifier::KERNEL,
@@ -279,7 +359,7 @@ impl ProcessManager {
         ) = kernel.run();
         debug_assert!(reason.is_none(), "kernel process should not be interrupted");
 
-        Self {
+        Ok(Self {
             interrupt_capable,
             interrupt_reason: None,
             next_pid: ProcessIdentifier::from(1),
@@ -291,11 +371,13 @@ impl ProcessManager {
             tm,
             live_count: 1,
             number_buffered_messages: 0,
-            delivery: DeliveryBroker::default(),
+            delivery,
+            #[cfg(feature = "test")]
+            fail_next_lifecycle_creation: false,
             deferred_reap: Vec::new(),
             deferred_exec_vmem: Vec::new(),
             daemon_pids: Vec::new(),
-        }
+        })
     }
 
     /// Classifies the [`ProcessRole`] of a process from its identifier and parent, using the set of
@@ -315,6 +397,10 @@ impl ProcessManager {
     ///
     /// If preparation fails, this function releases the reservation before returning the error.
     /// Sequence allocation is deferred until the caller commits the prepared process.
+    ///
+    /// `prepare` owns the cleanup of everything it allocates. In particular, no fallible step may
+    /// be added after the new user image is built unless it also reclaims that image's user frames,
+    /// which dropping a [`Vmem`] does not do.
     ///
     /// # Parameters
     ///
@@ -340,6 +426,38 @@ impl ProcessManager {
                 Err(error)
             },
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Fails once after process creation has reserved lifecycle capacity and identifiers. Compiles
+    /// to a no-op outside test builds.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an [`ErrorCode::OutOfMemory`] error when a failure has been injected.
+    ///
+    fn check_lifecycle_creation_injection(&mut self) -> Result<(), Error> {
+        #[cfg(feature = "test")]
+        if core::mem::take(&mut self.fail_next_lifecycle_creation) {
+            return Err(Error::new(ErrorCode::OutOfMemory, "injected lifecycle creation failure"));
+        }
+        Ok(())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Injects one failure into the next process creation, after it reserves lifecycle capacity.
+    ///
+    #[cfg(feature = "test")]
+    fn inject_lifecycle_creation_failure(&mut self) {
+        self.fail_next_lifecycle_creation = true;
     }
 
     ///
@@ -1181,14 +1299,45 @@ impl ProcessManager {
             );
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
         }
-        let (reservation, (pid, next_pid, next_tid, vmem, thread)): (
+        // Recognize a kernel-spawned system daemon by its program name (the first token of the
+        // command-line arguments) so it is classified as a daemon regardless of the process
+        // identifier it receives. This keeps daemon identification correct for deployments that
+        // omit a daemon and let the init workload take that daemon's conventional identifier. A
+        // name that is already registered is discarded, so this is set only when the commit below
+        // will actually grow the registry.
+        let program_name: &str = args.split_whitespace().next().unwrap_or("");
+        let daemon_name: Option<&'static str> = ::config::daemons::GUEST_DAEMON_NAMES
+            .iter()
+            .copied()
+            .find(|&name| name == program_name)
+            .filter(|name| {
+                !self
+                    .daemon_pids
+                    .iter()
+                    .any(|(registered, _)| registered == name)
+            });
+
+        let (reservation, (pid, next_pid, next_tid, parent_pid, mut prepared)): (
             LifecycleCreationReservation,
-            (ProcessIdentifier, ProcessIdentifier, ThreadIdentifier, Vmem, ReadyThread),
+            (
+                ProcessIdentifier,
+                ProcessIdentifier,
+                ThreadIdentifier,
+                ProcessIdentifier,
+                PreparedProcess,
+            ),
         ) = self.prepare_lifecycle_creation(|manager| {
             // Reserve the next process and thread identifiers early, before resource allocation.
             let (pid, next_pid): (ProcessIdentifier, ProcessIdentifier) = manager.try_next_pid()?;
             let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) =
                 manager.tm.try_next_tid()?;
+            manager.check_lifecycle_creation_injection()?;
+
+            if daemon_name.is_some() && manager.daemon_pids.try_reserve(1).is_err() {
+                let reason: &str = "failed to reserve process daemon registry capacity";
+                error!("{reason}");
+                return Err(Error::new(ErrorCode::OutOfMemory, reason));
+            }
 
             // The boot command line is space-separated, but the user-space runtime parses the
             // NUL-separated wire format produced by `execv()`. Stream the conversion into the new
@@ -1205,42 +1354,26 @@ impl ProcessManager {
                 manager.interrupt_capable,
             )?;
 
-            Ok((pid, next_pid, next_tid, vmem, thread))
+            let parent_pid: ProcessIdentifier = manager.get_running().state().pid();
+            let process: RunnableProcess =
+                RunnableProcess::new_uncommitted(pid, parent_pid, thread, vmem);
+
+            Ok((pid, next_pid, next_tid, parent_pid, PreparedProcess::new(process)))
         })?;
 
-        //==============================================================
-        // NOTE: if we fail beyond this point we need to free page mappings.
-        //==============================================================
-
-        // Recognize a kernel-spawned system daemon by its program name (the first token of the
-        // command-line arguments) so it is classified as a daemon regardless of the process
-        // identifier it receives. This keeps daemon identification correct for deployments that
-        // omit a daemon and let the init workload take that daemon's conventional identifier.
-
-        let program_name: &str = args.split_whitespace().next().unwrap_or("");
-        let daemon_name: Option<&'static str> = ::config::daemons::GUEST_DAEMON_NAMES
-            .iter()
-            .copied()
-            .find(|&n| n == program_name);
-
         Ok(no_fail!(ProcessIdentifier, {
-            // Commit the next process and thread identifiers now that all fallible operations have succeeded.
+            // Commit the next process and thread identifiers now that all allocations and fallible
+            // operations have succeeded.
             self.next_pid = next_pid;
             self.tm.commit_next_tid(next_tid);
             self.live_count += 1;
-            let parent_pid: ProcessIdentifier = self.get_running().state().pid();
 
             // Remember daemon identifiers so a process's role can be classified authoritatively
-            // later (e.g. at termination), when only its identifier is available.
+            // later (e.g. at termination), when only its identifier is available. `daemon_name` is
+            // only set for an unregistered daemon whose registry slot was reserved above, so this
+            // push cannot allocate.
             if let Some(daemon_name) = daemon_name {
-                let found_match = self
-                    .daemon_pids
-                    .iter()
-                    .any(|(name, _)| *name == daemon_name);
-
-                if !found_match {
-                    self.daemon_pids.push((daemon_name, pid));
-                }
+                self.daemon_pids.push((daemon_name, pid));
             }
 
             // Commit the creation to the ordered delivery broker. Waking the lifecycle owner is
@@ -1249,11 +1382,8 @@ impl ProcessManager {
             let termination_credit = self
                 .delivery
                 .commit_creation(reservation, ProcessCreationInfo::new(pid, parent_pid, role));
-            let process: RunnableProcess =
-                RunnableProcess::new(pid, parent_pid, termination_credit, thread, vmem);
-
-            // Add process to the queue of ready processes.
-            self.ready.push_back(process);
+            prepared.install_termination_credit(termination_credit);
+            prepared.enqueue(&mut self.ready);
 
             Ok(pid)
         }))
@@ -1562,32 +1692,9 @@ impl ProcessManager {
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
         }
         #[allow(clippy::type_complexity)]
-        let (
-            reservation,
-            (
-                child_pid,
-                next_pid,
-                child_tid,
-                next_tid,
-                vmem,
-                kernel_stack,
-                context,
-                inherited_signals,
-                inherited_blocked,
-            ),
-        ): (
+        let (reservation, (child_pid, next_pid, next_tid, mut prepared)): (
             LifecycleCreationReservation,
-            (
-                ProcessIdentifier,
-                ProcessIdentifier,
-                ThreadIdentifier,
-                ThreadIdentifier,
-                Vmem,
-                KernelStack,
-                ContextInformation,
-                SignalControl,
-                SigSet,
-            ),
+            (ProcessIdentifier, ProcessIdentifier, ThreadIdentifier, PreparedProcess),
         ) = self.prepare_lifecycle_creation(|manager| {
             // Reserve identifiers early, before allocation. Reap pending zombies on demand if the
             // thread cap is held by terminated-but-unharvested processes.
@@ -1595,6 +1702,7 @@ impl ProcessManager {
                 manager.try_next_pid()?;
             let (child_tid, next_tid): (ThreadIdentifier, ThreadIdentifier) =
                 manager.try_next_tid_reaping(mm)?;
+            manager.check_lifecycle_creation_injection()?;
 
             // Clone the caller's address space.
             let mut vmem: Vmem = mm.new_vmem(manager.get_running().state().vmem())?;
@@ -1630,27 +1738,24 @@ impl ProcessManager {
                 .thread_state()
                 .blocked();
 
-            Ok((
-                child_pid,
-                next_pid,
+            let mut thread: ReadyThread = manager.tm.create_thread(
                 child_tid,
-                next_tid,
-                vmem,
-                kernel_stack,
+                Some(kernel_stack),
+                None,
+                args.user_tda,
                 context,
-                inherited_signals,
-                inherited_blocked,
-            ))
+            );
+            thread.thread_state_mut().set_blocked(inherited_blocked);
+            let mut process: RunnableProcess =
+                RunnableProcess::new_uncommitted(child_pid, pid, thread, vmem);
+            process.set_signals(inherited_signals);
+
+            Ok((child_pid, next_pid, next_tid, PreparedProcess::new(process)))
         })?;
 
         Ok(no_fail!(ProcessIdentifier, {
-            let mut thread: ReadyThread =
-                self.tm
-                    .create_thread(child_tid, Some(kernel_stack), None, args.user_tda, context);
-            // The child's main thread inherits the calling thread's blocked-signal mask.
-            thread.thread_state_mut().set_blocked(inherited_blocked);
-
-            // Commit reserved identifiers now that all fallible operations succeeded.
+            // Commit reserved identifiers now that all allocations and fallible operations
+            // succeeded.
             self.next_pid = next_pid;
             self.tm.commit_next_tid(next_tid);
             self.live_count += 1;
@@ -1661,10 +1766,8 @@ impl ProcessManager {
             let termination_credit = self
                 .delivery
                 .commit_creation(reservation, ProcessCreationInfo::new(child_pid, pid, role));
-            let mut process: RunnableProcess =
-                RunnableProcess::new(child_pid, pid, termination_credit, thread, vmem);
-            process.set_signals(inherited_signals);
-            self.ready.push_back(process);
+            prepared.install_termination_credit(termination_credit);
+            prepared.enqueue(&mut self.ready);
 
             Ok(child_pid)
         }))
@@ -3248,6 +3351,22 @@ impl ProcessManager {
         let (info, credit) = termination.into_parts();
         self.delivery.release_termination(credit);
         info
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Disposes lifecycle state that cannot be delivered after terminal kernel shutdown begins.
+    ///
+    pub(crate) fn dispose_lifecycle(&mut self) {
+        let disposal: LifecycleDisposal = self.delivery.dispose();
+        if disposal.undelivered_records != 0 || disposal.retained_reservations != 0 {
+            warn!(
+                "disposed process lifecycle state at shutdown (undelivered_records={}, \
+                 retained_reservations={})",
+                disposal.undelivered_records, disposal.retained_reservations
+            );
+        }
     }
 
     /// Queues a synthetic creation record without retaining a future termination credit.

--- a/src/kernel/src/pm/process/manager/test.rs
+++ b/src/kernel/src/pm/process/manager/test.rs
@@ -16,6 +16,10 @@ use crate::hal::arch::{
 };
 use crate::{
     ipc::Mailbox,
+    mm::{
+        elf::Elf32Fhdr,
+        VirtMemoryManager,
+    },
     pm::{
         process::{
             LifecycleCreationReservation,
@@ -37,8 +41,10 @@ use ::sys::{
         MessageSender,
         MessageType,
     },
+    mm::VirtualAddress,
     pm::{
         ProcessIdentifier,
+        ThreadCreateArgs,
         ThreadIdentifier,
     },
     ExitStatus,
@@ -54,6 +60,25 @@ fn test_pid() -> ProcessIdentifier {
 
 fn test_tid() -> ThreadIdentifier {
     ThreadIdentifier::from(1000)
+}
+
+///
+/// # Description
+///
+/// Creates a lifecycle broker fixture for an in-kernel test.
+///
+/// # Returns
+///
+/// The broker fixture, or [`None`] if it could not be created.
+///
+fn new_broker() -> Option<DeliveryBroker> {
+    match DeliveryBroker::new() {
+        Ok(broker) => Some(broker),
+        Err(error) => {
+            error!("failed to create lifecycle broker fixture (error={error:?})");
+            None
+        },
+    }
 }
 
 fn creation_info() -> ProcessCreationInfo {
@@ -199,6 +224,132 @@ fn test_cross_process_switch_resets_quantum() -> bool {
 ///
 /// # Description
 ///
+/// Snapshots process-creation state that must not change when lifecycle reservation preparation
+/// fails.
+///
+/// # Parameters
+///
+/// - `pm`: Process manager to snapshot.
+///
+/// # Returns
+///
+/// A tuple of the next process identifier, live count, ready-queue length, and lifecycle capacity
+/// in use.
+///
+fn process_creation_state(pm: &ProcessManager) -> (ProcessIdentifier, usize, usize, Option<usize>) {
+    (pm.next_pid, pm.live_count, pm.ready.len(), pm.delivery.capacity_in_use())
+}
+
+///
+/// # Description
+///
+/// Disarms the injected creation failure and reports whether the call under test consumed it. An
+/// unconsumed injection means the entry point returned before reserving lifecycle capacity, which
+/// would leave the injection armed and break the next real process creation.
+///
+/// # Parameters
+///
+/// - `pm`: Process manager whose injection flag is disarmed.
+///
+/// # Returns
+///
+/// `true` if the injection was consumed by the call under test, otherwise `false`.
+///
+fn injection_was_consumed(pm: &mut ProcessManager) -> bool {
+    !::core::mem::take(&mut pm.fail_next_lifecycle_creation)
+}
+
+/// Verifies `create_process()` rolls back both lifecycle reservations on an injected failure.
+fn test_create_process_reservation_failure_rolls_back() -> bool {
+    let elf: Elf32Fhdr = Elf32Fhdr {
+        e_ident: [0u8; 16],
+        e_type: 0,
+        e_machine: 0,
+        e_version: 0,
+        e_entry: 0,
+        e_phoff: 0,
+        e_shoff: 0,
+        e_flags: 0,
+        e_ehsize: 0,
+        e_phentsize: 0,
+        e_phnum: 0,
+        e_shentsize: 0,
+        e_shnum: 0,
+        e_shstrndx: 0,
+    };
+    // SAFETY: process-manager tests run on one core with interrupts disabled and hold no other
+    // reference to either global manager.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+    let before = process_creation_state(pm);
+    pm.inject_lifecycle_creation_failure();
+
+    match pm.create_process(mm, &elf, "", "") {
+        Err(error) if error.code == ::sys::error::ErrorCode::OutOfMemory => {},
+        Err(error) => {
+            error!("injected create-process failure returned wrong error (error={error:?})");
+            return false;
+        },
+        Ok(pid) => {
+            error!("create_process() ignored injected reservation failure (pid={pid:?})");
+            return false;
+        },
+    }
+    if !injection_was_consumed(pm) {
+        error!("create_process() failed before reserving lifecycle capacity");
+        return false;
+    }
+    if process_creation_state(pm) != before {
+        error!("create_process() changed state after reservation rollback");
+        return false;
+    }
+    true
+}
+
+/// Verifies `duplicate_process()` rolls back both lifecycle reservations on an injected failure.
+fn test_duplicate_process_reservation_failure_rolls_back() -> bool {
+    let args: ThreadCreateArgs = ThreadCreateArgs {
+        user_fn: VirtualAddress::from_raw_value(::config::memory_layout::USER_BASE_RAW),
+        user_fn_arg0: 0,
+        user_fn_arg1: 0,
+        user_stack_base: VirtualAddress::from_raw_value(
+            ::config::memory_layout::USER_STACK_TOP_RAW,
+        ),
+        user_stack_size: ::arch::mem::PAGE_SIZE,
+        user_tda: None,
+    };
+    // SAFETY: process-manager tests run on one core with interrupts disabled and hold no other
+    // reference to either global manager.
+    let pm: &mut ProcessManager = unsafe { ProcessManager::get_mut() };
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+    let before = process_creation_state(pm);
+    pm.inject_lifecycle_creation_failure();
+
+    match pm.duplicate_process(mm, ProcessIdentifier::KERNEL, &args) {
+        Err(error) if error.code == ::sys::error::ErrorCode::OutOfMemory => {},
+        Err(error) => {
+            error!("injected duplicate failure returned wrong error (error={error:?})");
+            return false;
+        },
+        Ok(pid) => {
+            error!("duplicate_process() ignored injected reservation failure (pid={pid:?})");
+            return false;
+        },
+    }
+    if !injection_was_consumed(pm) {
+        error!("duplicate_process() failed before reserving lifecycle capacity");
+        return false;
+    }
+    if process_creation_state(pm) != before {
+        error!("duplicate_process() changed state after reservation rollback");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
 /// Verifies that older IPC is selected before a newer lifecycle record.
 ///
 /// # Returns
@@ -206,7 +357,9 @@ fn test_cross_process_switch_resets_quantum() -> bool {
 /// `true` if delivery follows production-sequence order, otherwise `false`.
 ///
 fn test_ipc_precedes_newer_lifecycle() -> bool {
-    let mut broker: DeliveryBroker = DeliveryBroker::default();
+    let Some(mut broker) = new_broker() else {
+        return false;
+    };
     let mut mailbox: Mailbox = Mailbox::default();
     let receiver: MessageReceiver = MessageReceiver::new(test_pid(), ThreadIdentifier::NONE);
     let ipc_sequence = broker.allocate_sequence();
@@ -251,7 +404,9 @@ fn test_ipc_precedes_newer_lifecycle() -> bool {
 /// `true` if the failed wakeup leaves ordering and both records intact, otherwise `false`.
 ///
 fn test_lifecycle_precedes_newer_ipc_after_failed_wakeup() -> bool {
-    let mut broker: DeliveryBroker = DeliveryBroker::default();
+    let Some(mut broker) = new_broker() else {
+        return false;
+    };
     let mut mailbox: Mailbox = Mailbox::default();
     let _termination_credit: LifecycleTerminationCredit = match commit_creation(&mut broker) {
         Some(credit) => credit,
@@ -304,7 +459,9 @@ fn test_lifecycle_precedes_newer_ipc_after_failed_wakeup() -> bool {
 /// `true` if ineligible IPC is excluded from lifecycle arbitration, otherwise `false`.
 ///
 fn test_other_thread_ipc_does_not_block_lifecycle() -> bool {
-    let mut broker: DeliveryBroker = DeliveryBroker::default();
+    let Some(mut broker) = new_broker() else {
+        return false;
+    };
     let mut mailbox: Mailbox = Mailbox::default();
     let other_tid: ThreadIdentifier = ThreadIdentifier::from(2000);
     let other_receiver: MessageReceiver = MessageReceiver::new(test_pid(), other_tid);
@@ -339,7 +496,9 @@ fn test_other_thread_ipc_does_not_block_lifecycle() -> bool {
 /// `true` if only an eligible owner receives lifecycle records in FIFO order, otherwise `false`.
 ///
 fn test_lifecycle_fifo_and_eligibility() -> bool {
-    let mut broker: DeliveryBroker = DeliveryBroker::default();
+    let Some(mut broker) = new_broker() else {
+        return false;
+    };
     let termination_credit: LifecycleTerminationCredit = match commit_creation(&mut broker) {
         Some(credit) => credit,
         None => return false,
@@ -375,7 +534,9 @@ fn test_lifecycle_fifo_and_eligibility() -> bool {
 /// otherwise `false`.
 ///
 fn test_lifecycle_delivery_is_transactional() -> bool {
-    let mut broker: DeliveryBroker = DeliveryBroker::default();
+    let Some(mut broker) = new_broker() else {
+        return false;
+    };
     let termination_credit: LifecycleTerminationCredit = match commit_creation(&mut broker) {
         Some(credit) => credit,
         None => return false,
@@ -427,7 +588,9 @@ fn test_lifecycle_delivery_is_transactional() -> bool {
 
 /// Verifies that pre-registration buffering and failed wakeups can re-arm owner notification.
 fn test_lifecycle_wakeup_request_can_be_rearmed() -> bool {
-    let mut broker: DeliveryBroker = DeliveryBroker::default();
+    let Some(mut broker) = new_broker() else {
+        return false;
+    };
     let _termination_credit: LifecycleTerminationCredit = match commit_creation(&mut broker) {
         Some(credit) => credit,
         None => return false,
@@ -495,6 +658,8 @@ pub(super) fn test() -> bool {
     passed &= run_test!(test_intra_process_switch_resets_exhausted_quantum);
     passed &= run_test!(test_intra_process_switch_preserves_remaining_quantum);
     passed &= run_test!(test_cross_process_switch_resets_quantum);
+    passed &= run_test!(test_create_process_reservation_failure_rolls_back);
+    passed &= run_test!(test_duplicate_process_reservation_failure_rolls_back);
     passed &= run_test!(test_ipc_precedes_newer_lifecycle);
     passed &= run_test!(test_lifecycle_precedes_newer_ipc_after_failed_wakeup);
     passed &= run_test!(test_other_thread_ipc_does_not_block_lifecycle);

--- a/src/kernel/src/pm/process/manager/unsafe.rs
+++ b/src/kernel/src/pm/process/manager/unsafe.rs
@@ -190,21 +190,35 @@ impl ProcessManager {
     /// - `root`: Root virtual memory.
     /// - `tm`: Thread manager.
     ///
+    /// # Returns
+    ///
+    /// Upon success, empty is returned. Otherwise, an error is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if lifecycle delivery capacity cannot be preallocated.
+    ///
     /// # Panics
     ///
     /// This function panics if the process manager is already initialized.
     ///
-    pub fn init(interrupt_capable: bool, kernel: ReadyThread, root: Vmem, tm: ThreadManager) {
+    pub fn init(
+        interrupt_capable: bool,
+        kernel: ReadyThread,
+        root: Vmem,
+        tm: ThreadManager,
+    ) -> Result<(), Error> {
         // Check if the process manager is already initialized.
         if unlikely(PROCESS_MANAGER_INIT.load(ORDER)) {
             panic!("process manager was already initialized");
         }
 
-        let pm: ProcessManager = ProcessManager::new(interrupt_capable, kernel, root, tm);
+        let pm: ProcessManager = ProcessManager::new(interrupt_capable, kernel, root, tm)?;
 
         // SAFETY: This happens during kernel initialization and no other threads are running.
         unsafe { PROCESS_MANAGER.write(pm) };
         PROCESS_MANAGER_INIT.store(true, ORDER);
+        Ok(())
     }
 
     ///

--- a/src/kernel/src/pm/process/mod.rs
+++ b/src/kernel/src/pm/process/mod.rs
@@ -19,16 +19,66 @@ pub(crate) mod state;
 // Lifecycle Capacity Credits
 //==================================================================================================
 
+/// Capacity credit owned by a queued process-creation record. Reservations are counted rather than
+/// identified, so this type carries no payload: it exists to make the credit a linear resource that
+/// only the delivery broker can mint and consume.
+#[derive(Debug)]
+#[must_use]
+pub(super) struct LifecycleCreationCredit {
+    _private: (),
+}
+
+impl LifecycleCreationCredit {
+    ///
+    /// # Description
+    ///
+    /// Creates a creation-capacity credit.
+    ///
+    /// # Returns
+    ///
+    /// A creation-capacity credit.
+    ///
+    fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
 /// Reservation for a process-creation record and its future process-termination record.
 #[derive(Debug)]
 #[must_use]
 pub(super) struct LifecycleCreationReservation {
-    _private: (),
+    creation_credit: LifecycleCreationCredit,
+    termination_credit: LifecycleTerminationCredit,
 }
 
 impl LifecycleCreationReservation {
+    ///
+    /// # Description
+    ///
+    /// Creates a reservation that owns one creation credit and one termination credit.
+    ///
+    /// # Returns
+    ///
+    /// A creation reservation.
+    ///
     fn new() -> Self {
-        Self { _private: () }
+        Self {
+            creation_credit: LifecycleCreationCredit::new(),
+            termination_credit: LifecycleTerminationCredit::new(),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Splits the reservation into its creation and termination credits.
+    ///
+    /// # Returns
+    ///
+    /// A tuple holding the creation credit and the termination credit.
+    ///
+    fn into_credits(self) -> (LifecycleCreationCredit, LifecycleTerminationCredit) {
+        (self.creation_credit, self.termination_credit)
     }
 }
 
@@ -40,6 +90,15 @@ pub(super) struct LifecycleTerminationCredit {
 }
 
 impl LifecycleTerminationCredit {
+    ///
+    /// # Description
+    ///
+    /// Creates a termination-capacity credit.
+    ///
+    /// # Returns
+    ///
+    /// A termination-capacity credit.
+    ///
     fn new() -> Self {
         Self { _private: () }
     }

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -317,6 +317,27 @@ impl ProcessState {
     ///
     /// # Description
     ///
+    /// Installs the capacity credit reserved for this process's termination record.
+    ///
+    /// # Parameters
+    ///
+    /// - `credit`: The capacity credit to install for the process's future termination record.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if a termination credit is already installed.
+    ///
+    fn install_termination_credit(&mut self, credit: LifecycleTerminationCredit) {
+        assert!(
+            self.termination_credit.is_none(),
+            "process termination credit was already installed"
+        );
+        self.termination_credit = Some(credit);
+    }
+
+    ///
+    /// # Description
+    ///
     /// Sets the pending exit status for the process if one is not already set. This is used
     /// when a thread calls `exit()` to terminate the process, but there are other threads that
     /// need to be terminated first. The exit status from the first thread that called `exit()`

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -66,20 +66,51 @@ pub struct RunnableProcess {
 }
 
 impl RunnableProcess {
-    pub(in crate::pm::process) fn new(
+    ///
+    /// # Description
+    ///
+    /// Creates a process whose termination credit will be installed at lifecycle commit.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the new process.
+    /// - `parent`: Identifier of the parent process.
+    /// - `ready_thread`: Ready main thread of the process.
+    /// - `vmem`: Address space of the process.
+    ///
+    /// # Returns
+    ///
+    /// A runnable process with no termination credit installed yet.
+    ///
+    pub(in crate::pm::process) fn new_uncommitted(
         pid: ProcessIdentifier,
         parent: ProcessIdentifier,
-        termination_credit: LifecycleTerminationCredit,
         ready_thread: ReadyThread,
         vmem: Vmem,
     ) -> Self {
         Self {
-            state: Box::new(ProcessState::new(pid, parent, Some(termination_credit), vmem)),
+            state: Box::new(ProcessState::new(pid, parent, None, vmem)),
             ready_threads: NonEmptyVecDeque::new(ready_thread),
             interrupted_threads: None,
             sleeping_threads: None,
             zombie_threads: None,
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Installs the capacity credit reserved for this process's termination record.
+    ///
+    /// # Parameters
+    ///
+    /// - `credit`: The capacity credit to install for the process's future termination record.
+    ///
+    pub(in crate::pm::process) fn install_termination_credit(
+        &mut self,
+        credit: LifecycleTerminationCredit,
+    ) {
+        self.state.install_termination_credit(credit);
     }
 
     pub(in crate::pm::process) fn new_kernel(


### PR DESCRIPTION
Move all process lifecycle notification storage and reservations to
kernel-initialization time so that producing a creation or termination
event after process creation commits can neither allocate nor fail. A
stalled or absent scheduling-event owner now causes deterministic
backpressure on new process creation instead of losing termination
events.

Closes #3052.

## Kernel
- Add a fixed-capacity `LifecycleReservationPool` for process creation
  and termination, sized from `MAX_PROCESSES`, replacing the old
  on-demand `VecDeque` accounting. Reservation capacity is now
  independent of `ProcessManager::live_count` and process harvest.
- Preallocate the lifecycle queue as slab-sized, separately boxed chunks
  during `DeliveryBroker::new()`, with chunk capacity derived from
  `MAX_SLAB_SIZE` and static-asserted to fit the kernel heap.
- Reserve creation and future-termination capacity before creation or
  duplication commits, and roll every reservation back on failure.
  `ProcessManager::init()`/`::new()` are now fallible.
- Carry the termination credit in process state and transfer it into the
  queued record; release it only on transactional dequeue, so harvest
  never releases an undelivered event's reservation.
- Splice the prepared process into the ready queue via a preallocated
  `PreparedProcess` node so the commit phase enqueues without allocating.
- Add `DeliveryBroker::dispose()`, invoked from the shutdown path, to
  release retained reservations and report undelivered records as
  diagnostics rather than deliveries; guard post-disposal use.

## Tests
- Add reservation fault injection for `create_process()` and
  `duplicate_process()` rollback, a stalled-consumer backpressure and
  ring-wraparound stress test, and a shutdown-disposal accounting test.

PID/TID allocation remains monotonic and non-recycling.