### PR TITLE
[hostfs-api] Forward full-precision stat timestamps

### DIFF
--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -62,7 +62,15 @@ use std::{
 };
 
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{
+    MetadataExt,
+    PermissionsExt,
+};
+#[cfg(not(unix))]
+use std::time::{
+    SystemTime,
+    UNIX_EPOCH,
+};
 
 fn open_regular_file(
     options: &OpenOptions,
@@ -107,9 +115,9 @@ pub struct HostFsHandler {
     assembler: HostFsAssembler,
     /// Queue of additional response payloads that a single request may produce.
     ///
-    /// Most hostfs operations reply with a single message, but a few (currently the
-    /// long-target variant of `readlink`) emit a multi-part response. The first part
-    /// is returned directly from [`Self::handle_request`]; the remaining parts are
+    /// Most hostfs operations reply with a single message. Long readlink/readdir responses and
+    /// stat timestamp continuations queue follow-up messages. The first response is returned
+    /// directly from [`Self::handle_request`]; the remaining messages are
     /// queued here and must be drained by the caller via
     /// [`Self::take_next_response_part`] before submitting the next request.
     extra_responses: std::collections::VecDeque<[u8; Message::PAYLOAD_SIZE]>,
@@ -733,7 +741,7 @@ impl HostFsHandler {
         req: long_msg::LongLstatRequest,
         response: &mut [u8; Message::PAYLOAD_SIZE],
     ) {
-        self.do_lstat(&req.path, response);
+        self.do_lstat(req.op_id, &req.path, response);
     }
 
     /// Handles a fully assembled long path-based following STAT request.
@@ -746,7 +754,7 @@ impl HostFsHandler {
         req: long_msg::LongLstatRequest,
         response: &mut [u8; Message::PAYLOAD_SIZE],
     ) {
-        self.do_pathstat(&req.path, response);
+        self.do_pathstat(req.op_id, &req.path, response);
     }
 
     /// Handles an inline single-message READLINK request.
@@ -820,7 +828,7 @@ impl HostFsHandler {
                 return;
             },
         };
-        self.do_lstat(path_str, response);
+        self.do_lstat(get_op_id(payload), path_str, response);
     }
 
     /// Handles an inline single-message path-based following STAT request.
@@ -862,7 +870,7 @@ impl HostFsHandler {
                 return;
             },
         };
-        self.do_pathstat(path_str, response);
+        self.do_pathstat(get_op_id(payload), path_str, response);
     }
 
     /// Shared `readlink` implementation used by both the inline and multi-part
