### PR TITLE
[vfs] Real file timestamps for stat/utimensat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,7 @@ version = "0.23.45"
 dependencies = [
  "error",
  "fatfs",
+ "sys",
 ]
 
 [[package]]

--- a/src/libs/fat32/Cargo.toml
+++ b/src/libs/fat32/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["lib"]
 [dependencies]
 error = { workspace = true }
 fatfs = { workspace = true, features = ["alloc", "lfn"] }
+sys = { workspace = true }
 
 [features]
 default = []

--- a/src/libs/fat32/src/fat/filesystem.rs
+++ b/src/libs/fat32/src/fat/filesystem.rs
@@ -19,16 +19,19 @@ use crate::{
             RawMemoryStorage,
             ReadOnlyMemoryStorage,
         },
-        time::NanvixTimeProvider,
+        time::{
+            date_to_unix,
+            datetime_to_unix,
+            unix_to_datetime,
+            NanvixTimeProvider,
+            FAT_EPOCH_SECS,
+        },
         InternalFatFs,
         ReadOnlyInternalFatFs,
     },
 };
 use ::core::fmt;
-use ::fatfs::{
-    Seek,
-    SeekFrom,
-};
+use ::fatfs::Write;
 
 //==================================================================================================
 // Internal Enum
@@ -257,11 +260,58 @@ impl Fat {
         })
     }
 
+    /// Sets access and/or modification times on a file.
+    ///
+    /// `None` leaves that timestamp unchanged (POSIX `UTIME_OMIT`). Times are
+    /// Unix seconds. FAT stores access as a date only, so sub-day access
+    /// precision is dropped. Directory targets are a no-op (fatfs exposes no
+    /// writable directory time entry).
+    ///
+    /// TODO(#3101): `path` should be an `AnchoredPath`, not a bare `&str`.
+    ///
+    /// # Errors
+    ///
+    /// - [`Fat32Error::ReadOnly`] if the mount is read-only.
+    /// - [`Fat32Error::NotFound`] if the path does not exist.
+    pub fn set_times(
+        &self,
+        path: &str,
+        atime: Option<i64>,
+        mtime: Option<i64>,
+    ) -> Result<(), Fat32Error> {
+        if self.is_readonly() {
+            return Err(Fat32Error::ReadOnly);
+        }
+        dispatch_fs!(self, |fs| {
+            let root = fs.root_dir();
+            let mut file = match root.open_file(path) {
+                Ok(file) => file,
+                // Directories have no writable time entry in fatfs; treat as no-op.
+                Err(_) if root.open_dir(path).is_ok() => return Ok(()),
+                Err(e) => return Err(map_fatfs_error(e)),
+            };
+            // The setters are deprecated upstream but are the only write path.
+            #[allow(deprecated)]
+            {
+                if let Some(secs) = mtime {
+                    file.set_modified(unix_to_datetime(secs));
+                }
+                if let Some(secs) = atime {
+                    file.set_accessed(unix_to_datetime(secs).date);
+                }
+            }
+            // Flush the dir entry now so I/O errors surface here, not on drop.
+            Write::flush(&mut file).map_err(map_fatfs_error)?;
+            Ok(())
+        })
+    }
+
     /// Gets file/directory metadata.
     ///
     /// # Parameters
     ///
     /// - `path`: Path relative to the FAT root.
+    ///   TODO(#3101): `path` should be an `AnchoredPath`, not a bare `&str`.
     ///
     /// # Returns
     ///