@@ -1044,7 +1052,12 @@ impl HostFsHandler {
 
     /// Shared `lstat` implementation used by both the inline and multi-part
     /// request handlers.
-    fn do_lstat(&mut self, path_str: &str, response: &mut [u8; Message::PAYLOAD_SIZE]) {
+    fn do_lstat(
+        &mut self,
+        op_id: OperationId,
+        path_str: &str,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
         set_kind(response, SystemCallMessageKind::HostFsLstatResponse as u16);
 
         let host_path: PathBuf = match self.sandbox.resolve_nofollow(path_str) {
@@ -1072,6 +1085,7 @@ impl HostFsHandler {
                     kind,
                 };
                 resp.encode(response);
+                self.queue_stat_times(op_id, metadata_times(&meta));
             },
             Err(e) => {
                 let err = LstatResponse {
@@ -1098,7 +1112,12 @@ impl HostFsHandler {
     /// header. Because the final component is followed, [`metadata_kind`] never reports
     /// [`file_kind::SYMLINK`]: a dangling final link surfaces as the host `ENOENT`, and a
     /// resolved link reports the target's kind.
-    fn do_pathstat(&mut self, path_str: &str, response: &mut [u8; Message::PAYLOAD_SIZE]) {
+    fn do_pathstat(
+        &mut self,
+        op_id: OperationId,
+        path_str: &str,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
         set_kind(response, SystemCallMessageKind::HostFsPathStatResponse as u16);
 
         let host_path: PathBuf = match self.sandbox.resolve(path_str) {
@@ -1126,6 +1145,7 @@ impl HostFsHandler {
                     kind,
                 };
                 resp.encode(response);
+                self.queue_stat_times(op_id, metadata_times(&meta));
             },
             Err(e) => {
                 let err = LstatResponse {
@@ -1483,6 +1503,7 @@ impl HostFsHandler {
                 };
                 resp.encode(response);
                 set_kind(response, SystemCallMessageKind::HostFsStatResponse as u16);
+                self.queue_stat_times(get_op_id(payload), metadata_times(&meta));
             },
             Err(e) => {
                 log::debug!("hostfsd: stat failed (path={:?}, kind={:?}): {}", path, e.kind(), e);
@@ -1496,6 +1517,15 @@ impl HostFsHandler {
                 set_kind(response, SystemCallMessageKind::HostFsStatResponse as u16);
             },
         }
+    }
+
+    /// Queues timestamps after successful stat metadata.
+    fn queue_stat_times(&mut self, op_id: OperationId, times: StatTimesResponse) {
+        let mut response: [u8; Message::PAYLOAD_SIZE] = [0; Message::PAYLOAD_SIZE];
+        set_kind(&mut response, SystemCallMessageKind::HostFsStatTimesResponse as u16);
+        set_op_id(&mut response, op_id);
+        times.encode(&mut response);
+        self.extra_responses.push_back(response);
     }
 
     fn handle_readdir(
@@ -2084,6 +2114,66 @@ fn metadata_kind(meta: &fs::Metadata) -> u8 {
         file_kind::REGULAR
     } else {
         file_kind::OTHER
+    }
+}
+
+/// Host timestamps with full available precision.
+#[cfg(unix)]
+fn metadata_times(meta: &fs::Metadata) -> StatTimesResponse {
+    let time = |tv_sec: i64, tv_nsec: i64| {
+        let tv_nsec: u32 = match u32::try_from(tv_nsec) {
+            Ok(tv_nsec) if tv_nsec < 1_000_000_000 => tv_nsec,
+            _ => {
+                log::warn!("hostfsd: invalid metadata nanoseconds (tv_nsec={})", tv_nsec);
+                0
+            },
+        };
+        StatTime { tv_sec, tv_nsec }
+    };
+    StatTimesResponse {
+        atim: time(meta.atime(), meta.atime_nsec()),
+        mtim: time(meta.mtime(), meta.mtime_nsec()),
+        ctim: time(meta.ctime(), meta.ctime_nsec()),
+    }
+}
+
+/// Host timestamps with full available precision.
+#[cfg(not(unix))]
+fn metadata_times(meta: &fs::Metadata) -> StatTimesResponse {
+    let time = |result: io::Result<SystemTime>| {
+        let Ok(value) = result else {
+            return StatTime {
+                tv_sec: 0,
+                tv_nsec: 0,
+            };
+        };
+        match value.duration_since(UNIX_EPOCH) {
+            Ok(duration) => StatTime {
+                tv_sec: duration.as_secs() as i64,
+                tv_nsec: duration.subsec_nanos(),
+            },
+            Err(error) => {
+                let duration = error.duration();
+                let nanos: u32 = duration.subsec_nanos();
+                if nanos == 0 {
+                    StatTime {
+                        tv_sec: -(duration.as_secs() as i64),
+                        tv_nsec: 0,
+                    }
+                } else {
+                    StatTime {
+                        tv_sec: -(duration.as_secs() as i64) - 1,
+                        tv_nsec: 1_000_000_000 - nanos,
+                    }
+                }
+            },
+        }
+    };
+    let modified: StatTime = time(meta.modified());
+    StatTimesResponse {
+        atim: time(meta.accessed()),
+        mtim: modified,
+        ctim: modified,
     }
 }
 

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -417,6 +417,16 @@ fn test_stat_file() {
     assert_eq!(resp.status, 0);
     assert_eq!(resp.size, 10);
     assert_eq!(resp.is_dir, 0);
+
+    let times_payload = handler
+        .take_next_response_part()
+        .expect("missing stat timestamps");
+    let kind = u16::from_ne_bytes([times_payload[0], times_payload[1]]);
+    assert_eq!(kind, SystemCallMessageKind::HostFsStatTimesResponse as u16);
+    assert_eq!(get_op_id(&times_payload), OperationId::from_raw(0));
+    let times = StatTimesResponse::decode(&times_payload).expect("valid stat timestamps");
+    assert!(times.mtim.tv_nsec < 1_000_000_000);
+    assert!(handler.take_next_response_part().is_none());
 }
 
 #[test]
@@ -443,6 +453,7 @@ fn test_stat_invalid_fd() {
     let response: [u8; Message::PAYLOAD_SIZE] = handler.handle_request(&payload).unwrap();
     let resp: StatResponse = StatResponse::decode(&response);
     assert!(resp.status < 0, "stat of invalid fd should fail");
+    assert!(handler.take_next_response_part().is_none());
 }
 
 //==================================================================================================
@@ -1569,6 +1580,13 @@ fn test_lstat_regular_file() {
     assert_eq!(r.status, 0, "lstat should succeed");
     assert_eq!(r.kind, file_kind::REGULAR);
     assert_eq!(r.size, 5);
+    let times = handler
+        .take_next_response_part()
+        .expect("missing lstat timestamps");
+    assert_eq!(
+        u16::from_ne_bytes([times[0], times[1]]),
+        SystemCallMessageKind::HostFsStatTimesResponse as u16
+    );
 }
 
 #[test]
@@ -1619,6 +1637,13 @@ fn test_pathstat_regular_file() {
     assert_eq!(r.status, 0, "pathstat should succeed");
     assert_eq!(r.kind, file_kind::REGULAR);
     assert_eq!(r.size, 5);
+    let times = handler
+        .take_next_response_part()
+        .expect("missing pathstat timestamps");
+    assert_eq!(
+        u16::from_ne_bytes([times[0], times[1]]),
+        SystemCallMessageKind::HostFsStatTimesResponse as u16
+    );
 }
 
 #[test]

--- a/src/daemons/vfsd/src/main.rs
+++ b/src/daemons/vfsd/src/main.rs
@@ -365,6 +365,66 @@ pub fn main() {
                             }
                             continue;
                         }
+                        if matches!(
+                            header,
+                            SystemCallMessageKind::HostFsStatResponse
+                                | SystemCallMessageKind::HostFsLstatResponse
+                                | SystemCallMessageKind::HostFsPathStatResponse
+                        ) {
+                            let op_id: ::hostfs_api::OperationId =
+                                ::hostfs_api::get_op_id(&message.payload);
+                            let step: Option<pending::StatMetadataStep> = pending
+                                .get_mut(op_id)
+                                .map(|op| pending::stage_stat_metadata(op, &message.payload));
+                            match step {
+                                Some(pending::StatMetadataStep::Wait) => continue,
+                                Some(pending::StatMetadataStep::Complete) => {
+                                    if let Some(op) = pending.remove(op_id) {
+                                        pending::complete_pending_op(op, &message.payload);
+                                    }
+                                    continue;
+                                },
+                                Some(pending::StatMetadataStep::Invalid) => {
+                                    if let Some(op) = pending.remove(op_id) {
+                                        pending::cancel_pending_op(op, ErrorCode::IoErr);
+                                    }
+                                    continue;
+                                },
+                                None => {},
+                            }
+                        }
+                        if header == SystemCallMessageKind::HostFsStatTimesResponse {
+                            let op_id: ::hostfs_api::OperationId =
+                                ::hostfs_api::get_op_id(&message.payload);
+                            let is_staged_stat: bool = pending.get_mut(op_id).is_some_and(|op| {
+                                matches!(
+                                    op.kind,
+                                    pending::PendingOpKind::StatTimes { .. }
+                                        | pending::PendingOpKind::LstatTimes { .. }
+                                        | pending::PendingOpKind::PathStatTimes { .. }
+                                        | pending::PendingOpKind::ChdirTimes { .. }
+                                )
+                            });
+                            if is_staged_stat {
+                                if let Some(op) = pending.remove(op_id) {
+                                    pending::complete_stat_times(op, &message.payload);
+                                }
+                            } else if let Some(op) = pending.remove(op_id) {
+                                ::syslog::error!(
+                                    "stat timestamps for non-staged operation (op_id={})",
+                                    op_id,
+                                );
+                                pending::cancel_pending_op(op, ErrorCode::IoErr);
+                            } else if pending.discard_abandoned_operation(op_id) {
+                                // The originating process exited while stat was in flight.
+                            } else {
+                                ::syslog::warn!(
+                                    "stat timestamps with no pending op (op_id={})",
+                                    op_id,
+                                );
+                            }
+                            continue;
+                        }
                         if header.is_hostfs_response() {
                             let op_id: ::hostfs_api::OperationId =
                                 ::hostfs_api::get_op_id(&message.payload);

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -31,6 +31,7 @@ use ::hostfs_api::{
     LstatResponse,
     OperationId,
     OperationIdAllocator,
+    StatTimesResponse,
 };
 use ::sys::{
     error::ErrorCode,
@@ -95,8 +96,13 @@ pub(crate) enum PendingOpKind {
     Unlink,
     /// rename — response is a status code.
     Rename,
-    /// stat/fstat — response contains size, mode, is_dir.
+    /// stat/fstat — waiting for size, mode, and kind.
     Stat,
+    /// stat/fstat — metadata arrived; waiting for timestamps.
+    StatTimes {
+        /// First response payload.
+        metadata: [u8; Message::PAYLOAD_SIZE],
+    },
     /// symlink — response is a status code.
     Symlink,
     /// readlink — response contains the link target bytes.
@@ -106,14 +112,31 @@ pub(crate) enum PendingOpKind {
     },
     /// lstat — path-based stat that does not follow the final symbolic link.
     Lstat,
+    /// lstat metadata arrived; waiting for timestamps.
+    LstatTimes {
+        /// First response payload.
+        metadata: [u8; Message::PAYLOAD_SIZE],
+    },
     /// Path-based stat that follows the final symbolic link (default `stat(2)` semantics).
     /// Shares the `lstat` response wire format and completion path.
     PathStat,
+    /// Following stat metadata arrived; waiting for timestamps.
+    PathStatTimes {
+        /// First response payload.
+        metadata: [u8; Message::PAYLOAD_SIZE],
+    },
     /// chdir onto a hostfs path — a path-based stat whose completion commits the cwd
     /// when the target is a directory (else `ENOTDIR`). Reuses the `PathStat` wire form.
     Chdir {
         /// Absolute hostfs path to become the cwd once confirmed to be a directory.
         path: ResolvedPath,
+    },
+    /// chdir metadata arrived; waiting for the timestamp continuation.
+    ChdirTimes {
+        /// Absolute hostfs path to become the cwd once confirmed to be a directory.
+        path: ResolvedPath,
+        /// First response payload.
+        metadata: [u8; Message::PAYLOAD_SIZE],
     },
     /// getdents — directory listing over hostfs.
     ///
@@ -149,15 +172,10 @@ const MAX_PENDING_OPS: usize = 64;
 //==================================================================================================
 //
 // Hostfsd does not forward several `stat`/`lstat` fields from the host (timestamps,
-// device id, inode, link count). The constants below are the synthetic values used
-// to populate those fields so both completion paths report identical, deterministic
-// metadata.
-
-/// Fixed timestamp (2024-01-01T00:00:00Z) used for `st_atim`/`st_mtim`/`st_ctim`.
-///
-/// Keeps stat output stable across runs and hosts; tooling that only cares about
-/// ordering or equality continues to work.
-const STAT_FIXED_EPOCH: i64 = 1_704_067_200;
+// Hostfsd does not forward several `stat`/`lstat` fields from the host (device id,
+// inode, link count). The constants below are the synthetic values used to populate
+// those fields so both completion paths report identical, deterministic metadata.
+// Timestamps now carry real host `atim`/`mtim` (ctim is derived from mtim).
 
 /// Conventional Unix block size reported as `st_blksize`.
 ///
@@ -387,6 +405,83 @@ pub(crate) fn cancel_pending_op(op: PendingOp, code: ErrorCode) {
 // Response Completion
 //==================================================================================================
 
+/// Result of receiving the first half of a stat response.
+pub(crate) enum StatMetadataStep {
+    /// Metadata failed; complete the operation immediately.
+    Complete,
+    /// Metadata succeeded; wait for timestamps.
+    Wait,
+    /// The response did not match the pending operation.
+    Invalid,
+}
+
+/// Stores successful stat metadata until its timestamp continuation arrives.
+pub(crate) fn stage_stat_metadata(
+    pending: &mut PendingOp,
+    response_payload: &[u8; Message::PAYLOAD_SIZE],
+) -> StatMetadataStep {
+    if !validate_response_header(&pending.kind, response_payload) {
+        return StatMetadataStep::Invalid;
+    }
+    let offset: usize = ::hostfs_api::HOSTFS_DATA_START;
+    let status_bytes: [u8; 4] = match response_payload
+        .get(offset..offset + 4)
+        .and_then(|bytes| bytes.try_into().ok())
+    {
+        Some(bytes) => bytes,
+        None => return StatMetadataStep::Invalid,
+    };
+    let status: i32 = i32::from_le_bytes(status_bytes);
+    if status < 0 {
+        return StatMetadataStep::Complete;
+    }
+
+    let metadata: [u8; Message::PAYLOAD_SIZE] = *response_payload;
+    pending.kind = match &pending.kind {
+        PendingOpKind::Stat => PendingOpKind::StatTimes { metadata },
+        PendingOpKind::Lstat => PendingOpKind::LstatTimes { metadata },
+        PendingOpKind::PathStat => PendingOpKind::PathStatTimes { metadata },
+        PendingOpKind::Chdir { path } => PendingOpKind::ChdirTimes {
+            path: path.clone(),
+            metadata,
+        },
+        _ => return StatMetadataStep::Invalid,
+    };
+    StatMetadataStep::Wait
+}
+
+/// Completes a staged stat operation with its timestamp continuation.
+pub(crate) fn complete_stat_times(
+    pending: PendingOp,
+    response_payload: &[u8; Message::PAYLOAD_SIZE],
+) {
+    ::vfs::fd::set_current_process(pending.source_pid);
+    let Some(times) = StatTimesResponse::decode(response_payload) else {
+        ::syslog::error!("invalid stat timestamp continuation");
+        pending
+            .response_context
+            .send(&build_error(pending.source_tid, ErrorCode::IoErr));
+        return;
+    };
+    match pending.kind {
+        PendingOpKind::StatTimes { metadata } => {
+            complete_stat(pending.response_context, &metadata, Some(times));
+        },
+        PendingOpKind::LstatTimes { metadata } | PendingOpKind::PathStatTimes { metadata } => {
+            complete_lstat(pending.response_context, &metadata, Some(times));
+        },
+        PendingOpKind::ChdirTimes { path, metadata } => {
+            complete_chdir(pending.response_context, &metadata, path);
+        },
+        _ => {
+            ::syslog::error!("timestamp continuation for non-stat operation");
+            pending
+                .response_context
+                .send(&build_error(pending.source_tid, ErrorCode::IoErr));
+        },
+    }
+}
+
 /// Completes a pending hostfs operation given the IKC response payload.
 ///
 /// Builds and sends the appropriate response message to the guest caller.
@@ -448,16 +543,23 @@ pub(crate) fn complete_pending_op(
         PendingOpKind::Rename => {
             complete_status(response_context, response_payload, OpGroup::Rename)
         },
-        PendingOpKind::Stat => complete_stat(response_context, response_payload),
+        PendingOpKind::Stat => complete_stat(response_context, response_payload, None),
         PendingOpKind::Symlink => {
             complete_status(response_context, response_payload, OpGroup::Symlink)
         },
         PendingOpKind::Readlink { bufsiz } => {
             complete_readlink(response_context, response_payload, bufsiz)
         },
-        PendingOpKind::Lstat => complete_lstat(response_context, response_payload),
-        PendingOpKind::PathStat => complete_lstat(response_context, response_payload),
+        PendingOpKind::Lstat => complete_lstat(response_context, response_payload, None),
+        PendingOpKind::PathStat => complete_lstat(response_context, response_payload, None),
         PendingOpKind::Chdir { path } => complete_chdir(response_context, response_payload, path),
+        PendingOpKind::StatTimes { .. }
+        | PendingOpKind::LstatTimes { .. }
+        | PendingOpKind::PathStatTimes { .. }
+        | PendingOpKind::ChdirTimes { .. } => {
+            ::syslog::error!("staged stat operation routed to metadata completion");
+            response_context.send(&build_error(pending.source_tid, ErrorCode::IoErr));
+        },
         PendingOpKind::Getdents { .. } => {
             // Getdents sweeps are driven entirely by the main event loop, which keeps
             // the op buffered across round-trips and finalizes it via `finish_getdents`.
@@ -1090,6 +1192,7 @@ fn hostfs_error_to_code(code: i32) -> ErrorCode {
 fn complete_stat(
     response_context: ResponseContext,
     response_payload: &[u8; Message::PAYLOAD_SIZE],
+    times: Option<StatTimesResponse>,
 ) {
     use ::sysapi::{
         sys_stat::{
@@ -1115,6 +1218,11 @@ fn complete_stat(
         return;
     }
 
+    let Some(times): Option<StatTimesResponse> = times else {
+        ::syslog::error!("successful stat response missing timestamps");
+        response_context.send(&build_error(source_tid, ErrorCode::IoErr));
+        return;
+    };
     let is_dir: bool = resp.is_dir != 0;
     let mode: u32 = if resp.mode != 0 {
         // Use host-provided mode, adding file type bits.
@@ -1147,16 +1255,16 @@ fn complete_stat(
         st_rdev: 0,
         st_size: resp.size as off_t,
         st_atim: timespec {
-            tv_sec: STAT_FIXED_EPOCH,
-            tv_nsec: 0,
+            tv_sec: times.atim.tv_sec,
+            tv_nsec: times.atim.tv_nsec as _,
         },
         st_mtim: timespec {
-            tv_sec: STAT_FIXED_EPOCH,
-            tv_nsec: 0,
+            tv_sec: times.mtim.tv_sec,
+            tv_nsec: times.mtim.tv_nsec as _,
         },
         st_ctim: timespec {
-            tv_sec: STAT_FIXED_EPOCH,
-            tv_nsec: 0,
+            tv_sec: times.ctim.tv_sec,
+            tv_nsec: times.ctim.tv_nsec as _,
         },
         st_blksize: STAT_BLOCK_SIZE,
         st_blocks: resp.size.div_ceil(STAT_SECTOR_SIZE) as off_t,
@@ -1295,6 +1403,7 @@ fn complete_readlink(
 fn complete_lstat(
     response_context: ResponseContext,
     response_payload: &[u8; Message::PAYLOAD_SIZE],
+    times: Option<StatTimesResponse>,
 ) {
     use ::sysapi::{
         sys_stat::{
@@ -1326,6 +1435,11 @@ fn complete_lstat(
         return;
     }
 
+    let Some(times): Option<StatTimesResponse> = times else {
+        ::syslog::error!("successful lstat response missing timestamps");
+        response_context.send(&build_error(source_tid, ErrorCode::IoErr));
+        return;
+    };
     let type_bits: u32 = match resp.kind {
         ::hostfs_api::file_kind::DIRECTORY => file_type::S_IFDIR,
         ::hostfs_api::file_kind::SYMLINK => file_type::S_IFLNK,
@@ -1365,16 +1479,16 @@ fn complete_lstat(
         st_rdev: 0,
         st_size: resp.size as off_t,
         st_atim: timespec {
-            tv_sec: STAT_FIXED_EPOCH,
-            tv_nsec: 0,
+            tv_sec: times.atim.tv_sec,
+            tv_nsec: times.atim.tv_nsec as _,
         },
         st_mtim: timespec {
-            tv_sec: STAT_FIXED_EPOCH,
-            tv_nsec: 0,
+            tv_sec: times.mtim.tv_sec,
+            tv_nsec: times.mtim.tv_nsec as _,
         },
         st_ctim: timespec {
-            tv_sec: STAT_FIXED_EPOCH,
-            tv_nsec: 0,
+            tv_sec: times.ctim.tv_sec,
+            tv_nsec: times.ctim.tv_nsec as _,
         },
         st_blksize: STAT_BLOCK_SIZE,
         st_blocks: resp.size.div_ceil(STAT_SECTOR_SIZE) as off_t,
@@ -1427,4 +1541,119 @@ fn complete_chdir(
         ProcessIdentifier::VFSD,
         MessageType::Ipc,
     ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::hostfs_api::{
+        set_kind,
+        StatResponse,
+    };
+    use ::sys::ipc::{
+        MessageSender,
+        RequestIdentifier,
+    };
+    use ::syscall::SystemCallMessageKind;
+
+    fn pending(kind: PendingOpKind) -> PendingOp {
+        let process = ProcessIdentifier::from(10);
+        let thread = ThreadIdentifier::from(20);
+        PendingOp {
+            response_context: ResponseContext::new(
+                MessageSender::new(process, thread),
+                RequestIdentifier::from_raw(1),
+            ),
+            source_tid: thread,
+            source_pid: process,
+            kind,
+        }
+    }
+
+    fn stat_payload(status: i32) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload = [0; Message::PAYLOAD_SIZE];
+        set_kind(&mut payload, SystemCallMessageKind::HostFsStatResponse as u16);
+        StatResponse {
+            status,
+            size: 42,
+            mode: 0o644,
+            is_dir: 0,
+        }
+        .encode(&mut payload);
+        payload
+    }
+
+    fn lstat_payload(kind: SystemCallMessageKind) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload = [0; Message::PAYLOAD_SIZE];
+        set_kind(&mut payload, kind as u16);
+        LstatResponse {
+            status: 0,
+            size: 42,
+            mode: 0o644,
+            kind: file_kind::REGULAR,
+        }
+        .encode(&mut payload);
+        payload
+    }
+
+    #[test]
+    fn successful_stat_waits_for_timestamps() {
+        let mut op = pending(PendingOpKind::Stat);
+        let payload = stat_payload(0);
+
+        assert!(matches!(stage_stat_metadata(&mut op, &payload), StatMetadataStep::Wait));
+        assert!(matches!(op.kind, PendingOpKind::StatTimes { .. }));
+    }
+
+    #[test]
+    fn failed_stat_completes_without_timestamps() {
+        let mut op = pending(PendingOpKind::Stat);
+        let payload = stat_payload(::hostfs_api::HOSTFS_ERR_NOT_FOUND);
+
+        assert!(matches!(stage_stat_metadata(&mut op, &payload), StatMetadataStep::Complete));
+        assert!(matches!(op.kind, PendingOpKind::Stat));
+    }
+
+    #[test]
+    fn path_stat_variants_wait_for_timestamps() {
+        let mut lstat = pending(PendingOpKind::Lstat);
+        let payload = lstat_payload(SystemCallMessageKind::HostFsLstatResponse);
+        assert!(matches!(stage_stat_metadata(&mut lstat, &payload), StatMetadataStep::Wait));
+        assert!(matches!(lstat.kind, PendingOpKind::LstatTimes { .. }));
+
+        let mut pathstat = pending(PendingOpKind::PathStat);
+        let payload = lstat_payload(SystemCallMessageKind::HostFsPathStatResponse);
+        assert!(matches!(stage_stat_metadata(&mut pathstat, &payload), StatMetadataStep::Wait));
+        assert!(matches!(pathstat.kind, PendingOpKind::PathStatTimes { .. }));
+    }
+
+    #[test]
+    fn chdir_retains_path_while_waiting_for_timestamps() {
+        let path = ::vfs::path::vfs_resolve_path(0, "/host/dir").unwrap();
+        let mut op = pending(PendingOpKind::Chdir { path: path.clone() });
+        let payload = lstat_payload(SystemCallMessageKind::HostFsPathStatResponse);
+
+        assert!(matches!(stage_stat_metadata(&mut op, &payload), StatMetadataStep::Wait));
+        match op.kind {
+            PendingOpKind::ChdirTimes { path: actual, .. } => assert_eq!(actual, path),
+            _ => panic!("chdir should wait for timestamps"),
+        }
+    }
+
+    #[test]
+    fn purged_staged_stat_is_discarded_on_metadata() {
+        let mut queue = PendingQueue::new();
+        let op_id = OperationId::from_raw(7);
+        let op = pending(PendingOpKind::Stat);
+        let process = op.source_pid;
+        queue.insert(op_id, op).unwrap();
+        let payload = stat_payload(0);
+        let step = stage_stat_metadata(queue.get_mut(op_id).unwrap(), &payload);
+        assert!(matches!(step, StatMetadataStep::Wait));
+
+        queue.purge_pid(process);
+
+        assert!(queue.discard_abandoned_operation(op_id));
+        assert!(!queue.discard_abandoned_operation(op_id));
+    }
 }

--- a/src/libs/hostfs-api/src/lib.rs
+++ b/src/libs/hostfs-api/src/lib.rs
@@ -47,6 +47,7 @@ mod readlink;
 mod rename;
 mod rmdir;
 mod stat;
+mod stat_times;
 mod truncate;
 mod unlink;
 mod write;
@@ -86,6 +87,10 @@ pub use self::{
     stat::{
         StatRequest,
         StatResponse,
+    },
+    stat_times::{
+        StatTime,
+        StatTimesResponse,
     },
     truncate::TruncateRequest,
     unlink::UnlinkRequest,

--- a/src/libs/hostfs-api/src/stat_times.rs
+++ b/src/libs/hostfs-api/src/stat_times.rs
@@ -1,0 +1,114 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Timestamp response shared by hostfs stat operations.
+
+use crate::HOSTFS_DATA_START;
+use ::sys::ipc::Message;
+
+/// Wire timestamp with full POSIX precision.
+#[derive(Debug, Clone, Copy)]
+pub struct StatTime {
+    /// Seconds since the Unix epoch.
+    pub tv_sec: i64,
+    /// Nanoseconds within the second.
+    pub tv_nsec: u32,
+}
+
+/// Timestamps returned after successful stat metadata.
+#[derive(Debug, Clone, Copy)]
+pub struct StatTimesResponse {
+    /// Last access time.
+    pub atim: StatTime,
+    /// Last modification time.
+    pub mtim: StatTime,
+    /// Last status-change time.
+    pub ctim: StatTime,
+}
+
+impl StatTimesResponse {
+    const TIME_SIZE: usize = 12;
+
+    /// Encodes this response into the message payload.
+    pub fn encode(&self, payload: &mut [u8; Message::PAYLOAD_SIZE]) {
+        for (index, time) in [self.atim, self.mtim, self.ctim].iter().enumerate() {
+            let offset: usize = HOSTFS_DATA_START + index * Self::TIME_SIZE;
+            payload[offset..offset + 8].copy_from_slice(&time.tv_sec.to_le_bytes());
+            payload[offset + 8..offset + 12].copy_from_slice(&time.tv_nsec.to_le_bytes());
+        }
+    }
+
+    /// Decodes this response from the message payload.
+    pub fn decode(payload: &[u8; Message::PAYLOAD_SIZE]) -> Option<Self> {
+        let decode = |index: usize| {
+            let offset: usize = HOSTFS_DATA_START + index * Self::TIME_SIZE;
+            let tv_nsec: u32 =
+                u32::from_le_bytes(payload[offset + 8..offset + 12].try_into().ok()?);
+            if tv_nsec >= 1_000_000_000 {
+                return None;
+            }
+            Some(StatTime {
+                tv_sec: i64::from_le_bytes(payload[offset..offset + 8].try_into().ok()?),
+                tv_nsec,
+            })
+        };
+        Some(Self {
+            atim: decode(0)?,
+            mtim: decode(1)?,
+            ctim: decode(2)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_roundtrips() {
+        let expected = StatTimesResponse {
+            atim: StatTime {
+                tv_sec: -1,
+                tv_nsec: 999_999_999,
+            },
+            mtim: StatTime {
+                tv_sec: 1_704_067_200,
+                tv_nsec: 123_456_789,
+            },
+            ctim: StatTime {
+                tv_sec: 1_704_067_201,
+                tv_nsec: 42,
+            },
+        };
+        let mut payload = [0; Message::PAYLOAD_SIZE];
+        expected.encode(&mut payload);
+        let actual = StatTimesResponse::decode(&payload).expect("valid timestamps");
+        assert_eq!(actual.atim.tv_sec, expected.atim.tv_sec);
+        assert_eq!(actual.atim.tv_nsec, expected.atim.tv_nsec);
+        assert_eq!(actual.mtim.tv_sec, expected.mtim.tv_sec);
+        assert_eq!(actual.mtim.tv_nsec, expected.mtim.tv_nsec);
+        assert_eq!(actual.ctim.tv_sec, expected.ctim.tv_sec);
+        assert_eq!(actual.ctim.tv_nsec, expected.ctim.tv_nsec);
+    }
+
+    #[test]
+    fn response_rejects_invalid_nanoseconds() {
+        let response = StatTimesResponse {
+            atim: StatTime {
+                tv_sec: 0,
+                tv_nsec: 1_000_000_000,
+            },
+            mtim: StatTime {
+                tv_sec: 0,
+                tv_nsec: 0,
+            },
+            ctim: StatTime {
+                tv_sec: 0,
+                tv_nsec: 0,
+            },
+        };
+        let mut payload = [0; Message::PAYLOAD_SIZE];
+        response.encode(&mut payload);
+        assert!(StatTimesResponse::decode(&payload).is_none());
+    }
+}

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -357,6 +357,8 @@ pub enum SystemCallMessageKind {
     PipeOpCancelRequest,
     PipeOpCancelResponse,
     PipeReadRetry,
+    /// Timestamp continuation for successful hostfs stat operations.
+    HostFsStatTimesResponse,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageKind.
 impl TryFrom<u16> for SystemCallMessageKind {
@@ -546,6 +548,7 @@ impl TryFrom<u16> for SystemCallMessageKind {
             x if x == PipeOpCancelRequest as u16 => Ok(PipeOpCancelRequest),
             x if x == PipeOpCancelResponse as u16 => Ok(PipeOpCancelResponse),
             x if x == PipeReadRetry as u16 => Ok(PipeReadRetry),
+            x if x == HostFsStatTimesResponse as u16 => Ok(HostFsStatTimesResponse),
             _ => Err(()),
         }
     }
@@ -600,6 +603,7 @@ impl SystemCallMessageKind {
                 | Self::HostFsPathStatRequest
                 | Self::HostFsPathStatRequestPart
                 | Self::HostFsPathStatResponse
+                | Self::HostFsStatTimesResponse
         )
     }
 
@@ -671,6 +675,7 @@ impl SystemCallMessageKind {
                 | Self::HostFsReadlinkResponse
                 | Self::HostFsLstatResponse
                 | Self::HostFsPathStatResponse
+                | Self::HostFsStatTimesResponse
         )
     }
 

--- a/src/uservm/src/standalone.rs
+++ b/src/uservm/src/standalone.rs
@@ -572,10 +572,9 @@ async fn standalone_io_handler(
                             // Build the first response message and any queued
                             // multi-part follow-ups together so the entire response
                             // stream is delivered before the next request is
-                            // processed. Hostfs multi-part responses (the long-target
-                            // `readlink` and long-name `readdir` forms) leave
-                            // additional payloads in the handler's queue that must be
-                            // drained via `take_next_response_part` immediately after
+                            // processed. Long readlink/readdir responses and stat
+                            // timestamp continuations leave additional payloads in the
+                            // handler's queue that must be drained immediately after
                             // the head.
                             let mut response_payloads: std::vec::Vec<[u8; Message::PAYLOAD_SIZE]> =
                                 std::vec::Vec::new();
@@ -994,9 +993,7 @@ fn hostfs_part_info(
 ///
 /// Builds a per-operation error payload so that each vfsd completion handler detects the
 /// failure correctly. Most operations check a leading i32 field for negative values; lseek
-/// checks an i64 offset; stat uses all-zeros as its error sentinel; readdir uses name_len==0
-/// as end-of-directory. Using 0xFF indiscriminately would produce bogus metadata for stat
-/// (whose `size` field is `u64`).
+/// checks an i64 offset, and readdir uses name_len==0 as end-of-directory.
 ///
 /// The `op_id` from the original request is echoed into the response so that vfsd's
 /// `PendingQueue::remove` can match it to the correct pending operation.
@@ -1027,9 +1024,7 @@ async fn send_hostfs_error(
             err_payload[ds..ds + 8]
                 .copy_from_slice(&(::hostfs_api::HOSTFS_ERR_IO as i64).to_le_bytes());
         },
-        SystemCallMessageKind::HostFsStatResponse
-        | SystemCallMessageKind::HostFsReadDirResponse => {
-            // Stat uses all-zeros (size==0 && mode==0 && is_dir==0) as error sentinel.
+        SystemCallMessageKind::HostFsReadDirResponse => {
             // Readdir uses name_len==0 as end-of-directory signal.
             // Zeros are already in place from the initialization above.
         },


### PR DESCRIPTION
# [hostfs-api] Forward full-precision stat timestamps

Part of #3099.

Hostfs currently drops host timestamps and vfsd substitutes a synthetic epoch.
This PR forwards access, modification, and status-change times without
constraining future filesystems to FAT timestamp precision.

## Changes

- Split successful hostfs stat results into metadata followed by timestamps.
- Encode each timestamp as signed Unix seconds plus nanoseconds.
- Preserve host `atime`, `mtime`, and `ctime` on Unix; use `mtime` as the
  conservative non-Unix `ctime` fallback.
- Stage stat, lstat, path-stat, and hostfs chdir operations until both responses
  arrive.
- Complete metadata errors immediately without waiting for a continuation.
- Validate nanoseconds before constructing guest `timespec` values.
- Preserve negative status in standalone transport-error responses.
- Add wire-format, producer-ordering, and pending-state tests.

The two-message shape is required by the fixed IPC payload: three full
`timespec` values do not fit beside the ordinary stat metadata.