@@ -274,27 +324,40 @@ impl Fat {
         dispatch_fs!(self, |fs| {
             let root = fs.root_dir();
 
+            // Mount root has no directory entry; report FAT-epoch times.
             if path.is_empty() || path == "/" || path == "." {
                 return Ok(FatStat {
                     size: 0,
                     is_dir: true,
+                    atime: FAT_EPOCH_SECS,
+                    mtime: FAT_EPOCH_SECS,
+                    ctime: FAT_EPOCH_SECS,
                 });
             }
 
-            // Try opening as file first.
-            if let Ok(mut file) = root.open_file(path) {
-                let size: u64 = file.seek(SeekFrom::End(0)).map_err(map_fatfs_error)?;
-                return Ok(FatStat {
-                    size,
-                    is_dir: false,
-                });
-            }
+            // Timestamps live on the directory entry, so scan the parent.
+            let (parent, name) = match path.rsplit_once('/') {
+                Some((parent, name)) => (parent, name),
+                None => ("", path),
+            };
+            let dir = if parent.is_empty() {
+                root
+            } else {
+                root.open_dir(parent).map_err(map_fatfs_error)?
+            };
 
-            // Try opening as directory.
-            if root.open_dir(path).is_ok() {
+            for entry in dir.iter() {
+                let entry = entry.map_err(map_fatfs_error)?;
+                if !entry.file_name().eq_ignore_ascii_case(name) {
+                    continue;
+                }
+                let is_dir: bool = entry.is_dir();
                 return Ok(FatStat {
-                    size: 0,
-                    is_dir: true,
+                    size: if is_dir { 0 } else { entry.len() },
+                    is_dir,
+                    atime: date_to_unix(entry.accessed()),
+                    mtime: datetime_to_unix(entry.modified()),
+                    ctime: datetime_to_unix(entry.created()),
                 });
             }
 
@@ -570,6 +633,12 @@ pub struct FatStat {
     pub size: u64,
     /// True if this is a directory.
     pub is_dir: bool,
+    /// Last access time (Unix seconds). FAT stores this date-only.
+    pub atime: i64,
+    /// Last modification time (Unix seconds).
+    pub mtime: i64,
+    /// Creation time (Unix seconds).
+    pub ctime: i64,
 }
 
 /// Directory entry from a FAT filesystem.
@@ -808,6 +877,43 @@ mod tests {
         let fat: FatHandle = FatHandle::new();
         let result: Result<FatStat, Fat32Error> = fat.stat("nope.txt");
         assert_eq!(result.unwrap_err(), Fat32Error::NotFound);
+    }
+
+    /// Tests that set_times is reflected by a later stat.
+    #[test]
+    fn set_times_roundtrip() {
+        let fat: FatHandle = FatHandle::new();
+        fat.create_new("t.txt", true, true)
+            .expect("create should succeed");
+
+        // 2024-06-15T12:30:00Z.
+        let when: i64 = 1_718_454_600;
+        fat.set_times("t.txt", Some(when), Some(when))
+            .expect("set_times should succeed");
+
+        let info: FatStat = fat.stat("t.txt").expect("stat should succeed");
+        // FAT stores modification at 2s resolution.
+        assert!((info.mtime - when).abs() <= 2, "mtime should round-trip");
+        // FAT stores access as a date only: truncated to midnight.
+        assert_eq!(info.atime, when - when % 86_400, "atime is date-only");
+    }
+
+    /// Tests that set_times omits the field passed as `None`.
+    #[test]
+    fn set_times_omit_leaves_mtime() {
+        let fat: FatHandle = FatHandle::new();
+        fat.create_new("omit.txt", true, true)
+            .expect("create should succeed");
+
+        let base: i64 = 1_718_454_600;
+        fat.set_times("omit.txt", Some(base), Some(base))
+            .expect("set_times should succeed");
+        // Change only atime; mtime must stay put.
+        fat.set_times("omit.txt", Some(base + 86_400), None)
+            .expect("set_times should succeed");
+
+        let info: FatStat = fat.stat("omit.txt").expect("stat should succeed");
+        assert!((info.mtime - base).abs() <= 2, "mtime unchanged");
     }
 
     // -- mkdir / rmdir tests -----------------------------------------------------

--- a/src/libs/fat32/src/fat/filesystem.rs
+++ b/src/libs/fat32/src/fat/filesystem.rs
@@ -22,6 +22,7 @@ use crate::{
         time::{
             date_to_unix,
             datetime_to_unix,
+            is_fat_timestamp,
             unix_to_datetime,
             NanvixTimeProvider,
             FAT_EPOCH_SECS,
@@ -271,6 +272,10 @@ impl Fat {
     ///
     /// # Errors
     ///
+    /// POSIX requires `EINVAL` for timestamps unsupported by the filesystem:
+    /// <https://pubs.opengroup.org/onlinepubs/9799919799/functions/utimensat.html>.
+    ///
+    /// - [`Fat32Error::InvalidArgument`] if a timestamp is outside the FAT range.
     /// - [`Fat32Error::ReadOnly`] if the mount is read-only.
     /// - [`Fat32Error::NotFound`] if the path does not exist.
     pub fn set_times(
@@ -279,6 +284,16 @@ impl Fat {
         atime: Option<i64>,
         mtime: Option<i64>,
     ) -> Result<(), Fat32Error> {
+        if atime.is_none() && mtime.is_none() {
+            return Ok(());
+        }
+        if atime
+            .into_iter()
+            .chain(mtime)
+            .any(|secs| !is_fat_timestamp(secs))
+        {
+            return Err(Fat32Error::InvalidArgument);
+        }
         if self.is_readonly() {
             return Err(Fat32Error::ReadOnly);
         }
@@ -324,8 +339,13 @@ impl Fat {
         dispatch_fs!(self, |fs| {
             let root = fs.root_dir();
 
+            // POSIX pathname resolution requires a trailing slash to name a directory.
+            // https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html#tag_04_16
+            let requires_dir: bool = path.ends_with('/');
+            let path: &str = path.trim_end_matches('/');
+
             // Mount root has no directory entry; report FAT-epoch times.
-            if path.is_empty() || path == "/" || path == "." {
+            if path.is_empty() || path == "." {
                 return Ok(FatStat {
                     size: 0,
                     is_dir: true,
@@ -348,10 +368,15 @@ impl Fat {
 
             for entry in dir.iter() {
                 let entry = entry.map_err(map_fatfs_error)?;
-                if !entry.file_name().eq_ignore_ascii_case(name) {
+                if !entry.file_name().eq_ignore_ascii_case(name)
+                    && !entry.short_file_name().eq_ignore_ascii_case(name)
+                {
                     continue;
                 }
                 let is_dir: bool = entry.is_dir();
+                if requires_dir && !is_dir {
+                    return Err(Fat32Error::NotADirectory);
+                }
                 return Ok(FatStat {
                     size: if is_dir { 0 } else { entry.len() },
                     is_dir,
@@ -879,6 +904,33 @@ mod tests {
         assert_eq!(result.unwrap_err(), Fat32Error::NotFound);
     }
 
+    /// Tests stat with a trailing separator.
+    #[test]
+    fn stat_trailing_separator() {
+        let fat: FatHandle = FatHandle::new();
+        fat.mkdir("subdir").expect("mkdir should succeed");
+        fat.create_new("file.txt", true, true)
+            .expect("create should succeed");
+
+        let info: FatStat = fat.stat("subdir/").expect("stat should succeed");
+        assert!(info.is_dir, "entry should be a directory");
+        assert_eq!(fat.stat("file.txt/").unwrap_err(), Fat32Error::NotADirectory);
+    }
+
+    /// Tests lookup through a long file name's short alias.
+    #[test]
+    fn stat_short_name_alias() {
+        let fat: FatHandle = FatHandle::new();
+        fat.create_new("Long File Name.txt", true, true)
+            .expect("create should succeed");
+
+        let when: i64 = 1_718_454_600;
+        fat.set_times("LONGFI~1.TXT", Some(when), Some(when))
+            .expect("short alias should resolve");
+        fat.stat("LONGFI~1.TXT")
+            .expect("short alias should resolve");
+    }
+
     /// Tests that set_times is reflected by a later stat.
     #[test]
     fn set_times_roundtrip() {
@@ -896,6 +948,20 @@ mod tests {
         assert!((info.mtime - when).abs() <= 2, "mtime should round-trip");
         // FAT stores access as a date only: truncated to midnight.
         assert_eq!(info.atime, when - when % 86_400, "atime is date-only");
+    }
+
+    /// Tests that set_times rejects timestamps outside the FAT range.
+    #[test]
+    fn set_times_rejects_unsupported_timestamp() {
+        let fat: FatHandle = FatHandle::new();
+        fat.create_new("range.txt", true, true)
+            .expect("create should succeed");
+
+        assert_eq!(fat.set_times("range.txt", Some(0), None), Err(Fat32Error::InvalidArgument));
+        assert_eq!(
+            fat.set_times("range.txt", None, Some(4_354_819_200)),
+            Err(Fat32Error::InvalidArgument)
+        );
     }
 
     /// Tests that set_times omits the field passed as `None`.
@@ -1282,6 +1348,14 @@ mod readonly_tests {
     }
 
     // -- Read-only write guards --------------------------------------------------
+
+    /// Tests that omitting both timestamps does not resolve the path.
+    #[test]
+    fn readonly_set_times_omit_succeeds() {
+        let fat: ReadOnlyFatHandle = ReadOnlyFatHandle::new();
+        fat.set_times("missing.txt", None, None)
+            .expect("omitting timestamps should succeed");
+    }
 
     /// Tests that open with write flag returns ReadOnly on a read-only filesystem.
     #[test]

--- a/src/libs/fat32/src/fat/mod.rs
+++ b/src/libs/fat32/src/fat/mod.rs
@@ -6,7 +6,7 @@
 //! This module provides:
 //! - [`RawMemoryStorage`]: Low-level adapter implementing fatfs I/O traits
 //!   over raw memory.
-//! - [`NanvixTimeProvider`]: TimeProvider returning fixed 1980-01-01 timestamp.
+//! - [`NanvixTimeProvider`]: TimeProvider backed by the wall clock.
 //! - [`Fat`]: High-level FAT filesystem wrapper for guest operations.
 //! - [`FatFile`]: File handle for FAT files.
 
@@ -31,6 +31,7 @@ pub use self::{
         RawMemoryStorage,
         ReadOnlyMemoryStorage,
     },
+    time::FAT_EPOCH_SECS,
 };
 
 //==================================================================================================

--- a/src/libs/fat32/src/fat/time.rs
+++ b/src/libs/fat32/src/fat/time.rs
@@ -1,17 +1,48 @@
 // Copyright (c) The Maintainers of Nanvix.
 // Licensed under the MIT license.
 
-//! Time provider for FAT filesystem operations.
+//! Time provider and epoch conversions for FAT filesystem operations.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use ::fatfs::{
+    Date,
+    DateTime,
+    Time,
+    TimeProvider,
+};
+#[cfg(not(feature = "std"))]
+use ::sys::{
+    kcall::pm::__kcall_gettime,
+    time::SystemTime,
+};
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Seconds between the Unix epoch (1970-01-01) and the FAT epoch (1980-01-01).
+pub const FAT_EPOCH_SECS: i64 = 315_532_800;
+
+/// Lowest year representable in a FAT timestamp.
+const MIN_FAT_YEAR: i64 = 1980;
+
+/// Highest year representable in a FAT timestamp.
+const MAX_FAT_YEAR: i64 = 2107;
+
+const SECS_PER_DAY: i64 = 86_400;
 
 //==================================================================================================
 // Structures
 //==================================================================================================
 
-/// A time provider that always returns the FAT epoch (1980-01-01 00:00:00).
+/// A time provider backed by the wall clock.
 ///
-/// Guest VMs have no reliable clock, so a fixed timestamp is used.
-/// The FAT epoch is the earliest representable FAT timestamp and clearly
-/// indicates "timestamp not meaningful."
+/// FAT stamps create/modify/access times from this provider on file I/O. Guest
+/// builds read the real clock via `gettime`; host (`std`) test builds fall back
+/// to the FAT epoch so results stay deterministic.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct NanvixTimeProvider;
 
@@ -19,12 +50,149 @@ pub struct NanvixTimeProvider;
 // Trait Implementations
 //==================================================================================================
 
-impl ::fatfs::TimeProvider for NanvixTimeProvider {
-    fn get_current_date(&self) -> ::fatfs::Date {
-        ::fatfs::Date::new(1980, 1, 1)
+impl TimeProvider for NanvixTimeProvider {
+    fn get_current_date(&self) -> Date {
+        unix_to_datetime(now_secs()).date
     }
 
-    fn get_current_date_time(&self) -> ::fatfs::DateTime {
-        ::fatfs::DateTime::new(::fatfs::Date::new(1980, 1, 1), ::fatfs::Time::new(0, 0, 0, 0))
+    fn get_current_date_time(&self) -> DateTime {
+        unix_to_datetime(now_secs())
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Current wall-clock time in Unix seconds.
+///
+/// Falls back to the FAT epoch when no clock is available.
+#[cfg(not(feature = "std"))]
+fn now_secs() -> i64 {
+    let mut now: SystemTime = SystemTime::default();
+    match __kcall_gettime(&mut now) {
+        Ok(()) => now.seconds() as i64,
+        Err(_) => FAT_EPOCH_SECS,
+    }
+}
+
+/// Host test builds have no kernel clock; use the FAT epoch.
+#[cfg(feature = "std")]
+fn now_secs() -> i64 {
+    FAT_EPOCH_SECS
+}
+
+/// Converts Unix seconds to a FAT `DateTime`, clamped to the FAT year range.
+///
+/// Uses Howard Hinnant's civil-from-days algorithm. Sub-second precision is
+/// dropped (FAT has none).
+pub(crate) fn unix_to_datetime(secs: i64) -> DateTime {
+    let days: i64 = secs.div_euclid(SECS_PER_DAY);
+    let rem: i64 = secs.rem_euclid(SECS_PER_DAY);
+    let (year, month, day) = civil_from_days(days);
+
+    // Clamp to what a FAT date can hold.
+    if year < MIN_FAT_YEAR {
+        return DateTime::new(Date::new(MIN_FAT_YEAR as u16, 1, 1), Time::new(0, 0, 0, 0));
+    }
+    if year > MAX_FAT_YEAR {
+        return DateTime::new(Date::new(MAX_FAT_YEAR as u16, 12, 31), Time::new(23, 59, 58, 0));
+    }
+
+    let hour: u16 = (rem / 3600) as u16;
+    let min: u16 = ((rem % 3600) / 60) as u16;
+    let sec: u16 = (rem % 60) as u16;
+    DateTime::new(Date::new(year as u16, month as u16, day as u16), Time::new(hour, min, sec, 0))
+}
+
+/// Converts a FAT `DateTime` back to Unix seconds.
+pub(crate) fn datetime_to_unix(dt: DateTime) -> i64 {
+    let days: i64 =
+        days_from_civil(i64::from(dt.date.year), i64::from(dt.date.month), i64::from(dt.date.day));
+    days * SECS_PER_DAY
+        + i64::from(dt.time.hour) * 3600
+        + i64::from(dt.time.min) * 60
+        + i64::from(dt.time.sec)
+}
+
+/// Converts a FAT `Date` (no time part) to Unix seconds at midnight.
+pub(crate) fn date_to_unix(date: Date) -> i64 {
+    days_from_civil(i64::from(date.year), i64::from(date.month), i64::from(date.day)) * SECS_PER_DAY
+}
+
+/// Civil (year, month, day) from days since the Unix epoch.
+///
+/// Howard Hinnant, <http://howardhinnant.github.io/date_algorithms.html>.
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    let z: i64 = z + 719_468;
+    let era: i64 = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe: i64 = z - era * 146_097;
+    let yoe: i64 = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let year: i64 = yoe + era * 400;
+    let doy: i64 = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp: i64 = (5 * doy + 2) / 153;
+    let day: i64 = doy - (153 * mp + 2) / 5 + 1;
+    let month: i64 = if mp < 10 { mp + 3 } else { mp - 9 };
+    (year + i64::from(month <= 2), month, day)
+}
+
+/// Days since the Unix epoch from a civil (year, month, day).
+///
+/// Howard Hinnant, <http://howardhinnant.github.io/date_algorithms.html>.
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year: i64 = year - i64::from(month <= 2);
+    let era: i64 = if year >= 0 { year } else { year - 399 } / 400;
+    let yoe: i64 = year - era * 400;
+    let doy: i64 = (153 * (if month > 2 { month - 3 } else { month + 9 }) + 2) / 5 + day - 1;
+    let doe: i64 = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+//==================================================================================================
+// Unit Tests
+//==================================================================================================
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    /// Round-trips a known timestamp through DateTime and back.
+    #[test]
+    fn unix_datetime_roundtrip() {
+        // 2024-01-01T00:00:00Z.
+        let secs: i64 = 1_704_067_200;
+        let dt: DateTime = unix_to_datetime(secs);
+        assert_eq!(dt.date.year, 2024, "year");
+        assert_eq!(dt.date.month, 1, "month");
+        assert_eq!(dt.date.day, 1, "day");
+        assert_eq!(datetime_to_unix(dt), secs, "roundtrip");
+    }
+
+    /// Time-of-day survives the conversion.
+    #[test]
+    fn unix_datetime_time_of_day() {
+        // 2026-08-11T21:02:05Z.
+        let secs: i64 = 1_786_568_525;
+        let dt: DateTime = unix_to_datetime(secs);
+        assert_eq!(dt.time.hour, 21, "hour");
+        assert_eq!(dt.time.min, 2, "min");
+        // FAT stores modification seconds at 2s resolution; readback tolerates it.
+        assert!((datetime_to_unix(dt) - secs).abs() <= 2, "within 2s");
+    }
+
+    /// Pre-1980 timestamps clamp to the FAT epoch.
+    #[test]
+    fn unix_datetime_clamps_low() {
+        let dt: DateTime = unix_to_datetime(0);
+        assert_eq!(dt.date.year, 1980, "clamped to min FAT year");
+    }
+
+    /// FAT epoch constant matches 1980-01-01.
+    #[test]
+    fn fat_epoch_constant() {
+        let dt: DateTime = unix_to_datetime(FAT_EPOCH_SECS);
+        assert_eq!(dt.date.year, 1980, "year");
+        assert_eq!(dt.date.month, 1, "month");
+        assert_eq!(dt.date.day, 1, "day");
     }
 }

--- a/src/libs/fat32/src/fat/time.rs
+++ b/src/libs/fat32/src/fat/time.rs
@@ -32,6 +32,9 @@ const MIN_FAT_YEAR: i64 = 1980;
 /// Highest year representable in a FAT timestamp.
 const MAX_FAT_YEAR: i64 = 2107;
 
+/// Last Unix second representable by FAT (2107-12-31T23:59:59Z).
+const MAX_FAT_TIMESTAMP: i64 = 4_354_819_199;
+
 const SECS_PER_DAY: i64 = 86_400;
 
 //==================================================================================================
@@ -80,6 +83,11 @@ fn now_secs() -> i64 {
 #[cfg(feature = "std")]
 fn now_secs() -> i64 {
     FAT_EPOCH_SECS
+}
+
+/// Returns whether Unix seconds can be represented by FAT.
+pub(crate) fn is_fat_timestamp(secs: i64) -> bool {
+    (FAT_EPOCH_SECS..=MAX_FAT_TIMESTAMP).contains(&secs)
 }
 
 /// Converts Unix seconds to a FAT `DateTime`, clamped to the FAT year range.

--- a/src/libs/fat32/src/lib.rs
+++ b/src/libs/fat32/src/lib.rs
@@ -37,5 +37,6 @@ pub use crate::{
         FatFile,
         RawMemoryStorage,
         ReadOnlyMemoryStorage,
+        FAT_EPOCH_SECS,
     },
 };

--- a/src/libs/vfs/src/descriptor/vfs_stat.rs
+++ b/src/libs/vfs/src/descriptor/vfs_stat.rs
@@ -42,26 +42,31 @@ impl VfsStat {
     }
 
     /// Returns the file size in bytes.
+    #[must_use]
     pub fn size(&self) -> u64 {
         self.size
     }
 
     /// Returns whether this entry is a directory.
+    #[must_use]
     pub fn is_dir(&self) -> bool {
         self.is_dir
     }
 
     /// Returns the last access time (Unix seconds).
+    #[must_use]
     pub fn atime(&self) -> i64 {
         self.atime
     }
 
     /// Returns the last modification time (Unix seconds).
+    #[must_use]
     pub fn mtime(&self) -> i64 {
         self.mtime
     }
 
     /// Returns the creation time (Unix seconds).
+    #[must_use]
     pub fn ctime(&self) -> i64 {
         self.ctime
     }

--- a/src/libs/vfs/src/descriptor/vfs_stat.rs
+++ b/src/libs/vfs/src/descriptor/vfs_stat.rs
@@ -17,6 +17,12 @@ pub struct VfsStat {
     size: u64,
     /// Whether this entry is a directory.
     is_dir: bool,
+    /// Last access time (Unix seconds).
+    atime: i64,
+    /// Last modification time (Unix seconds).
+    mtime: i64,
+    /// Creation time (Unix seconds).
+    ctime: i64,
 }
 
 //==================================================================================================
@@ -25,8 +31,14 @@ pub struct VfsStat {
 
 impl VfsStat {
     /// Creates a new `VfsStat`.
-    pub fn new(size: u64, is_dir: bool) -> Self {
-        Self { size, is_dir }
+    pub fn new(size: u64, is_dir: bool, atime: i64, mtime: i64, ctime: i64) -> Self {
+        Self {
+            size,
+            is_dir,
+            atime,
+            mtime,
+            ctime,
+        }
     }
 
     /// Returns the file size in bytes.
@@ -37,5 +49,20 @@ impl VfsStat {
     /// Returns whether this entry is a directory.
     pub fn is_dir(&self) -> bool {
         self.is_dir
+    }
+
+    /// Returns the last access time (Unix seconds).
+    pub fn atime(&self) -> i64 {
+        self.atime
+    }
+
+    /// Returns the last modification time (Unix seconds).
+    pub fn mtime(&self) -> i64 {
+        self.mtime
+    }
+
+    /// Returns the creation time (Unix seconds).
+    pub fn ctime(&self) -> i64 {
+        self.ctime
     }
 }

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -124,6 +124,9 @@ const STAT_BLOCK_SIZE: i64 = 4096;
 /// Sector size used for `st_blocks` computation (POSIX convention: 512 bytes).
 const STAT_SECTOR_SIZE: u64 = 512;
 
+/// Last Unix second representable by FAT (2107-12-31T23:59:59Z).
+const MAX_FAT_TIMESTAMP: i64 = 4_354_819_199;
+
 /// Default file mode creation mask.
 const DEFAULT_FILE_CREATION_MASK: mode_t = 0;
 
@@ -2144,6 +2147,9 @@ pub fn vfs_fchownat(
 
 /// Sets file access and modification times through the VFS.
 ///
+/// POSIX timestamp rules:
+/// <https://pubs.opengroup.org/onlinepubs/9799919799/functions/utimensat.html>.
+///
 /// Resolves `UTIME_NOW` against the wall clock and honors `UTIME_OMIT`, then
 /// applies the result to the backing file. FAT stores access as a date only, so
 /// sub-day access precision is dropped.
@@ -2157,7 +2163,8 @@ pub fn vfs_fchownat(
 ///
 /// # Errors
 ///
-/// Returns [`Fat32Error::InvalidArgument`] if the path cannot be resolved.
+/// Returns [`Fat32Error::InvalidArgument`] if the path cannot be resolved or a
+/// timestamp has an invalid nanosecond value or is outside the FAT range.
 /// Returns [`Fat32Error::FileNotFound`] if the resolved path does not exist.
 pub fn vfs_utimensat(
     dirfd: c_int,
@@ -2169,22 +2176,29 @@ pub fn vfs_utimensat(
     if flags != 0 {
         return Err(Fat32Error::InvalidArgument);
     }
+    // POSIX requires no ownership or permission checks when both fields are omitted.
+    if times.iter().all(|ts| ts.tv_nsec == UTIME_OMIT) {
+        return Ok(());
+    }
     let resolved = vfs_resolve_path(dirfd, pathname)?;
 
     // POSIX permission check (owner / write access / privilege) is not enforced:
     // Nanvix is single-user so it always passes. Tracked for the multiuser model.
 
-    // Resolve a single request field to concrete seconds, or `None` to omit.
-    let resolve = |ts: &timespec, now: i64| -> Option<i64> {
+    // POSIX rejects non-special nanoseconds outside [0, 1000 million).
+    let resolve = |ts: &timespec, now: i64| -> Result<Option<i64>, Fat32Error> {
         match ts.tv_nsec {
-            n if n == UTIME_OMIT => None,
-            n if n == UTIME_NOW => Some(now),
-            _ => Some(ts.tv_sec),
+            n if n == UTIME_OMIT => Ok(None),
+            n if n == UTIME_NOW => Ok(Some(now)),
+            0..1_000_000_000 if (FAT_EPOCH_SECS..=MAX_FAT_TIMESTAMP).contains(&ts.tv_sec) => {
+                Ok(Some(ts.tv_sec))
+            },
+            _ => Err(Fat32Error::InvalidArgument),
         }
     };
     let now: i64 = wall_clock_secs();
-    let atime: Option<i64> = resolve(&times[0], now);
-    let mtime: Option<i64> = resolve(&times[1], now);
+    let atime: Option<i64> = resolve(&times[0], now)?;
+    let mtime: Option<i64> = resolve(&times[1], now)?;
 
     filesystem::set_times(&current_cwd(), resolved.as_str(), atime, mtime)
 }

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -63,9 +63,17 @@ use ::alloc::{
     vec::Vec,
 };
 use ::core::sync::atomic::Ordering;
-use ::fat32::Fat32Error;
+use ::fat32::{
+    Fat32Error,
+    FAT_EPOCH_SECS,
+};
 use ::spin::Mutex;
 use ::sys::pm::ProcessIdentifier;
+#[cfg(not(feature = "std"))]
+use ::sys::{
+    kcall::pm::__kcall_gettime,
+    time::SystemTime,
+};
 use ::sysapi::{
     fcntl::{
         file_control_request,
@@ -86,6 +94,8 @@ use ::sysapi::{
     sys_stat::{
         file_mode,
         file_type,
+        UTIME_NOW,
+        UTIME_OMIT,
     },
     sys_types::{
         c_size_t,
@@ -1101,14 +1111,20 @@ pub fn vfs_lseek(fd: c_int, offset: off_t, whence: c_int) -> Result<off_t, Fat32
 
 /// Populates common stat fields for VFS entries.
 ///
-/// FAT32 lacks Unix metadata so we use sensible defaults:
+/// FAT32 lacks Unix ownership metadata so we use sensible defaults:
 /// - `st_nlink = 1` (single link).
-/// - Timestamps set to a fixed epoch value (FAT has no sub-second precision).
 /// - Permissions: owner read+write for files, owner rwx for directories.
-fn populate_stat_fields(buf: &mut ::sysapi::sys_stat::stat, size: u64, is_dir: bool) {
-    // Fixed epoch timestamp: 2024-01-01T00:00:00Z (1704067200).
-    const FIXED_EPOCH: i64 = 1_704_067_200;
-
+///
+/// Timestamps (`atime`/`mtime`/`ctime`, Unix seconds) come from the backing
+/// directory entry.
+fn populate_stat_fields(
+    buf: &mut ::sysapi::sys_stat::stat,
+    size: u64,
+    is_dir: bool,
+    atime: i64,
+    mtime: i64,
+    ctime: i64,
+) {
     buf.st_size = size as off_t;
     buf.st_nlink = if is_dir { 2 } else { 1 };
     buf.st_dev = 1; // Synthetic device ID for the VFS.
@@ -1121,15 +1137,15 @@ fn populate_stat_fields(buf: &mut ::sysapi::sys_stat::stat, size: u64, is_dir: b
     buf.st_blksize = STAT_BLOCK_SIZE;
     buf.st_blocks = size.div_ceil(STAT_SECTOR_SIZE) as off_t;
     buf.st_atim = timespec {
-        tv_sec: FIXED_EPOCH,
+        tv_sec: atime,
         tv_nsec: 0,
     };
     buf.st_mtim = timespec {
-        tv_sec: FIXED_EPOCH,
+        tv_sec: mtime,
         tv_nsec: 0,
     };
     buf.st_ctim = timespec {
-        tv_sec: FIXED_EPOCH,
+        tv_sec: ctime,
         tv_nsec: 0,
     };
 }
@@ -1230,7 +1246,12 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
     } else if let Some(pipe_id) = pipe_id {
         populate_pipe_stat_fields(buf, pipe_id);
     } else {
-        populate_stat_fields(buf, size, is_dir);
+        // fatfs exposes time getters only on a directory entry (reached by scanning
+        // the parent), never on an open `File`, and an open handle keeps no path.
+        // We are not patching upstream fatfs (slated for replacement), so an open fd
+        // reports the FAT epoch; path-based stat (`vfs_stat`) carries the real times.
+        // Known POSIX divergence, tracked for the fatfs replacement.
+        populate_stat_fields(buf, size, is_dir, FAT_EPOCH_SECS, FAT_EPOCH_SECS, FAT_EPOCH_SECS);
     }
 
     Ok(())
@@ -1382,7 +1403,14 @@ pub fn vfs_stat(path: &str, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
         ::core::ptr::write_bytes(buf as *mut ::sysapi::sys_stat::stat, 0, 1);
     }
 
-    populate_stat_fields(buf, info.size(), info.is_dir());
+    populate_stat_fields(
+        buf,
+        info.size(),
+        info.is_dir(),
+        info.atime(),
+        info.mtime(),
+        info.ctime(),
+    );
 
     Ok(())
 }
@@ -2116,15 +2144,15 @@ pub fn vfs_fchownat(
 
 /// Sets file access and modification times through the VFS.
 ///
-/// FAT32 does not support fine-grained POSIX timestamps. This function
-/// validates its arguments and returns success without modifying any
-/// timestamps.
+/// Resolves `UTIME_NOW` against the wall clock and honors `UTIME_OMIT`, then
+/// applies the result to the backing file. FAT stores access as a date only, so
+/// sub-day access precision is dropped.
 ///
 /// # Parameters
 ///
 /// - `dirfd`: Directory file descriptor for relative path resolution.
 /// - `pathname`: Path to the target file.
-/// - `_times`: Access and modification times (ignored on FAT32).
+/// - `times`: Access (`[0]`) and modification (`[1]`) times.
 /// - `flags`: Flags (must be zero; unsupported flags are rejected).
 ///
 /// # Errors
@@ -2134,7 +2162,7 @@ pub fn vfs_fchownat(
 pub fn vfs_utimensat(
     dirfd: c_int,
     pathname: &str,
-    _times: &[timespec; 2],
+    times: &[timespec; 2],
     flags: c_int,
 ) -> Result<(), Fat32Error> {
     // Reject unsupported flags since FAT32 does not handle them.
@@ -2142,13 +2170,39 @@ pub fn vfs_utimensat(
         return Err(Fat32Error::InvalidArgument);
     }
     let resolved = vfs_resolve_path(dirfd, pathname)?;
-    // POSIX TODO: NULL/UTIME_NOW times need write access, owner match, or privilege.
-    // See https://pubs.opengroup.org/onlinepubs/9799919799/functions/utimensat.html
-    // Nanvix is single-user, so owner and privilege always hold — the check
-    // reduces to writability. Enforce via check_writable when timestamp
-    // persistence lands.
-    // Verify that the target exists using the VFS-level stat for consistent semantics.
-    filesystem::stat(&current_cwd(), resolved.as_str()).map(|_| ())
+
+    // POSIX permission check (owner / write access / privilege) is not enforced:
+    // Nanvix is single-user so it always passes. Tracked for the multiuser model.
+
+    // Resolve a single request field to concrete seconds, or `None` to omit.
+    let resolve = |ts: &timespec, now: i64| -> Option<i64> {
+        match ts.tv_nsec {
+            n if n == UTIME_OMIT => None,
+            n if n == UTIME_NOW => Some(now),
+            _ => Some(ts.tv_sec),
+        }
+    };
+    let now: i64 = wall_clock_secs();
+    let atime: Option<i64> = resolve(&times[0], now);
+    let mtime: Option<i64> = resolve(&times[1], now);
+
+    filesystem::set_times(&current_cwd(), resolved.as_str(), atime, mtime)
+}
+
+/// Current wall-clock time in Unix seconds, falling back to the FAT epoch.
+#[cfg(not(feature = "std"))]
+fn wall_clock_secs() -> i64 {
+    let mut now: SystemTime = SystemTime::default();
+    match __kcall_gettime(&mut now) {
+        Ok(()) => now.seconds() as i64,
+        Err(_) => FAT_EPOCH_SECS,
+    }
+}
+
+/// Host test builds have no kernel clock; use the FAT epoch.
+#[cfg(feature = "std")]
+fn wall_clock_secs() -> i64 {
+    FAT_EPOCH_SECS
 }
 
 //==================================================================================================
@@ -2170,7 +2224,7 @@ mod tests {
     /// Tests VfsStat construction and accessors for a file.
     #[test]
     fn vfs_stat_file() {
-        let s: VfsStat = VfsStat::new(1024, false);
+        let s: VfsStat = VfsStat::new(1024, false, 0, 0, 0);
         assert_eq!(s.size(), 1024, "file size should be 1024");
         assert!(!s.is_dir(), "should not be a directory");
     }
@@ -2178,7 +2232,7 @@ mod tests {
     /// Tests VfsStat construction and accessors for a directory.
     #[test]
     fn vfs_stat_directory() {
-        let s: VfsStat = VfsStat::new(0, true);
+        let s: VfsStat = VfsStat::new(0, true, 0, 0, 0);
         assert_eq!(s.size(), 0, "directory size should be 0");
         assert!(s.is_dir(), "should be a directory");
     }

--- a/src/libs/vfs/src/fd/open.rs
+++ b/src/libs/vfs/src/fd/open.rs
@@ -66,7 +66,13 @@ pub fn exists(cwd: &str, path: &str) -> bool {
 /// [`VfsStat`] on success, or a [`Fat32Error`] on error.
 pub fn stat(cwd: &str, path: &str) -> Result<VfsStat, Fat32Error> {
     let info: filesystem::Stat = filesystem::stat(cwd, path)?;
-    Ok(VfsStat::new(info.size(), info.is_dir()))
+    Ok(VfsStat::new(
+        info.size(),
+        info.is_dir(),
+        info.atime(),
+        info.mtime(),
+        info.ctime(),
+    ))
 }
 
 //==================================================================================================

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -37,6 +37,7 @@ use ::alloc::{
 use ::fat32::{
     Fat32Error,
     FatFile,
+    FAT_EPOCH_SECS,
 };
 
 //==================================================================================================
@@ -105,13 +106,48 @@ pub(crate) fn stat(cwd: &str, path: &str) -> Result<Stat, Fat32Error> {
 
     // Handle root of mount specially.
     if relative_path.is_empty() {
-        return Ok(Stat::new(0, true));
+        return Ok(Stat::new(0, true, FAT_EPOCH_SECS, FAT_EPOCH_SECS, FAT_EPOCH_SECS));
     }
 
     state::with_vfs(|vfs| {
         let mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
         let fat_stat = mount.fat().stat(&relative_path)?;
-        Ok(Stat::new(fat_stat.size, fat_stat.is_dir))
+        Ok(Stat::new(
+            fat_stat.size,
+            fat_stat.is_dir,
+            fat_stat.atime,
+            fat_stat.mtime,
+            fat_stat.ctime,
+        ))
+    })
+}
+
+/// Sets access and/or modification times on a path.
+///
+/// `None` leaves that timestamp unchanged (POSIX `UTIME_OMIT`).
+///
+/// # Errors
+///
+/// - [`Fat32Error::NotFound`] if the path doesn't exist.
+/// - [`Fat32Error::ReadOnly`] if the mount is read-only.
+pub(crate) fn set_times(
+    cwd: &str,
+    path: &str,
+    atime: Option<i64>,
+    mtime: Option<i64>,
+) -> Result<(), Fat32Error> {
+    let (mount_idx, relative_path) = resolve_path(cwd, path)?;
+
+    // Mount root has no writable time entry; nothing to do.
+    if relative_path.is_empty() {
+        return Ok(());
+    }
+
+    check_writable(mount_idx)?;
+
+    state::with_vfs(|vfs| {
+        let mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
+        mount.fat().set_times(&relative_path, atime, mtime)
     })
 }
 

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -102,6 +102,7 @@ pub(crate) fn file_raw_region(cwd: &str, path: &str) -> Option<(*const u8, usize
 /// - [`Fat32Error::NotInitialized`] if the filesystem hasn't been initialized.
 /// - [`Fat32Error::NotFound`] if the path doesn't exist.
 pub(crate) fn stat(cwd: &str, path: &str) -> Result<Stat, Fat32Error> {
+    let requires_dir: bool = path.ends_with('/');
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;
 
     // Handle root of mount specially.
@@ -112,6 +113,10 @@ pub(crate) fn stat(cwd: &str, path: &str) -> Result<Stat, Fat32Error> {
     state::with_vfs(|vfs| {
         let mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
         let fat_stat = mount.fat().stat(&relative_path)?;
+        // POSIX treats a trailing slash as a directory requirement.
+        if requires_dir && !fat_stat.is_dir {
+            return Err(Fat32Error::NotADirectory);
+        }
         Ok(Stat::new(
             fat_stat.size,
             fat_stat.is_dir,
@@ -136,6 +141,15 @@ pub(crate) fn set_times(
     atime: Option<i64>,
     mtime: Option<i64>,
 ) -> Result<(), Fat32Error> {
+    if atime.is_none() && mtime.is_none() {
+        return Ok(());
+    }
+
+    // Normalization drops trailing slashes, so enforce the directory requirement first.
+    if path.ends_with('/') {
+        stat(cwd, path)?;
+    }
+
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;
 
     // Mount root has no writable time entry; nothing to do.

--- a/src/libs/vfs/src/filesystem/stat.rs
+++ b/src/libs/vfs/src/filesystem/stat.rs
@@ -14,6 +14,12 @@ pub struct Stat {
     size: u64,
     /// Whether this is a directory.
     is_dir: bool,
+    /// Last access time (Unix seconds).
+    atime: i64,
+    /// Last modification time (Unix seconds).
+    mtime: i64,
+    /// Creation time (Unix seconds).
+    ctime: i64,
 }
 
 //==================================================================================================
@@ -27,8 +33,17 @@ impl Stat {
     ///
     /// - `size`: File size in bytes (0 for directories).
     /// - `is_dir`: Whether this entry is a directory.
-    pub fn new(size: u64, is_dir: bool) -> Self {
-        Self { size, is_dir }
+    /// - `atime`: Last access time (Unix seconds).
+    /// - `mtime`: Last modification time (Unix seconds).
+    /// - `ctime`: Creation time (Unix seconds).
+    pub fn new(size: u64, is_dir: bool, atime: i64, mtime: i64, ctime: i64) -> Self {
+        Self {
+            size,
+            is_dir,
+            atime,
+            mtime,
+            ctime,
+        }
     }
 
     /// Returns the file size in bytes (0 for directories).
@@ -41,6 +56,24 @@ impl Stat {
     #[must_use]
     pub fn is_dir(&self) -> bool {
         self.is_dir
+    }
+
+    /// Returns the last access time (Unix seconds).
+    #[must_use]
+    pub fn atime(&self) -> i64 {
+        self.atime
+    }
+
+    /// Returns the last modification time (Unix seconds).
+    #[must_use]
+    pub fn mtime(&self) -> i64 {
+        self.mtime
+    }
+
+    /// Returns the creation time (Unix seconds).
+    #[must_use]
+    pub fn ctime(&self) -> i64 {
+        self.ctime
     }
 }
 
@@ -55,11 +88,11 @@ mod tests {
     /// Tests Stat equality and debug.
     #[test]
     fn stat_clone_eq_debug() {
-        let stat: Stat = Stat::new(42, false);
+        let stat: Stat = Stat::new(42, false, 0, 0, 0);
         let cloned: Stat = stat;
         assert_eq!(stat, cloned, "clone should preserve equality");
 
-        let other: Stat = Stat::new(0, true);
+        let other: Stat = Stat::new(0, true, 0, 0, 0);
         assert_ne!(stat, other, "different stats should not be equal");
 
         assert_eq!(stat.size(), 42, "size accessor should return 42");

--- a/src/tests/integration/test-rust-vfs-test/src/main.rs
+++ b/src/tests/integration/test-rust-vfs-test/src/main.rs
@@ -49,6 +49,8 @@ use ::sysapi::{
     sys_stat::{
         file_type,
         stat,
+        UTIME_NOW,
+        UTIME_OMIT,
     },
     time::timespec,
 };
@@ -761,8 +763,123 @@ fn test_stat_timestamps() -> Result<(), Error> {
         return Err(Error::new(ErrorCode::InvalidArgument, "stat st_mtim should round-trip"));
     }
     // FAT stores access as a date only, truncated to midnight.
-    if st.st_atim.tv_sec != when - when % 86_400 {
+    let initial_atime: i64 = when - when % 86_400;
+    if st.st_atim.tv_sec != initial_atime {
         return Err(Error::new(ErrorCode::InvalidArgument, "stat st_atim should be date-only"));
+    }
+
+    // Omit access time while changing modification time.
+    let later: i64 = when + 86_400;
+    let omit_access: [timespec; 2] = [
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_OMIT,
+        },
+        timespec {
+            tv_sec: later,
+            tv_nsec: 999_999_999,
+        },
+    ];
+    vfs::fd::vfs_utimensat(0, "/sts/ts.txt", &omit_access, 0)
+        .map_err(|e| fat_err(e, "utimensat omit access"))?;
+    vfs::fd::vfs_stat("/sts/ts.txt", &mut st).map_err(|e| fat_err(e, "stat after omit"))?;
+    if st.st_atim.tv_sec != initial_atime || (st.st_mtim.tv_sec - later).abs() > 2 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "UTIME_OMIT should preserve access"));
+    }
+
+    // Omitting both fields succeeds without resolving the path.
+    let omitted: [timespec; 2] = [
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_OMIT,
+        },
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_OMIT,
+        },
+    ];
+    vfs::fd::vfs_utimensat(0, "/sts/ts.txt", &omitted, 0)
+        .map_err(|e| fat_err(e, "utimensat omit both"))?;
+    vfs::fd::vfs_utimensat(0, "/sts/missing.txt", &omitted, 0)
+        .map_err(|e| fat_err(e, "utimensat omit missing"))?;
+    let mut unchanged: stat = unsafe { core::mem::zeroed() };
+    vfs::fd::vfs_stat("/sts/ts.txt", &mut unchanged)
+        .map_err(|e| fat_err(e, "stat after omit both"))?;
+    if unchanged.st_atim.tv_sec != st.st_atim.tv_sec
+        || unchanged.st_mtim.tv_sec != st.st_mtim.tv_sec
+    {
+        return Err(Error::new(ErrorCode::InvalidArgument, "omitting both should change nothing"));
+    }
+
+    // A trailing slash requires a directory through each public path API.
+    if vfs::fd::vfs_stat("/sts/ts.txt/", &mut unchanged) != Err(vfs::Fat32Error::NotADirectory) {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "stat accepted file with trailing slash",
+        ));
+    }
+    let dir_fd: i32 = vfs::fd::vfs_open("/sts", file_creation_flags::O_DIRECTORY)
+        .map_err(|e| fat_err(e, "open timestamp directory"))?;
+    let fstatat_result: Result<(), vfs::Fat32Error> =
+        vfs::fd::vfs_fstatat(dir_fd, "ts.txt/", &mut unchanged);
+    vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close timestamp directory"))?;
+    if fstatat_result != Err(vfs::Fat32Error::NotADirectory) {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "fstatat accepted file with trailing slash",
+        ));
+    }
+    if vfs::fd::vfs_utimensat(0, "/sts/ts.txt/", &times, 0) != Err(vfs::Fat32Error::NotADirectory) {
+        return Err(Error::new(
+            ErrorCode::InvalidArgument,
+            "utimensat accepted file with trailing slash",
+        ));
+    }
+
+    // UTIME_NOW ignores tv_sec and uses the current clock.
+    let now: [timespec; 2] = [
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_NOW,
+        },
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_NOW,
+        },
+    ];
+    vfs::fd::vfs_utimensat(0, "/sts/ts.txt", &now, 0).map_err(|e| fat_err(e, "utimensat now"))?;
+    vfs::fd::vfs_stat("/sts/ts.txt", &mut st).map_err(|e| fat_err(e, "stat after now"))?;
+    if st.st_atim.tv_sec < FAT_EPOCH_FALLBACK || st.st_mtim.tv_sec < FAT_EPOCH_FALLBACK {
+        return Err(Error::new(ErrorCode::InvalidArgument, "UTIME_NOW should use the clock"));
+    }
+
+    // Invalid nanoseconds and unsupported FAT seconds are rejected.
+    for invalid in [
+        timespec {
+            tv_sec: when,
+            tv_nsec: -1,
+        },
+        timespec {
+            tv_sec: when,
+            tv_nsec: 1_000_000_000,
+        },
+        timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        },
+        timespec {
+            tv_sec: 4_354_819_200,
+            tv_nsec: 0,
+        },
+    ] {
+        let invalid_times: [timespec; 2] = [invalid, omitted[1]];
+        if vfs::fd::vfs_utimensat(0, "/sts/ts.txt", &invalid_times, 0)
+            != Err(vfs::Fat32Error::InvalidArgument)
+            || vfs::fd::vfs_utimensat(0, "/sts", &invalid_times, 0)
+                != Err(vfs::Fat32Error::InvalidArgument)
+        {
+            return Err(Error::new(ErrorCode::InvalidArgument, "invalid timestamp accepted"));
+        }
     }
 
     // Clean up.
@@ -1261,11 +1378,11 @@ fn test_utimensat() -> Result<(), Error> {
 
     let times: [timespec; 2] = [
         timespec {
-            tv_sec: 1_000_000,
+            tv_sec: 1_718_454_600,
             tv_nsec: 0,
         },
         timespec {
-            tv_sec: 2_000_000,
+            tv_sec: 1_718_454_600,
             tv_nsec: 0,
         },
     ];

--- a/src/tests/integration/test-rust-vfs-test/src/main.rs
+++ b/src/tests/integration/test-rust-vfs-test/src/main.rs
@@ -61,8 +61,9 @@ use ::vfs::path::vfs_resolve_path;
 /// Encoded 8-byte "RAMFS   " tag exposed by the MicroVM RAMFS MMIO region.
 const RAMFS_MMIO_TAG: u64 = u64::from_be_bytes(*b"RAMFS   ");
 
-/// Fixed timestamp epoch (2024-01-01T00:00:00 UTC) used by the VFS stat layer.
-const VFS_FIXED_TIMESTAMP: i64 = 1704067200;
+/// FAT epoch (1980-01-01) reported by `fstat`, which cannot reach the backing
+/// directory entry from an open handle.
+const FAT_EPOCH_FALLBACK: i64 = 315_532_800;
 
 //==================================================================================================
 // Helpers
@@ -648,8 +649,8 @@ fn test_getdents() -> Result<(), Error> {
 // Test: Fstat Directory Mode and Timestamps
 //==================================================================================================
 
-/// Tests that `vfs_fstat()` returns `S_IFDIR` for directory handles and sets
-/// the fixed 2024-01-01 timestamps.
+/// Tests that `vfs_fstat()` returns `S_IFDIR` for directory handles and reports
+/// the FAT-epoch fallback (an open handle cannot reach its directory entry).
 fn test_fstat_directory_and_timestamps() -> Result<(), Error> {
     ::syslog::info!("vfs-test: test_fstat_directory_and_timestamps begin");
 
@@ -676,12 +677,12 @@ fn test_fstat_directory_and_timestamps() -> Result<(), Error> {
     if st.st_mode & file_type::S_IFMT != file_type::S_IFREG {
         return Err(Error::new(ErrorCode::InvalidArgument, "file should be S_IFREG"));
     }
-    // Verify fixed timestamp.
-    if st.st_atim.tv_sec != VFS_FIXED_TIMESTAMP
-        || st.st_mtim.tv_sec != VFS_FIXED_TIMESTAMP
-        || st.st_ctim.tv_sec != VFS_FIXED_TIMESTAMP
+    // fstat cannot reach the directory entry, so it reports the FAT epoch.
+    if st.st_atim.tv_sec != FAT_EPOCH_FALLBACK
+        || st.st_mtim.tv_sec != FAT_EPOCH_FALLBACK
+        || st.st_ctim.tv_sec != FAT_EPOCH_FALLBACK
     {
-        return Err(Error::new(ErrorCode::InvalidArgument, "file timestamps should be 2024-01-01"));
+        return Err(Error::new(ErrorCode::InvalidArgument, "file fstat should report FAT epoch"));
     }
     vfs::fd::vfs_close(file_fd).map_err(|e| fat_err(e, "close file fd"))?;
 
@@ -697,11 +698,11 @@ fn test_fstat_directory_and_timestamps() -> Result<(), Error> {
     if dst.st_size != 0 {
         return Err(Error::new(ErrorCode::InvalidArgument, "dir size should be 0"));
     }
-    if dst.st_atim.tv_sec != VFS_FIXED_TIMESTAMP
-        || dst.st_mtim.tv_sec != VFS_FIXED_TIMESTAMP
-        || dst.st_ctim.tv_sec != VFS_FIXED_TIMESTAMP
+    if dst.st_atim.tv_sec != FAT_EPOCH_FALLBACK
+        || dst.st_mtim.tv_sec != FAT_EPOCH_FALLBACK
+        || dst.st_ctim.tv_sec != FAT_EPOCH_FALLBACK
     {
-        return Err(Error::new(ErrorCode::InvalidArgument, "dir timestamps should be 2024-01-01"));
+        return Err(Error::new(ErrorCode::InvalidArgument, "dir fstat should report FAT epoch"));
     }
     vfs::fd::vfs_close(dir_fd).map_err(|e| fat_err(e, "close dir fd"))?;
 
@@ -717,7 +718,8 @@ fn test_fstat_directory_and_timestamps() -> Result<(), Error> {
 // Test: Stat Timestamps
 //==================================================================================================
 
-/// Tests that `vfs_stat()` sets the fixed 2024-01-01 timestamps.
+/// Tests that a time set via `vfs_utimensat()` is reported by a later
+/// `vfs_stat()`.
 fn test_stat_timestamps() -> Result<(), Error> {
     ::syslog::info!("vfs-test: test_stat_timestamps begin");
 
@@ -735,18 +737,32 @@ fn test_stat_timestamps() -> Result<(), Error> {
         file.flush().map_err(|e| fat_err(e, "flush ts.txt"))?;
     }
 
-    // Stat the file via path.
+    // Set a known time, then read it back via path stat.
+    // 2024-06-15T12:30:00Z.
+    let when: i64 = 1_718_454_600;
+    let times: [timespec; 2] = [
+        timespec {
+            tv_sec: when,
+            tv_nsec: 0,
+        },
+        timespec {
+            tv_sec: when,
+            tv_nsec: 0,
+        },
+    ];
+    vfs::fd::vfs_utimensat(0, "/sts/ts.txt", &times, 0)
+        .map_err(|e| fat_err(e, "utimensat ts.txt"))?;
+
     let mut st: stat = unsafe { core::mem::zeroed() };
     vfs::fd::vfs_stat("/sts/ts.txt", &mut st).map_err(|e| fat_err(e, "vfs_stat ts.txt"))?;
 
-    if st.st_atim.tv_sec != VFS_FIXED_TIMESTAMP {
-        return Err(Error::new(ErrorCode::InvalidArgument, "stat st_atim should be 2024-01-01"));
+    // FAT stores modification at 2s resolution.
+    if (st.st_mtim.tv_sec - when).abs() > 2 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "stat st_mtim should round-trip"));
     }
-    if st.st_mtim.tv_sec != VFS_FIXED_TIMESTAMP {
-        return Err(Error::new(ErrorCode::InvalidArgument, "stat st_mtim should be 2024-01-01"));
-    }
-    if st.st_ctim.tv_sec != VFS_FIXED_TIMESTAMP {
-        return Err(Error::new(ErrorCode::InvalidArgument, "stat st_ctim should be 2024-01-01"));
+    // FAT stores access as a date only, truncated to midnight.
+    if st.st_atim.tv_sec != when - when % 86_400 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "stat st_atim should be date-only"));
     }
 
     // Clean up.
@@ -1254,7 +1270,7 @@ fn test_utimensat() -> Result<(), Error> {
         },
     ];
 
-    // utimensat with absolute path should succeed (FAT32 ignores times).
+    // utimensat with absolute path should succeed.
     vfs::fd::vfs_utimensat(0, "/uts/f.txt", &times, 0)
         .map_err(|e| fat_err(e, "utimensat absolute path"))?;
 


### PR DESCRIPTION
# [vfs] Real file timestamps for stat/utimensat

Closes #3098.

The VFS stubbed all file times to a fixed epoch: `stat`/`fstat` returned a
hardcoded `1704067200`, `utimensat` ignored its `times`, and the FAT
`TimeProvider` was pinned to 1980. This makes timestamps real.

## Changes

- `NanvixTimeProvider` is now wall-clock backed via `gettime`; host/`std` test
  builds fall back to the FAT epoch for determinism.
- Added Unix<->FAT date conversions (Howard Hinnant civil/days), clamped to the
  FAT year range [1980, 2107].
- `FatStat` carries `atime`/`mtime`/`ctime`; `Fat::stat` reads them from the
  directory entry and `Fat::set_times` writes them.
- Times thread through the VFS `Stat`/`VfsStat` layers; `vfs_utimensat` resolves
  `UTIME_NOW`/`UTIME_OMIT` and applies the result.
- New `fat32` round-trip tests; `test-rust-vfs-test` now sets a time and reads
  it back.

## Known limitations

- `fstat` on an open fd still reports the FAT epoch: fatfs exposes time getters
  only on a directory entry, not on an open handle. Path-based `stat` carries the
  real times. Tracked in #3103.
- Directory `utimensat` is a no-op (fatfs has no writable directory time entry).

## Follow-ups

- Per-process euid + utimensat permission enforcement (#3104, blocked by this).
- `Stat`/`VfsStat` type consolidation (drafted).
- Timestamp/epoch consolidation (#3099).

Verified against the full lifecycle.
