### PR TITLE
[kernel] E: Emit Thread Lifecycle Events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -906,8 +906,9 @@ image: all-nanvix
 image-clean:
 	$(RM_CMD) $(IMAGE)
 
-# Standalone tests that do NOT require daemons (run as bare .elf binaries).
-STANDALONE_NO_DAEMON_TESTS := test-rust-kernel
+# Standalone tests that need only procd. The kernel-interface test owns the RAMFS MMIO region
+# directly, so vfsd must remain absent, but its thread-lifecycle stress requires a consumer.
+STANDALONE_PROCD_ONLY_TESTS := test-rust-kernel
 
 # Guest binaries that are bundled into a ramfs image rather than launched directly, so they must
 # not have a standalone .initrd of their own. The execv targets are loaded at runtime by
@@ -924,7 +925,7 @@ STANDALONE_NO_VFS_BINARIES := vfs-bench-nostd
 # NOTE: ALL_POSIX_TESTS are intentionally NOT bundled here. The ported POSIX C
 # test suites build their own standalone images (with custom argv[0]/env) in
 # build/make/posix-tests.mk.
-STANDALONE_TEST_BINARIES := $(filter-out $(STANDALONE_NO_DAEMON_TESTS) $(STANDALONE_NO_VFS_BINARIES) $(STANDALONE_RAMFS_ONLY_BINARIES),$(ALL_GUEST_TESTS)) $(filter-out $(STANDALONE_NO_VFS_BINARIES),$(ALL_GUEST_BENCHMARKS)) $(ALL_GUEST_APPLICATIONS)
+STANDALONE_TEST_BINARIES := $(filter-out $(STANDALONE_PROCD_ONLY_TESTS) $(STANDALONE_NO_VFS_BINARIES) $(STANDALONE_RAMFS_ONLY_BINARIES),$(ALL_GUEST_TESTS)) $(filter-out $(STANDALONE_NO_VFS_BINARIES),$(ALL_GUEST_BENCHMARKS)) $(ALL_GUEST_APPLICATIONS)
 
 .PHONY: standalone-images standalone-images-clean
 
@@ -936,6 +937,7 @@ STANDALONE_TEST_BINARIES := $(filter-out $(STANDALONE_NO_DAEMON_TESTS) $(STANDAL
 # mid-path and producing 'invalid entry' errors from mkimage.
 STANDALONE_WITH_VFS_INITRDS := $(STANDALONE_TEST_BINARIES:%=$(BINARIES_DIR)/%.initrd)
 STANDALONE_NO_VFS_INITRDS   := $(STANDALONE_NO_VFS_BINARIES:%=$(BINARIES_DIR)/%.initrd)
+STANDALONE_PROCD_ONLY_INITRDS := $(STANDALONE_PROCD_ONLY_TESTS:%=$(BINARIES_DIR)/%.initrd)
 
 # Cross-target build guard.
 #
@@ -1008,14 +1010,24 @@ $(STANDALONE_NO_VFS_INITRDS): $(BINARIES_DIR)/%.initrd: \
 		$(BINARIES_DIR)/memd.$(EXEC_FORMAT)\;memd \
 		$(BINARIES_DIR)/$*.$(EXEC_FORMAT)\;$*
 
+$(STANDALONE_PROCD_ONLY_INITRDS): $(BINARIES_DIR)/%.initrd: \
+		$(BINARIES_DIR)/%.$(EXEC_FORMAT) \
+		$(BINARIES_DIR)/procd.$(EXEC_FORMAT) \
+		$(MKIMAGE) \
+		| target-guard
+	$(MKIMAGE) -o $@ \
+		$(BINARIES_DIR)/procd.$(EXEC_FORMAT)\;procd \
+		$(BINARIES_DIR)/$*.$(EXEC_FORMAT)\;$*
+
 # Build standalone multibinary images for all test/benchmark/application binaries. Uses .initrd
 # extension to avoid collisions with other build artifacts (e.g., vfs-test.img).
-standalone-images: $(STANDALONE_WITH_VFS_INITRDS) $(STANDALONE_NO_VFS_INITRDS)
+standalone-images: $(STANDALONE_WITH_VFS_INITRDS) $(STANDALONE_NO_VFS_INITRDS) $(STANDALONE_PROCD_ONLY_INITRDS)
 	@echo "Standalone images built successfully."
 
 standalone-images-clean:
 	$(foreach bin,$(STANDALONE_TEST_BINARIES),$(RM_CMD) $(BINARIES_DIR)/$(bin).initrd ;)
 	$(foreach bin,$(STANDALONE_NO_VFS_BINARIES),$(RM_CMD) $(BINARIES_DIR)/$(bin).initrd ;)
+	$(foreach bin,$(STANDALONE_PROCD_ONLY_TESTS),$(RM_CMD) $(BINARIES_DIR)/$(bin).initrd ;)
 
 #===================================================================================================
 # Build Rules for Running Tests

--- a/src/kernel/src/kcall/handler.rs
+++ b/src/kernel/src/kcall/handler.rs
@@ -99,6 +99,15 @@ where
 ///
 /// Kernel call handler.
 ///
+/// # Returns
+///
+/// The exit status that should be reported when the kernel shuts down.
+///
+/// # Panics
+///
+/// This function panics if the event manager cannot be initialized, lifecycle state was already
+/// disposed, or lifecycle reservation accounting is inconsistent during shutdown.
+///
 pub fn kcall_handler() -> ExitStatus {
     if let Err(e) = event::init() {
         panic!("failed to initialize event manager: {:?}", e);
@@ -119,12 +128,8 @@ pub fn kcall_handler() -> ExitStatus {
                 // Check if the process manager daemon (PROCD) terminated.
                 if termination.info().pid == ProcessIdentifier::PROCD {
                     // It was, so we should shutdown.
-                    let info = pm!().release_process_termination(termination);
-                    break info.status;
+                    break termination.into_info().status;
                 }
-                // Commit the termination to the ordered delivery broker. Waking the lifecycle
-                // owner is deferred until no reference to the process manager is held.
-                pm!().commit_process_termination(termination);
                 harvested_process = true;
             },
             Err(e) => {
@@ -155,7 +160,7 @@ pub fn kcall_handler() -> ExitStatus {
     };
 
     while let Ok(Some(termination)) = pm!().harvest_zombies(mm!()) {
-        let info = pm!().release_process_termination(termination);
+        let info = termination.into_info();
         info!("harvested zombie process: pid={:?}, status={:?}", info.pid, info.status);
     }
     pm!().dispose_lifecycle();

--- a/src/kernel/src/pm/process/manager/delivery.rs
+++ b/src/kernel/src/pm/process/manager/delivery.rs
@@ -21,6 +21,8 @@ use crate::{
         LifecycleCreationCredit,
         LifecycleCreationReservation,
         LifecycleTerminationCredit,
+        ThreadLifecycleReservation,
+        ThreadLifecycleTerminationCredit,
     },
 };
 use ::alloc::{
@@ -36,6 +38,7 @@ use ::sys::{
     event::{
         ProcessCreationInfo,
         ProcessTerminationInfo,
+        ThreadTerminationInfo,
     },
     ipc::{
         Message,
@@ -51,6 +54,7 @@ use ::sys::{
 
 ::static_assert::assert_eq!(mem::size_of::<ProcessTerminationInfo>() <= Message::PAYLOAD_SIZE);
 ::static_assert::assert_eq!(mem::size_of::<ProcessCreationInfo>() <= Message::PAYLOAD_SIZE);
+::static_assert::assert_eq!(mem::size_of::<ThreadTerminationInfo>() <= Message::PAYLOAD_SIZE);
 
 /// Number of process-creation reservations. This is the depth of the undelivered-creation buffer:
 /// it bounds how many processes may be created while the lifecycle consumer is stalled, not how many
@@ -62,14 +66,26 @@ const PROCESS_CREATION_RESERVATIONS: usize = ::config::kernel::MAX_PROCESSES;
 /// delivered. The excess over that bound is undelivered-termination buffer depth.
 const PROCESS_TERMINATION_RESERVATIONS: usize = ::config::kernel::MAX_PROCESSES;
 
-/// Number of lifecycle records that may be queued. Thread lifecycle records are not produced in
-/// this change, so the global thread limit does not consume queue capacity. Every admitted process
-/// owns at most one creation reservation and one eventual termination reservation.
-const LIFECYCLE_CAPACITY: usize =
-    match PROCESS_CREATION_RESERVATIONS.checked_add(PROCESS_TERMINATION_RESERVATIONS) {
+/// Number of thread-termination reservations. The permanent bootstrap kernel thread cannot
+/// terminate and therefore does not consume an undeliverable reservation.
+const THREAD_TERMINATION_RESERVATIONS: usize = match ::config::kernel::MAX_THREADS.checked_sub(1) {
+    Some(capacity) => capacity,
+    None => panic!("thread lifecycle capacity underflow"),
+};
+
+/// Number of lifecycle records that may be queued. This covers every credit even though credits
+/// retained by live processes and threads do not occupy queue slots.
+const LIFECYCLE_CAPACITY: usize = {
+    let process_capacity: usize =
+        match PROCESS_CREATION_RESERVATIONS.checked_add(PROCESS_TERMINATION_RESERVATIONS) {
+            Some(capacity) => capacity,
+            None => panic!("process lifecycle capacity overflow"),
+        };
+    match process_capacity.checked_add(THREAD_TERMINATION_RESERVATIONS) {
         Some(capacity) => capacity,
-        None => panic!("process lifecycle capacity overflow"),
-    };
+        None => panic!("thread lifecycle capacity overflow"),
+    }
+};
 
 //==================================================================================================
 // Lifecycle Notification
@@ -81,6 +97,8 @@ enum LifecycleNotification {
     Creation(ProcessCreationInfo, LifecycleCreationCredit),
     /// Process-termination record.
     Termination(ProcessTerminationInfo, LifecycleTerminationCredit),
+    /// Thread-termination record.
+    ThreadTermination(ThreadTerminationInfo, ThreadLifecycleTerminationCredit),
 }
 
 impl LifecycleNotification {
@@ -109,6 +127,11 @@ impl LifecycleNotification {
                 let info_bytes = info.to_ne_bytes();
                 payload[0..info_bytes.len()].copy_from_slice(&info_bytes);
                 MessageType::ProcessTerminationEvent
+            },
+            Self::ThreadTermination(info, _) => {
+                let info_bytes = info.to_ne_bytes();
+                payload[0..info_bytes.len()].copy_from_slice(&info_bytes);
+                MessageType::ThreadTerminationEvent
             },
         };
 
@@ -457,7 +480,7 @@ pub(super) struct LifecycleDisposal {
 ///
 /// # Description
 ///
-/// Orders the delivery domain shared by local IPC and process lifecycle notifications: it reserves
+/// Orders the delivery domain shared by local IPC and lifecycle notifications: it reserves
 /// lifecycle capacity, allocates the sequence number stamped on every committed item, holds records
 /// in production-sequence order, and tracks whether the lifecycle owner needs a deferred wakeup.
 ///
@@ -470,6 +493,8 @@ pub(super) struct DeliveryBroker {
     creation_reservations: LifecycleReservationPool<PROCESS_CREATION_RESERVATIONS>,
     /// Capacity reserved by live processes or queued process-termination records.
     termination_reservations: LifecycleReservationPool<PROCESS_TERMINATION_RESERVATIONS>,
+    /// Capacity reserved by live threads or queued thread-termination records.
+    thread_termination_reservations: LifecycleReservationPool<THREAD_TERMINATION_RESERVATIONS>,
     /// Does the lifecycle owner need a deferred wakeup attempt?
     lifecycle_wakeup_pending: bool,
     /// Has terminal shutdown disposal already run?
@@ -486,9 +511,13 @@ impl DeliveryBroker {
     ///
     /// Upon success, an empty delivery broker is returned. Otherwise, an error is returned.
     ///
+    /// # Errors
+    ///
+    /// This function returns an error if the lifecycle queue cannot be preallocated.
+    ///
     pub(super) fn new() -> Result<Self, Error> {
         let lifecycle: LifecycleQueue = LifecycleQueue::new().inspect_err(|error| {
-            error!("failed to preallocate process lifecycle queue (error={error:?})");
+            error!("failed to preallocate lifecycle queue (error={error:?})");
         })?;
 
         Ok(Self {
@@ -496,6 +525,7 @@ impl DeliveryBroker {
             lifecycle,
             creation_reservations: LifecycleReservationPool::new(),
             termination_reservations: LifecycleReservationPool::new(),
+            thread_termination_reservations: LifecycleReservationPool::new(),
             lifecycle_wakeup_pending: false,
             disposed: false,
         })
@@ -558,6 +588,9 @@ impl DeliveryBroker {
         self.creation_reservations
             .in_use()
             .checked_add(self.termination_reservations.in_use())
+            .and_then(|capacity| {
+                capacity.checked_add(self.thread_termination_reservations.in_use())
+            })
     }
 
     ///
@@ -615,6 +648,81 @@ impl DeliveryBroker {
     ///
     /// # Description
     ///
+    /// Reserves capacity for the future termination of a thread being created.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, a thread lifecycle reservation is returned. Otherwise, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an [`ErrorCode::OutOfMemory`] error if thread lifecycle capacity is
+    /// exhausted.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was already disposed.
+    ///
+    pub(super) fn try_reserve_thread_creation(
+        &mut self,
+    ) -> Result<ThreadLifecycleReservation, Error> {
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
+        if !self.thread_termination_reservations.try_reserve() {
+            let reason: &str = "thread lifecycle capacity exhausted";
+            error!("{reason}");
+            return Err(Error::new(ErrorCode::OutOfMemory, reason));
+        }
+
+        Ok(ThreadLifecycleReservation::new())
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Cancels the lifecycle reservation for a thread whose creation did not commit.
+    ///
+    /// # Parameters
+    ///
+    /// - `_reservation`: Thread lifecycle reservation to cancel.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was already disposed or if the reservation pool
+    /// is empty.
+    ///
+    pub(super) fn cancel_thread_creation(&mut self, _reservation: ThreadLifecycleReservation) {
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
+        self.thread_termination_reservations.release();
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Transfers a lifecycle reservation into a committed live thread.
+    ///
+    /// # Parameters
+    ///
+    /// - `reservation`: Reservation to transfer into the committed thread.
+    ///
+    /// # Returns
+    ///
+    /// A capacity credit for the future termination of the committed thread.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was already disposed.
+    ///
+    pub(super) fn commit_thread_creation(
+        &mut self,
+        reservation: ThreadLifecycleReservation,
+    ) -> ThreadLifecycleTerminationCredit {
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
+        reservation.into_credit()
+    }
+
+    ///
+    /// # Description
+    ///
     /// Commits a process-creation record in the ordered delivery domain.
     ///
     /// # Parameters
@@ -662,8 +770,49 @@ impl DeliveryBroker {
         self.lifecycle_wakeup_pending = true;
     }
 
-    /// Releases a termination credit when the process terminates without producing a lifecycle
+    ///
+    /// # Description
+    ///
+    /// Commits a thread-termination record in the ordered delivery domain.
+    ///
+    /// # Parameters
+    ///
+    /// - `credit`: Capacity credit reserved when the thread was created.
+    /// - `info`: Thread-termination record to queue.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was already disposed, the delivery sequence is
+    /// exhausted, or the preallocated lifecycle queue is full.
+    ///
+    pub(super) fn commit_thread_termination(
+        &mut self,
+        credit: ThreadLifecycleTerminationCredit,
+        info: ThreadTerminationInfo,
+    ) {
+        assert!(!self.disposed, "lifecycle delivery used after disposal");
+        let sequence: DeliverySequence = self.allocate_sequence();
+        self.lifecycle
+            .push_back((sequence, LifecycleNotification::ThreadTermination(info, credit)));
+        self.lifecycle_wakeup_pending = true;
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Releases a termination credit when a test process terminates without producing a lifecycle
     /// record.
+    ///
+    /// # Parameters
+    ///
+    /// - `credit`: Process-termination capacity credit to release.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was already disposed or if the reservation pool
+    /// is empty.
+    ///
+    #[cfg(feature = "test")]
     pub(super) fn release_termination(&mut self, _credit: LifecycleTerminationCredit) {
         assert!(!self.disposed, "lifecycle delivery used after disposal");
         self.termination_reservations.release();
@@ -810,10 +959,17 @@ impl DeliveryBroker {
     ///
     /// - `notification`: Lifecycle record whose reservation is released.
     ///
+    /// # Panics
+    ///
+    /// This function panics if the reservation pool corresponding to `notification` is empty.
+    ///
     fn release_notification(&mut self, notification: LifecycleNotification) {
         match notification {
             LifecycleNotification::Creation(..) => self.creation_reservations.release(),
             LifecycleNotification::Termination(..) => self.termination_reservations.release(),
+            LifecycleNotification::ThreadTermination(..) => {
+                self.thread_termination_reservations.release()
+            },
         }
     }
 
@@ -822,13 +978,18 @@ impl DeliveryBroker {
     ///
     /// Disposes all lifecycle state during terminal shutdown. Queued records are removed as
     /// undelivered and release the exact reservations they own. Any reservation that remains in a
-    /// pending creation or live process is then released because no further lifecycle transition
-    /// can occur after this terminal operation.
+    /// pending creation, live process, or live thread is then released because no further lifecycle
+    /// transition can occur after this terminal operation.
     ///
     /// # Returns
     ///
     /// Disposal accounting that distinguishes undelivered records from externally retained
     /// reservations.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was already disposed or if lifecycle reservation
+    /// accounting is inconsistent.
     ///
     pub(super) fn dispose(&mut self) -> LifecycleDisposal {
         assert!(!self.disposed, "lifecycle delivery was already disposed");
@@ -843,8 +1004,15 @@ impl DeliveryBroker {
 
         let creation_reservations: usize = self.creation_reservations.release_all();
         let termination_reservations: usize = self.termination_reservations.release_all();
-        let retained_reservations: usize =
+        let thread_termination_reservations: usize =
+            self.thread_termination_reservations.release_all();
+        let process_reservations: usize =
             match creation_reservations.checked_add(termination_reservations) {
+                Some(reservations) => reservations,
+                None => unreachable!("lifecycle disposal accounting overflow"),
+            };
+        let retained_reservations: usize =
+            match process_reservations.checked_add(thread_termination_reservations) {
                 Some(reservations) => reservations,
                 None => unreachable!("lifecycle disposal accounting overflow"),
             };
@@ -922,18 +1090,26 @@ mod test {
         DeliveryBroker,
         DeliverySequence,
         LIFECYCLE_CAPACITY,
+        THREAD_TERMINATION_RESERVATIONS,
     };
     use crate::pm::process::{
         LifecycleCreationReservation,
         LifecycleTerminationCredit,
+        ThreadLifecycleReservation,
+        ThreadLifecycleTerminationCredit,
     };
     use ::sys::{
         event::{
             ProcessCreationInfo,
             ProcessRole,
             ProcessTerminationInfo,
+            ThreadTerminationInfo,
         },
-        pm::ProcessIdentifier,
+        ipc::MessageType,
+        pm::{
+            ProcessIdentifier,
+            ThreadIdentifier,
+        },
         ExitStatus,
     };
 
@@ -1084,6 +1260,72 @@ mod test {
         true
     }
 
+    ///
+    /// # Description
+    ///
+    /// Verifies thread lifecycle ownership across cancellation, commit, delivery, and reuse.
+    ///
+    /// # Returns
+    ///
+    /// `true` if every ownership transition preserves the expected capacity accounting, otherwise
+    /// `false`.
+    ///
+    fn test_thread_lifecycle_reservation_ownership_is_stateful() -> bool {
+        let Some(mut broker) = new_broker() else {
+            return false;
+        };
+
+        let cancelled: ThreadLifecycleReservation = match broker.try_reserve_thread_creation() {
+            Ok(reservation) => reservation,
+            Err(error) => {
+                error!("thread lifecycle reservation failed (error={error:?})");
+                return false;
+            },
+        };
+        broker.cancel_thread_creation(cancelled);
+        if broker.capacity_in_use() != Some(0) {
+            error!("canceling a thread lifecycle reservation did not release capacity");
+            return false;
+        }
+
+        let reservation: ThreadLifecycleReservation = match broker.try_reserve_thread_creation() {
+            Ok(reservation) => reservation,
+            Err(error) => {
+                error!("released thread lifecycle capacity was not reusable (error={error:?})");
+                return false;
+            },
+        };
+        let credit: ThreadLifecycleTerminationCredit = broker.commit_thread_creation(reservation);
+        if broker.capacity_in_use() != Some(1) || broker.has_lifecycle() {
+            error!("thread creation commit changed reservation ownership or queued a record");
+            return false;
+        }
+
+        let info: ThreadTerminationInfo = ThreadTerminationInfo::new(
+            ProcessIdentifier::from(3),
+            ThreadIdentifier::from(7),
+            ExitStatus::from(11_u32),
+        );
+        broker.commit_thread_termination(credit, info);
+        let Some((_sequence, message)) = broker.peek_lifecycle(ProcessIdentifier::KERNEL) else {
+            error!("committed thread termination record was not selectable");
+            return false;
+        };
+        let info_bytes = info.to_ne_bytes();
+        if message.message_type != MessageType::ThreadTerminationEvent
+            || message.payload[..info_bytes.len()] != info_bytes
+        {
+            error!("thread termination record was serialized incorrectly");
+            return false;
+        }
+        if !commit_lifecycle(&mut broker) || broker.capacity_in_use() != Some(0) {
+            error!("thread termination dequeue did not release lifecycle capacity");
+            return false;
+        }
+
+        true
+    }
+
     /// Verifies a failed termination reservation rolls back the creation slot acquired first.
     fn test_termination_reservation_failure_rolls_back_creation() -> bool {
         let Some(mut broker) = new_broker() else {
@@ -1132,7 +1374,7 @@ mod test {
     ///
     /// Verifies deterministic backpressure and recovery while the lifecycle consumer is stalled.
     /// Every admitted process immediately terminates, proving that termination enqueue remains
-    /// infallible even as both preallocated reservation pools and the queue become full. The test
+    /// infallible even as all preallocated reservation pools and the queue become full. The test
     /// then drains and refills part of the queue to exercise ring wraparound before releasing all
     /// capacity through transactional dequeue.
     ///
@@ -1164,6 +1406,21 @@ mod test {
             };
             let credit: LifecycleTerminationCredit = broker.commit_creation(reservation, creation);
             broker.commit_termination(credit, termination);
+        }
+        let thread_termination: ThreadTerminationInfo =
+            ThreadTerminationInfo::new(pid, ThreadIdentifier::from(1), ExitStatus::ok());
+        for _ in 0..THREAD_TERMINATION_RESERVATIONS {
+            let reservation: ThreadLifecycleReservation = match broker.try_reserve_thread_creation()
+            {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    error!("thread lifecycle capacity exhausted too early (error={error:?})");
+                    return false;
+                },
+            };
+            let credit: ThreadLifecycleTerminationCredit =
+                broker.commit_thread_creation(reservation);
+            broker.commit_thread_termination(credit, thread_termination);
         }
 
         if broker.capacity_in_use() != Some(LIFECYCLE_CAPACITY)
@@ -1227,7 +1484,16 @@ mod test {
         broker.capacity_in_use() == Some(0)
     }
 
+    ///
+    /// # Description
+    ///
     /// Verifies terminal disposal releases queued and externally retained reservations separately.
+    ///
+    /// # Returns
+    ///
+    /// `true` if disposal reports and releases all queued and retained reservations, otherwise
+    /// `false`.
+    ///
     fn test_lifecycle_shutdown_disposal_accounts_undelivered_state() -> bool {
         let Some(mut broker) = new_broker() else {
             return false;
@@ -1272,8 +1538,40 @@ mod test {
                 return false;
             },
         };
+        let live_thread_reservation: ThreadLifecycleReservation =
+            match broker.try_reserve_thread_creation() {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    error!("failed to reserve live-thread fixture (error={error:?})");
+                    return false;
+                },
+            };
+        let _live_thread_credit: ThreadLifecycleTerminationCredit =
+            broker.commit_thread_creation(live_thread_reservation);
+        let terminated_thread_reservation: ThreadLifecycleReservation =
+            match broker.try_reserve_thread_creation() {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    error!("failed to reserve terminated-thread fixture (error={error:?})");
+                    return false;
+                },
+            };
+        let terminated_thread_credit: ThreadLifecycleTerminationCredit =
+            broker.commit_thread_creation(terminated_thread_reservation);
+        broker.commit_thread_termination(
+            terminated_thread_credit,
+            ThreadTerminationInfo::new(pid, ThreadIdentifier::from(1), ExitStatus::ok()),
+        );
+        let _pending_thread_reservation: ThreadLifecycleReservation =
+            match broker.try_reserve_thread_creation() {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    error!("failed to reserve pending-thread fixture (error={error:?})");
+                    return false;
+                },
+            };
         let disposal = broker.dispose();
-        if disposal.undelivered_records != 3 || disposal.retained_reservations != 3 {
+        if disposal.undelivered_records != 4 || disposal.retained_reservations != 5 {
             error!(
                 "lifecycle shutdown disposal reported incorrect accounting (undelivered={}, \
                  retained={})",
@@ -1291,11 +1589,20 @@ mod test {
         true
     }
 
+    ///
+    /// # Description
+    ///
     /// Runs all delivery broker in-kernel tests.
+    ///
+    /// # Returns
+    ///
+    /// `true` if every delivery broker test passes, otherwise `false`.
+    ///
     pub(super) fn test() -> bool {
         let mut passed: bool = true;
         passed &= run_test!(test_delivery_sequence_exhaustion_is_detected);
         passed &= run_test!(test_lifecycle_reservation_ownership_is_stateful);
+        passed &= run_test!(test_thread_lifecycle_reservation_ownership_is_stateful);
         passed &= run_test!(test_termination_reservation_failure_rolls_back_creation);
         passed &= run_test!(test_stalled_lifecycle_consumer_backpressures_and_recovers);
         passed &= run_test!(test_lifecycle_shutdown_disposal_accounts_undelivered_state);

--- a/src/kernel/src/pm/process/manager/mod.rs
+++ b/src/kernel/src/pm/process/manager/mod.rs
@@ -67,6 +67,7 @@ use crate::{
                     UNBLOCKABLE,
                 },
                 InterruptedProcess,
+                PendingProcessTermination,
                 ProcessRef,
                 ProcessRefMut,
                 ProcessState,
@@ -74,10 +75,13 @@ use crate::{
                 RunningProcess,
                 SleepingProcess,
                 ZombieProcess,
+                ZombieProcessTransition,
             },
             HarvestedProcess,
             LifecycleCreationReservation,
             LifecycleTerminationCredit,
+            ThreadLifecycleReservation,
+            ThreadLifecycleTerminationCredit,
         },
         sync::{
             condvar::Condvar,
@@ -88,6 +92,7 @@ use crate::{
         },
         thread::{
             InterruptReason,
+            PendingThreadTermination,
             ReadyThread,
             ThreadManager,
             ThreadRef,
@@ -240,6 +245,9 @@ pub struct ProcessManager {
     /// Injects one process-creation preparation failure after lifecycle capacity is reserved.
     #[cfg(feature = "test")]
     fail_next_lifecycle_creation: bool,
+    /// Injects one thread-creation preparation failure after lifecycle capacity is reserved.
+    #[cfg(feature = "test")]
+    fail_next_thread_lifecycle_creation: bool,
     /// Detached-thread zombies whose reaping was deferred because their
     /// `ContextInformation` was still needed by an in-progress context switch.
     deferred_reap: Vec<(ProcessIdentifier, ZombieThread)>,
@@ -305,6 +313,27 @@ impl PreparedProcess {
     ///
     /// # Description
     ///
+    /// Installs the capacity credit reserved for the prepared process's main thread termination.
+    ///
+    /// # Parameters
+    ///
+    /// - `credit`: Capacity credit to install in the prepared process's main thread.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the prepared process node is empty or the thread already owns a
+    /// termination credit.
+    ///
+    fn install_thread_termination_credit(&mut self, credit: ThreadLifecycleTerminationCredit) {
+        match self.node.front_mut() {
+            Some(process) => process.install_thread_termination_credit(credit),
+            None => unreachable!("prepared process node is empty"),
+        }
+    }
+
+    ///
+    /// # Description
+    ///
     /// Appends this process to a queue of ready processes.
     ///
     /// # Parameters
@@ -320,7 +349,7 @@ impl ProcessManager {
     ///
     /// # Description
     ///
-    /// Initializes the process manager and preallocates process lifecycle delivery capacity.
+    /// Initializes the process manager and preallocates lifecycle delivery capacity.
     ///
     /// # Parameters
     ///
@@ -374,6 +403,8 @@ impl ProcessManager {
             delivery,
             #[cfg(feature = "test")]
             fail_next_lifecycle_creation: false,
+            #[cfg(feature = "test")]
+            fail_next_thread_lifecycle_creation: false,
             deferred_reap: Vec::new(),
             deferred_exec_vmem: Vec::new(),
             daemon_pids: Vec::new(),
@@ -392,8 +423,8 @@ impl ProcessManager {
     ///
     /// # Description
     ///
-    /// Runs fallible process-creation preparation while holding lifecycle capacity for both the
-    /// creation record and the process's future termination record.
+    /// Runs fallible process-creation preparation while holding lifecycle capacity for the process
+    /// creation, process termination, and main-thread termination records.
     ///
     /// If preparation fails, this function releases the reservation before returning the error.
     /// Sequence allocation is deferred until the caller commits the prepared process.
@@ -408,24 +439,101 @@ impl ProcessManager {
     ///
     /// # Returns
     ///
-    /// Upon success, the creation reservation and prepared value are returned. Otherwise, an error
-    /// is returned instead.
+    /// Upon success, the process and thread reservations and prepared value are returned.
+    /// Otherwise, an error is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if lifecycle capacity cannot be reserved or if `prepare`
+    /// fails.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was already disposed.
     ///
     fn prepare_lifecycle_creation<T, F>(
         &mut self,
         prepare: F,
-    ) -> Result<(LifecycleCreationReservation, T), Error>
+    ) -> Result<(LifecycleCreationReservation, ThreadLifecycleReservation, T), Error>
     where
         F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         let reservation: LifecycleCreationReservation = self.delivery.try_reserve_creation()?;
+        let thread_reservation: ThreadLifecycleReservation =
+            match self.delivery.try_reserve_thread_creation() {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    self.delivery.cancel_creation(reservation);
+                    return Err(error);
+                },
+            };
         match prepare(self) {
-            Ok(prepared) => Ok((reservation, prepared)),
+            Ok(prepared) => Ok((reservation, thread_reservation, prepared)),
             Err(error) => {
+                self.delivery.cancel_thread_creation(thread_reservation);
                 self.delivery.cancel_creation(reservation);
                 Err(error)
             },
         }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Runs fallible thread preparation while holding its termination-record capacity.
+    ///
+    /// # Parameters
+    ///
+    /// - `prepare`: Fallible thread preparation to run while capacity is reserved.
+    ///
+    /// # Returns
+    ///
+    /// Upon success, the thread reservation and prepared value are returned. Otherwise, an error
+    /// is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if thread lifecycle capacity cannot be reserved, a test
+    /// failure is injected, or `prepare` fails.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was already disposed.
+    ///
+    fn prepare_thread_lifecycle_creation<T, F>(
+        &mut self,
+        prepare: F,
+    ) -> Result<(ThreadLifecycleReservation, T), Error>
+    where
+        F: FnOnce(&mut Self) -> Result<T, Error>,
+    {
+        let reservation: ThreadLifecycleReservation =
+            self.delivery.try_reserve_thread_creation()?;
+        #[cfg(feature = "test")]
+        if core::mem::take(&mut self.fail_next_thread_lifecycle_creation) {
+            self.delivery.cancel_thread_creation(reservation);
+            return Err(Error::new(
+                ErrorCode::OutOfMemory,
+                "injected thread lifecycle creation failure",
+            ));
+        }
+        match prepare(self) {
+            Ok(prepared) => Ok((reservation, prepared)),
+            Err(error) => {
+                self.delivery.cancel_thread_creation(reservation);
+                Err(error)
+            },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Injects one failure into the next standalone thread or `execv()` thread preparation.
+    ///
+    #[cfg(feature = "test")]
+    fn inject_thread_lifecycle_creation_failure(&mut self) {
+        self.fail_next_thread_lifecycle_creation = true;
     }
 
     ///
@@ -546,12 +654,16 @@ impl ProcessManager {
     /// Upon successful completion, the thread identifier of the new thread is returned.
     /// Otherwise, an error is returned instead.
     ///
-    /// # Safety Notes
+    /// # Errors
     ///
-    /// - `thread_create_args` must have valid fields, specifically:
-    ///   - `user_wrapper_fn` must point to a user memory region that is executable.
-    ///   - `user_fn` must point to a user memory region that is executable.
-    ///   - `user_stack` must point to a user memory region that is writable.
+    /// This function returns an error if lifecycle capacity or a thread identifier cannot be
+    /// reserved, or if the thread execution context cannot be prepared.
+    ///
+    /// # Panics
+    ///
+    /// This function panics in debug builds if `thread_create_args.user_fn` is not a user address
+    /// or `pid` does not identify the running process. It also panics if lifecycle delivery was
+    /// disposed or a committed thread already owns a termination credit.
     ///
     pub fn create_thread(
         &mut self,
@@ -568,33 +680,29 @@ impl ProcessManager {
             "create_thread: pid must match the running process"
         );
 
-        // Reserve the next thread identifier early, before any resource allocation. Reap pending
-        // zombies on demand if the system-wide thread cap has been reached, so a terminate-heavy
-        // workload is not spuriously refused while reclaimable slots are awaiting harvest.
-        let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) =
-            self.try_next_tid_reaping(mm)?;
-
-        let enable_interrupts: bool = self.interrupt_capable;
-
-        // Create a kernel context.
-        let (kernel_stack, context): (KernelStack, ContextInformation) = Self::forge_user_context(
-            mm,
-            self.get_running_mut().state_mut().vmem_mut(),
-            thread_create_args,
-            enable_interrupts,
-        )?;
-
-        //==============================================================
-        // NOTE: if we fail beyond this point we need to page mappings.
-        //==============================================================
-
-        // A new thread inherits the creating (running) thread's blocked-signal mask, as POSIX
-        // requires; the signal dispositions are process-wide and therefore already shared.
-        let inherited_blocked: SigSet = self
-            .get_running_mut()
-            .running_mut()
-            .thread_state()
-            .blocked();
+        let (reservation, (tid, next_tid, kernel_stack, context, inherited_blocked)): (
+            ThreadLifecycleReservation,
+            (ThreadIdentifier, ThreadIdentifier, KernelStack, ContextInformation, SigSet),
+        ) = self.prepare_thread_lifecycle_creation(|manager| {
+            // Reserve the next thread identifier early, before any resource allocation. Reap
+            // pending zombies on demand if the system-wide thread cap has been reached.
+            let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) =
+                manager.try_next_tid_reaping(mm)?;
+            let enable_interrupts: bool = manager.interrupt_capable;
+            let (kernel_stack, context): (KernelStack, ContextInformation) =
+                Self::forge_user_context(
+                    mm,
+                    manager.get_running_mut().state_mut().vmem_mut(),
+                    thread_create_args,
+                    enable_interrupts,
+                )?;
+            let inherited_blocked: SigSet = manager
+                .get_running_mut()
+                .running_mut()
+                .thread_state()
+                .blocked();
+            Ok((tid, next_tid, kernel_stack, context, inherited_blocked))
+        })?;
 
         Ok(no_fail!(ThreadIdentifier, {
             // Create a new thread.
@@ -605,6 +713,11 @@ impl ProcessManager {
                 thread_create_args.user_tda,
                 context,
             );
+            let termination_credit: ThreadLifecycleTerminationCredit =
+                self.delivery.commit_thread_creation(reservation);
+            ready_thread
+                .thread_state_mut()
+                .install_termination_credit(termination_credit);
             ready_thread
                 .thread_state_mut()
                 .set_blocked(inherited_blocked);
@@ -1280,6 +1393,17 @@ impl ProcessManager {
     /// Upon successful completion, the process identifier of the new process is returned.
     /// Otherwise, an error is returned instead.
     ///
+    /// # Errors
+    ///
+    /// This function returns an error if process or thread capacity is exhausted, lifecycle
+    /// capacity cannot be reserved, or the process image cannot be prepared.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was disposed, a lifecycle sequence is exhausted,
+    /// the preallocated lifecycle queue is full, or a committed process or thread already owns its
+    /// termination credit.
+    ///
     pub fn create_process(
         &mut self,
         mm: &mut VirtMemoryManager,
@@ -1317,8 +1441,9 @@ impl ProcessManager {
                     .any(|(registered, _)| registered == name)
             });
 
-        let (reservation, (pid, next_pid, next_tid, parent_pid, mut prepared)): (
+        let (reservation, thread_reservation, (pid, next_pid, next_tid, parent_pid, mut prepared)): (
             LifecycleCreationReservation,
+            ThreadLifecycleReservation,
             (
                 ProcessIdentifier,
                 ProcessIdentifier,
@@ -1382,7 +1507,10 @@ impl ProcessManager {
             let termination_credit = self
                 .delivery
                 .commit_creation(reservation, ProcessCreationInfo::new(pid, parent_pid, role));
+            let thread_termination_credit: ThreadLifecycleTerminationCredit =
+                self.delivery.commit_thread_creation(thread_reservation);
             prepared.install_termination_credit(termination_credit);
+            prepared.install_thread_termination_credit(thread_termination_credit);
             prepared.enqueue(&mut self.ready);
 
             Ok(pid)
@@ -1636,6 +1764,15 @@ impl ProcessManager {
     ///   resources that prevent it from being duplicated.
     /// - [`ErrorCode::InvalidArgument`]: The supplied entry function or stack does not lie
     ///   within the user address space.
+    /// - [`ErrorCode::OutOfMemory`]: Process, thread, or lifecycle capacity is exhausted, or the
+    ///   child process cannot be prepared.
+    ///
+    /// # Panics
+    ///
+    /// This function panics in debug builds if `pid` does not identify the running process. It also
+    /// panics if lifecycle delivery was disposed, a lifecycle sequence is exhausted, the
+    /// preallocated lifecycle queue is full, or a committed process or thread already owns its
+    /// termination credit.
     ///
     pub fn duplicate_process(
         &mut self,
@@ -1692,8 +1829,9 @@ impl ProcessManager {
             return Err(Error::new(ErrorCode::OutOfMemory, reason));
         }
         #[allow(clippy::type_complexity)]
-        let (reservation, (child_pid, next_pid, next_tid, mut prepared)): (
+        let (reservation, thread_reservation, (child_pid, next_pid, next_tid, mut prepared)): (
             LifecycleCreationReservation,
+            ThreadLifecycleReservation,
             (ProcessIdentifier, ProcessIdentifier, ThreadIdentifier, PreparedProcess),
         ) = self.prepare_lifecycle_creation(|manager| {
             // Reserve identifiers early, before allocation. Reap pending zombies on demand if the
@@ -1766,7 +1904,10 @@ impl ProcessManager {
             let termination_credit = self
                 .delivery
                 .commit_creation(reservation, ProcessCreationInfo::new(child_pid, pid, role));
+            let thread_termination_credit: ThreadLifecycleTerminationCredit =
+                self.delivery.commit_thread_creation(thread_reservation);
             prepared.install_termination_credit(termination_credit);
+            prepared.install_thread_termination_credit(thread_termination_credit);
             prepared.enqueue(&mut self.ready);
 
             Ok(child_pid)
@@ -2101,6 +2242,19 @@ impl ProcessManager {
     ///
     /// On failure, an error is returned and the calling process is left unchanged.
     ///
+    /// # Errors
+    ///
+    /// This function returns an error if the kernel process attempts to replace its image, the
+    /// calling process is not single-threaded, the process owns resources that cannot survive an
+    /// image replacement, lifecycle capacity is exhausted, or the new image cannot be prepared.
+    ///
+    /// # Panics
+    ///
+    /// This function panics in debug builds if `pid` does not identify the running process. It also
+    /// panics if lifecycle delivery was disposed, the outgoing or replacement thread does not own
+    /// the expected termination credit, the delivery sequence is exhausted, or the preallocated
+    /// lifecycle queue is full.
+    ///
     #[allow(clippy::type_complexity)]
     fn do_execv(
         &mut self,
@@ -2151,24 +2305,29 @@ impl ProcessManager {
             return Err(Error::new(ErrorCode::OperationNotPermitted, reason));
         }
 
-        // Reserve a thread identifier for the new image's main thread.
-        let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) = self.tm.try_next_tid()?;
+        let (reservation, (tid, next_tid, vmem, mut thread)): (
+            ThreadLifecycleReservation,
+            (ThreadIdentifier, ThreadIdentifier, Vmem, ReadyThread),
+        ) = self.prepare_thread_lifecycle_creation(|manager| {
+            // Reserve a thread identifier for the new image's main thread.
+            let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) =
+                manager.tm.try_next_tid()?;
 
-        // Build the new address space and main thread, streaming the ELF image directly from the
-        // calling process's (still-active) address space. All fallible work happens here; on
-        // failure the running process is left untouched.
-        let src_vmem: &Vmem = self.get_running().state().vmem();
-        let (vmem, thread): (Vmem, ReadyThread) = Self::build_user_image(
-            mm,
-            &self.tm,
-            src_vmem,
-            tid,
-            |mm, dst_vmem| mm.load_elf_from_user(dst_vmem, src_vmem, elf_base, elf_len),
-            args,
-            env,
-            false,
-            self.interrupt_capable,
-        )?;
+            // Build the new address space and main thread while the calling image remains intact.
+            let src_vmem: &Vmem = manager.get_running().state().vmem();
+            let (vmem, thread): (Vmem, ReadyThread) = Self::build_user_image(
+                mm,
+                &manager.tm,
+                src_vmem,
+                tid,
+                |mm, dst_vmem| mm.load_elf_from_user(dst_vmem, src_vmem, elf_base, elf_len),
+                args,
+                env,
+                false,
+                manager.interrupt_capable,
+            )?;
+            Ok((tid, next_tid, vmem, thread))
+        })?;
 
         //==============================================================
         // Commit. Everything below is infallible.
@@ -2183,15 +2342,23 @@ impl ProcessManager {
                 Option<VirtualAddress>,
             ),
             {
+                let termination_credit: ThreadLifecycleTerminationCredit =
+                    self.delivery.commit_thread_creation(reservation);
+                thread
+                    .thread_state_mut()
+                    .install_termination_credit(termination_credit);
+
                 // Swap the address space and running thread in place, retiring the outgoing
                 // thread.
-                let (old_vmem, old_zombie, from_ctx, to_ctx, user_tda): (
+                let (old_vmem, old_zombie, pending_termination, from_ctx, to_ctx, user_tda): (
                     Vmem,
                     ZombieThread,
+                    PendingThreadTermination,
                     *mut ContextInformation,
                     *mut ContextInformation,
                     Option<VirtualAddress>,
                 ) = self.get_running_mut().replace_image(vmem, thread);
+                Self::commit_thread_termination(&mut self.delivery, pending_termination);
 
                 // The new thread is now live; commit its reserved identifier.
                 self.tm.commit_next_tid(next_tid);
@@ -2232,6 +2399,13 @@ impl ProcessManager {
     /// - A pointer to the context information of the next thread.
     /// - An optional base address for the user-space thread data area of the next thread to run.
     ///
+    /// # Panics
+    ///
+    /// This function panics if the kernel process attempts to exit, process-manager state cannot
+    /// provide a running or ready process during the context switch, a terminating thread or
+    /// process lacks its termination credit, lifecycle delivery was disposed, the delivery sequence
+    /// is exhausted, or the preallocated lifecycle queue is full.
+    ///
     fn do_exit(
         &mut self,
         status: ExitStatus,
@@ -2265,18 +2439,22 @@ impl ProcessManager {
         self.cleanup_rendezvous(running_process.state().pid(), "do_exit");
 
         // Terminate the calling thread.
-        let previous_context: *mut ContextInformation = match running_process.exit(status) {
-            // The calling process still has runnable threads, put it in the list of ready processes.
-            Ok((runnable_process, previous_context)) => {
-                self.ready.push_back(runnable_process);
-                previous_context
-            },
-            // The calling process has only sleeping threads left, put it in the list of zombies processes.
-            Err((zombie_process, previous_context)) => {
-                self.zombies.push_back(zombie_process);
-                previous_context
-            },
-        };
+        let previous_context: *mut ContextInformation =
+            match running_process.exit(status, &mut |pending| {
+                Self::commit_thread_termination(&mut self.delivery, pending);
+            }) {
+                // The calling process still has runnable threads, put it in the list of ready processes.
+                Ok((runnable_process, previous_context)) => {
+                    self.ready.push_back(runnable_process);
+                    previous_context
+                },
+                // The calling process has only sleeping threads left, put it in the list of zombies processes.
+                Err((transition, previous_context)) => {
+                    let zombie_process: ZombieProcess = self.commit_zombie_process(transition);
+                    self.zombies.push_back(zombie_process);
+                    previous_context
+                },
+            };
 
         // Schedule another thread to run.
         let next_process: RunnableProcess = self.take_earliest_ready();
@@ -2314,13 +2492,12 @@ impl ProcessManager {
     /// - A pointer to the context information of the next thread.
     /// - An optional base address for the user-space thread data area of the next thread to run.
     ///
-    /// # Safety
+    /// # Panics
     ///
-    /// This function is unsafe because it may panic.
-    ///
-    /// This function is safe to use if and only if the following conditions are met:
-    ///
-    /// - The calling process is not the kernel process.
+    /// This function panics if the kernel process attempts to exit a thread, process-manager state
+    /// cannot provide a running or ready process during the context switch, the terminating thread
+    /// or process lacks its termination credit, lifecycle delivery was disposed, the delivery
+    /// sequence is exhausted, or the preallocated lifecycle queue is full.
     ///
     fn do_exit_thread(
         &mut self,
@@ -2358,7 +2535,9 @@ impl ProcessManager {
 
         // Terminate the calling thread and schedule another thread to run.
         let (join_cond, previous_context): (Condvar, *mut ContextInformation) =
-            match running_process.exit_thread(status) {
+            match running_process.exit_thread(status, &mut |pending| {
+                Self::commit_thread_termination(&mut self.delivery, pending);
+            }) {
                 // The calling process still has runnable threads, put it in the list of ready processes.
                 (Ok((join_cond, runnable_process, previous_context)), deferred_zombie) => {
                     let pid: ProcessIdentifier = runnable_process.state().pid();
@@ -2378,11 +2557,12 @@ impl ProcessManager {
                     (join_cond, previous_context)
                 },
                 // The calling process has only zombie threads left, put it in the list of zombies processes.
-                (Err(Err((join_cond, mut zombie_process, previous_context))), deferred_zombie) => {
+                (Err(Err((join_cond, transition, previous_context))), deferred_zombie) => {
                     debug_assert!(
                         deferred_zombie.is_none(),
                         "deferred zombie must be None when no other threads remain"
                     );
+                    let mut zombie_process: ZombieProcess = self.commit_zombie_process(transition);
                     let purged_messages: usize = zombie_process.state_mut().purge_messages();
                     self.note_messages_purged(purged_messages);
                     self.zombies.push_back(zombie_process);
@@ -2408,6 +2588,30 @@ impl ProcessManager {
         (next_pid, next_tid, join_cond, previous_context, next_context, user_tda)
     }
 
+    ///
+    /// # Description
+    ///
+    /// Terminates a non-running process and marks its remaining threads for termination.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the process to terminate.
+    ///
+    /// # Returns
+    ///
+    /// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an [`ErrorCode::InvalidArgument`] error if `pid` identifies the kernel
+    /// or running process, and an [`ErrorCode::NoSuchProcess`] error if the process does not exist.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if an immediately terminating thread or process lacks its termination
+    /// credit, lifecycle delivery was disposed, the delivery sequence is exhausted, or the
+    /// preallocated lifecycle queue is full.
+    ///
     pub fn terminate(&mut self, pid: ProcessIdentifier) -> Result<(), Error> {
         // Check if terminating kernel process.
         if pid == ProcessIdentifier::KERNEL {
@@ -2437,13 +2641,16 @@ impl ProcessManager {
         // Check if target process is ready.
         if let Some(process) = self.ready.iter().position(|p| p.state().pid() == pid) {
             let process: RunnableProcess = self.ready.remove(process);
-            match process.terminate() {
+            match process.terminate(&mut |pending| {
+                Self::commit_thread_termination(&mut self.delivery, pending);
+            }) {
                 Ok(interrupted_process) => {
                     let runnable_process: RunnableProcess = interrupted_process.resume();
                     self.ready.push_back(runnable_process);
                     return Ok(());
                 },
-                Err(zombie_process) => {
+                Err(transition) => {
+                    let zombie_process: ZombieProcess = self.commit_zombie_process(transition);
                     self.zombies.push_back(zombie_process);
                     return Ok(());
                 },
@@ -3332,25 +3539,48 @@ impl ProcessManager {
     ///
     /// # Description
     ///
-    /// Commits a harvested process termination to the ordered delivery broker.
+    /// Commits a pending thread termination to the ordered delivery broker.
     ///
     /// # Parameters
     ///
-    /// - `termination`: Harvested process termination and its reserved capacity credit.
+    /// - `delivery`: Delivery broker that receives the termination record.
+    /// - `pending`: Pending thread termination and its reserved capacity credit.
     ///
-    pub(crate) fn commit_process_termination(&mut self, termination: HarvestedProcess) {
-        let (info, credit) = termination.into_parts();
-        self.delivery.commit_termination(credit, info);
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was disposed, the delivery sequence is exhausted,
+    /// or the preallocated lifecycle queue is full.
+    ///
+    fn commit_thread_termination(delivery: &mut DeliveryBroker, pending: PendingThreadTermination) {
+        let (info, credit) = pending.into_parts();
+        delivery.commit_thread_termination(credit, info);
     }
 
-    /// Releases the capacity credit of a harvested process without producing a lifecycle record.
-    pub(crate) fn release_process_termination(
-        &mut self,
-        termination: HarvestedProcess,
-    ) -> ProcessTerminationInfo {
-        let (info, credit) = termination.into_parts();
-        self.delivery.release_termination(credit);
-        info
+    ///
+    /// # Description
+    ///
+    /// Commits a process termination at zombie-process creation and returns the zombie.
+    ///
+    /// # Parameters
+    ///
+    /// - `transition`: Zombie-process transition containing the process and pending termination.
+    ///
+    /// # Returns
+    ///
+    /// The zombie process whose termination record was committed.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle delivery was disposed, the delivery sequence is exhausted,
+    /// or the preallocated lifecycle queue is full.
+    ///
+    fn commit_zombie_process(&mut self, transition: ZombieProcessTransition) -> ZombieProcess {
+        let (zombie, pending): (ZombieProcess, PendingProcessTermination) = transition.into_parts();
+        let (pid, parent, status, credit) = pending.into_parts();
+        let role: ProcessRole = self.classify_role(pid, parent);
+        self.delivery
+            .commit_termination(credit, ProcessTerminationInfo::new(pid, status, parent, role));
+        zombie
     }
 
     ///
@@ -3358,11 +3588,16 @@ impl ProcessManager {
     ///
     /// Disposes lifecycle state that cannot be delivered after terminal kernel shutdown begins.
     ///
+    /// # Panics
+    ///
+    /// This function panics if lifecycle state was already disposed or its reservation accounting
+    /// is inconsistent.
+    ///
     pub(crate) fn dispose_lifecycle(&mut self) {
         let disposal: LifecycleDisposal = self.delivery.dispose();
         if disposal.undelivered_records != 0 || disposal.retained_reservations != 0 {
             warn!(
-                "disposed process lifecycle state at shutdown (undelivered_records={}, \
+                "disposed lifecycle state at shutdown (undelivered_records={}, \
                  retained_reservations={})",
                 disposal.undelivered_records, disposal.retained_reservations
             );
@@ -3432,9 +3667,6 @@ impl ProcessManager {
     /// [`Self::reap_deferred_zombie_threads`]) so that detached threads do not reintroduce the same
     /// spurious exhaustion.
     ///
-    /// Each harvested termination is committed to the ordered delivery broker so it remains
-    /// observable exactly as if the zombie had been harvested by the idle loop.
-    ///
     /// The process manager daemon ([`ProcessIdentifier::PROCD`]) is never reaped here. Harvesting
     /// PROCD is the kernel's shutdown signal, which is observed only by the idle-loop harvester
     /// ([`crate::kcall::handler::kcall_handler`]). Reaping it on this path would consume that
@@ -3462,10 +3694,7 @@ impl ProcessManager {
                 }
             }
             match self.harvest_zombies(mm) {
-                Ok(Some(termination)) => {
-                    self.commit_process_termination(termination);
-                    reaped += 1;
-                },
+                Ok(Some(_termination)) => reaped += 1,
                 Ok(None) => break,
                 Err(e) => {
                     error!("failed to harvest zombies during admission: {:?}", e);
@@ -3577,6 +3806,11 @@ impl ProcessManager {
     /// Upon success, the reserved thread identifier together with the next thread identifier to
     /// commit. Otherwise, an error is returned.
     ///
+    /// # Errors
+    ///
+    /// This function returns an error if the system-wide thread capacity remains exhausted after
+    /// reclaiming pending zombies, or if the thread identifier would overflow.
+    ///
     fn try_next_tid_reaping(
         &mut self,
         mm: &mut VirtMemoryManager,
@@ -3597,6 +3831,26 @@ impl ProcessManager {
         }
     }
 
+    ///
+    /// # Description
+    ///
+    /// Harvests the oldest zombie process and reclaims the resources owned by all of its threads.
+    /// Lifecycle records are not produced here because they commit when the corresponding zombie
+    /// transitions are created.
+    ///
+    /// # Parameters
+    ///
+    /// - `mm`: Virtual memory manager used to reclaim user-stack and address-space pages.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Some(termination))` if a zombie process was harvested, or `Ok(None)` if no zombie process
+    /// is pending.
+    ///
+    /// # Errors
+    ///
+    /// This function currently logs resource-reclamation failures and does not return an error.
+    ///
     pub(crate) fn harvest_zombies(
         &mut self,
         mm: &mut VirtMemoryManager,
@@ -3664,18 +3918,13 @@ impl ProcessManager {
             );
         }
 
-        // Build the authoritative termination record. The parent and role are known to the kernel,
-        // which spawns the init process and the daemons directly and recorded which identifiers are
-        // daemons at spawn time, so subscribers do not have to re-infer them from race-prone state.
+        // Preserve termination metadata for shutdown detection and diagnostics. The lifecycle
+        // record was already committed when this process first transitioned to zombie state.
         let pid: ProcessIdentifier = state.pid();
         let parent: ProcessIdentifier = state.ppid();
         let role: ProcessRole = self.classify_role(pid, parent);
-        let termination_credit = match state.take_termination_credit() {
-            Some(credit) => credit,
-            None => unreachable!("harvested user process must own a termination credit"),
-        };
         let info: ProcessTerminationInfo = ProcessTerminationInfo::new(pid, status, parent, role);
-        Ok(Some(HarvestedProcess::new(info, termination_credit)))
+        Ok(Some(HarvestedProcess::new(info)))
     }
 
     ///

--- a/src/kernel/src/pm/process/manager/test.rs
+++ b/src/kernel/src/pm/process/manager/test.rs
@@ -15,15 +15,34 @@ use crate::hal::arch::{
     split_kcall_result,
 };
 use crate::{
+    hal::arch::{
+        x86::cpu::FpuState,
+        ContextInformation,
+    },
     ipc::Mailbox,
     mm::{
         elf::Elf32Fhdr,
         VirtMemoryManager,
+        Vmem,
     },
     pm::{
         process::{
+            new_test_process_termination_credit,
+            new_test_thread_termination_credit,
+            state::{
+                PendingProcessTermination,
+                RunnableProcess,
+                RunningProcess,
+                ZombieProcess,
+            },
             LifecycleCreationReservation,
             LifecycleTerminationCredit,
+            ThreadLifecycleReservation,
+            ThreadLifecycleTerminationCredit,
+        },
+        thread::{
+            ReadyThread,
+            ThreadManager,
         },
         ProcessManager,
     },
@@ -34,6 +53,7 @@ use ::sys::{
         ProcessCreationInfo,
         ProcessRole,
         ProcessTerminationInfo,
+        ThreadTerminationInfo,
     },
     ipc::{
         Message,
@@ -131,6 +151,171 @@ fn receive_lifecycle(broker: &mut DeliveryBroker) -> Option<Message> {
     let (sequence, message): (DeliverySequence, Message) = broker.peek_lifecycle(test_pid())?;
     broker.commit_lifecycle(sequence);
     Some(message)
+}
+
+///
+/// # Description
+///
+/// Receives one lifecycle message and verifies its type and serialized payload.
+///
+/// # Parameters
+///
+/// - `broker`: Delivery broker from which to receive the lifecycle record.
+/// - `message_type`: Expected message type.
+/// - `expected_payload`: Expected serialized payload prefix.
+///
+/// # Returns
+///
+/// `true` if the next lifecycle message matches the expected type and payload, otherwise `false`.
+///
+/// # Panics
+///
+/// This function panics if `expected_payload` is larger than [`Message::PAYLOAD_SIZE`].
+///
+fn receive_expected_lifecycle(
+    broker: &mut DeliveryBroker,
+    message_type: MessageType,
+    expected_payload: &[u8],
+) -> bool {
+    let message: Message = match receive_lifecycle(broker) {
+        Some(message) => message,
+        None => {
+            error!("expected lifecycle record was not queued (type={message_type:?})");
+            return false;
+        },
+    };
+    if message.message_type != message_type
+        || message.payload[..expected_payload.len()] != *expected_payload
+    {
+        error!("lifecycle record did not match expected type or payload");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// Creates a local process manager whose running process is a single credited user thread.
+///
+/// # Returns
+///
+/// The local process-manager fixture, or [`None`] if its resources could not be prepared.
+///
+fn new_user_process_manager() -> Option<ProcessManager> {
+    // SAFETY: process-manager tests run on one core with interrupts disabled and hold no other
+    // reference to either global manager.
+    let global_pm: &ProcessManager = unsafe { ProcessManager::get() };
+    let mm: &VirtMemoryManager = unsafe { VirtMemoryManager::get() };
+    let root: Vmem = match mm.new_vmem(global_pm.current_vmem()) {
+        Ok(vmem) => vmem,
+        Err(error) => {
+            error!("failed to create local process-manager root vmem (error={error:?})");
+            return None;
+        },
+    };
+    let user_vmem: Vmem = match mm.new_vmem(global_pm.current_vmem()) {
+        Ok(vmem) => vmem,
+        Err(error) => {
+            error!("failed to create local user-process vmem (error={error:?})");
+            return None;
+        },
+    };
+    let (kernel, tm): (ReadyThread, ThreadManager) = crate::pm::thread::init();
+    let mut manager: ProcessManager = match ProcessManager::new(false, kernel, root, tm) {
+        Ok(manager) => manager,
+        Err(error) => {
+            error!("failed to create local process manager (error={error:?})");
+            return None;
+        },
+    };
+    let (tid, next_tid): (ThreadIdentifier, ThreadIdentifier) = match manager.tm.try_next_tid() {
+        Ok(ids) => ids,
+        Err(error) => {
+            error!("failed to reserve local user thread identifier (error={error:?})");
+            return None;
+        },
+    };
+    let thread: ReadyThread = ReadyThread::new(
+        tid,
+        Some(new_test_thread_termination_credit()),
+        None,
+        None,
+        None,
+        ContextInformation::default(),
+        // SAFETY: calls to FpuState::new are synchronized by the single-threaded test runner.
+        unsafe { FpuState::new() },
+    );
+    let pid: ProcessIdentifier = ProcessIdentifier::from(1);
+    let mut process: RunnableProcess =
+        RunnableProcess::new_uncommitted(pid, ProcessIdentifier::KERNEL, thread, user_vmem);
+    process.install_termination_credit(new_test_process_termination_credit());
+    let (running, reason, _ctx, _user_tda): (
+        RunningProcess,
+        Option<crate::pm::thread::InterruptReason>,
+        *mut ContextInformation,
+        Option<VirtualAddress>,
+    ) = process.run();
+    if reason.is_some() {
+        error!("local user process was unexpectedly interrupted");
+        return None;
+    }
+    manager.tm.commit_next_tid(next_tid);
+    manager.running = Some(running);
+    Some(manager)
+}
+
+///
+/// # Description
+///
+/// Snapshots state that must remain unchanged after failed standalone thread preparation.
+///
+/// # Parameters
+///
+/// - `pm`: Process manager to snapshot.
+///
+/// # Returns
+///
+/// A tuple containing the next thread identifiers, lifecycle capacity in use, running process and
+/// thread identifiers, and ready-queue length.
+///
+/// # Panics
+///
+/// This function panics if `pm` does not contain a running process.
+///
+fn thread_creation_state(
+    pm: &ProcessManager,
+) -> (
+    Option<(ThreadIdentifier, ThreadIdentifier)>,
+    Option<usize>,
+    ProcessIdentifier,
+    ThreadIdentifier,
+    usize,
+) {
+    (
+        pm.tm.try_next_tid().ok(),
+        pm.delivery.capacity_in_use(),
+        pm.get_running().state().pid(),
+        pm.get_running().get_tid(),
+        pm.ready.len(),
+    )
+}
+
+///
+/// # Description
+///
+/// Disarms and reports whether the standalone thread-preparation injection was consumed.
+///
+/// # Parameters
+///
+/// - `pm`: Process manager whose injection flag is disarmed.
+///
+/// # Returns
+///
+/// `true` if the injection was consumed by the call under test, otherwise `false`.
+///
+fn thread_injection_was_consumed(pm: &mut ProcessManager) -> bool {
+    !::core::mem::take(&mut pm.fail_next_thread_lifecycle_creation)
 }
 
 //==================================================================================================
@@ -344,6 +529,343 @@ fn test_duplicate_process_reservation_failure_rolls_back() -> bool {
         error!("duplicate_process() changed state after reservation rollback");
         return false;
     }
+    true
+}
+
+///
+/// # Description
+///
+/// Verifies ordinary thread preparation releases its reservation on failure.
+///
+/// # Returns
+///
+/// `true` if failed preparation leaves identifiers, process state, and lifecycle capacity
+/// unchanged, otherwise `false`.
+///
+fn test_create_thread_reservation_failure_rolls_back() -> bool {
+    let Some(mut pm) = new_user_process_manager() else {
+        return false;
+    };
+    let pid: ProcessIdentifier = pm.get_running().state().pid();
+    let args: ThreadCreateArgs = ThreadCreateArgs {
+        user_fn: VirtualAddress::from_raw_value(::config::memory_layout::USER_BASE_RAW),
+        user_fn_arg0: 0,
+        user_fn_arg1: 0,
+        user_stack_base: VirtualAddress::from_raw_value(
+            ::config::memory_layout::USER_STACK_TOP_RAW - ::arch::mem::PAGE_SIZE,
+        ),
+        user_stack_size: ::arch::mem::PAGE_SIZE,
+        user_tda: None,
+    };
+    let before = thread_creation_state(&pm);
+    pm.inject_thread_lifecycle_creation_failure();
+    // SAFETY: the local process manager is not aliased and tests run with interrupts disabled.
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+    match pm.create_thread(mm, pid, &args) {
+        Err(error) if error.code == ::sys::error::ErrorCode::OutOfMemory => {},
+        Err(error) => {
+            error!("injected create-thread failure returned wrong error (error={error:?})");
+            return false;
+        },
+        Ok(tid) => {
+            error!("create_thread() ignored injected reservation failure (tid={tid:?})");
+            return false;
+        },
+    }
+    if !thread_injection_was_consumed(&mut pm) || thread_creation_state(&pm) != before {
+        error!("create_thread() changed state or leaked capacity after reservation rollback");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// Verifies `execv()` replacement-thread preparation releases its reservation on failure.
+///
+/// # Returns
+///
+/// `true` if failed replacement preparation leaves the process and lifecycle capacity unchanged,
+/// otherwise `false`.
+///
+fn test_execv_thread_reservation_failure_rolls_back() -> bool {
+    let Some(mut pm) = new_user_process_manager() else {
+        return false;
+    };
+    let pid: ProcessIdentifier = pm.get_running().state().pid();
+    let before = thread_creation_state(&pm);
+    pm.inject_thread_lifecycle_creation_failure();
+    // SAFETY: the local process manager is not aliased and tests run with interrupts disabled.
+    let mm: &mut VirtMemoryManager = unsafe { VirtMemoryManager::get_mut() };
+    match pm.do_execv(
+        mm,
+        pid,
+        VirtualAddress::from_raw_value(::config::memory_layout::USER_BASE_RAW),
+        1,
+        "",
+        "",
+    ) {
+        Err(error) if error.code == ::sys::error::ErrorCode::OutOfMemory => {},
+        Err(error) => {
+            error!("injected execv preparation failure returned wrong error (error={error:?})");
+            return false;
+        },
+        Ok(_) => {
+            error!("execv() ignored injected thread reservation failure");
+            return false;
+        },
+    }
+    if !thread_injection_was_consumed(&mut pm) || thread_creation_state(&pm) != before {
+        error!("execv() changed state or leaked capacity after thread reservation rollback");
+        return false;
+    }
+    true
+}
+
+///
+/// # Description
+///
+/// Verifies creation, exact thread termination, and process termination production order.
+///
+/// # Returns
+///
+/// `true` if lifecycle records carry exact metadata, preserve ordering, and release all capacity,
+/// otherwise `false`.
+///
+fn test_zombie_transitions_produce_ordered_lifecycle_records() -> bool {
+    let Some(mut broker) = new_broker() else {
+        return false;
+    };
+    let pid: ProcessIdentifier = test_pid();
+    let parent: ProcessIdentifier = ProcessIdentifier::from(99);
+    let tid: ThreadIdentifier = test_tid();
+    let ready_tid: ThreadIdentifier = ThreadIdentifier::from(1001);
+    let status: ExitStatus = ExitStatus::from(0x1020_3040_u32);
+    let creation: ProcessCreationInfo = ProcessCreationInfo::new(pid, parent, ProcessRole::User);
+
+    let process_reservation: LifecycleCreationReservation = match broker.try_reserve_creation() {
+        Ok(reservation) => reservation,
+        Err(error) => {
+            error!("failed to reserve process lifecycle capacity (error={error:?})");
+            return false;
+        },
+    };
+    let thread_reservation: ThreadLifecycleReservation = match broker.try_reserve_thread_creation()
+    {
+        Ok(reservation) => reservation,
+        Err(error) => {
+            broker.cancel_creation(process_reservation);
+            error!("failed to reserve thread lifecycle capacity (error={error:?})");
+            return false;
+        },
+    };
+    let ready_thread_reservation: ThreadLifecycleReservation =
+        match broker.try_reserve_thread_creation() {
+            Ok(reservation) => reservation,
+            Err(error) => {
+                broker.cancel_thread_creation(thread_reservation);
+                broker.cancel_creation(process_reservation);
+                error!("failed to reserve ready-thread lifecycle capacity (error={error:?})");
+                return false;
+            },
+        };
+    let process_credit: LifecycleTerminationCredit =
+        broker.commit_creation(process_reservation, creation);
+    let thread_credit: ThreadLifecycleTerminationCredit =
+        broker.commit_thread_creation(thread_reservation);
+    let ready_thread_credit: ThreadLifecycleTerminationCredit =
+        broker.commit_thread_creation(ready_thread_reservation);
+
+    // SAFETY: process-manager tests run on one core with interrupts disabled and hold no other
+    // reference to either global manager.
+    let pm: &ProcessManager = unsafe { ProcessManager::get() };
+    let mm: &VirtMemoryManager = unsafe { VirtMemoryManager::get() };
+    let vmem: Vmem = match mm.new_vmem(pm.current_vmem()) {
+        Ok(vmem) => vmem,
+        Err(error) => {
+            error!("failed to create lifecycle transition vmem (error={error:?})");
+            return false;
+        },
+    };
+    let thread: ReadyThread = ReadyThread::new(
+        tid,
+        Some(thread_credit),
+        None,
+        None,
+        None,
+        ContextInformation::default(),
+        // SAFETY: calls to FpuState::new are synchronized by the single-threaded test runner.
+        unsafe { FpuState::new() },
+    );
+    let mut process: RunnableProcess = RunnableProcess::new_uncommitted(pid, parent, thread, vmem);
+    process.install_termination_credit(process_credit);
+    let (mut running, reason, _ctx, _user_tda) = process.run();
+    if reason.is_some() {
+        error!("new lifecycle transition fixture was unexpectedly interrupted");
+        return false;
+    }
+    running.add_thread(ReadyThread::new(
+        ready_tid,
+        Some(ready_thread_credit),
+        None,
+        None,
+        None,
+        ContextInformation::default(),
+        // SAFETY: calls to FpuState::new are synchronized by the single-threaded test runner.
+        unsafe { FpuState::new() },
+    ));
+
+    let (transition, _ctx) = match running.exit(status, &mut |pending| {
+        ProcessManager::commit_thread_termination(&mut broker, pending);
+    }) {
+        Err(transition) => transition,
+        Ok(_) => {
+            error!("process with a ready sibling did not transition to zombie state");
+            return false;
+        },
+    };
+    let (zombie, pending): (ZombieProcess, PendingProcessTermination) = transition.into_parts();
+    let (actual_pid, actual_parent, actual_status, process_credit) = pending.into_parts();
+    if actual_pid != pid || actual_parent != parent || actual_status != status {
+        error!("zombie process transition changed authoritative termination metadata");
+        return false;
+    }
+    let process_termination: ProcessTerminationInfo =
+        ProcessTerminationInfo::new(pid, status, parent, ProcessRole::User);
+    broker.commit_termination(process_credit, process_termination);
+
+    let thread_termination: ThreadTerminationInfo = ThreadTerminationInfo::new(pid, tid, status);
+    let ready_thread_termination: ThreadTerminationInfo =
+        ThreadTerminationInfo::new(pid, ready_tid, ::sys::error::ErrorCode::Interrupted.into());
+    if !receive_expected_lifecycle(
+        &mut broker,
+        MessageType::ProcessCreationEvent,
+        &creation.to_ne_bytes(),
+    ) || !receive_expected_lifecycle(
+        &mut broker,
+        MessageType::ThreadTerminationEvent,
+        &thread_termination.to_ne_bytes(),
+    ) || !receive_expected_lifecycle(
+        &mut broker,
+        MessageType::ThreadTerminationEvent,
+        &ready_thread_termination.to_ne_bytes(),
+    ) || !receive_expected_lifecycle(
+        &mut broker,
+        MessageType::ProcessTerminationEvent,
+        &process_termination.to_ne_bytes(),
+    ) {
+        return false;
+    }
+
+    let (zombie_threads, _state, buried_status) = zombie.bury();
+    let (mut remaining, first) = zombie_threads.pop_front();
+    let _ = first.harvest();
+    while let Some(thread) = remaining.pop_front() {
+        let _ = thread.harvest();
+    }
+    if buried_status != status || broker.has_lifecycle() || broker.capacity_in_use() != Some(0) {
+        error!("zombie reclamation produced a duplicate or retained lifecycle capacity");
+        return false;
+    }
+
+    true
+}
+
+///
+/// # Description
+///
+/// Verifies `execv()` retirement emits one zero-status thread record and keeps the process live.
+///
+/// # Returns
+///
+/// `true` if image replacement emits only the outgoing thread record and preserves the process,
+/// otherwise `false`.
+///
+fn test_exec_replacement_produces_thread_termination_only() -> bool {
+    let Some(mut broker) = new_broker() else {
+        return false;
+    };
+    let reservation: ThreadLifecycleReservation = match broker.try_reserve_thread_creation() {
+        Ok(reservation) => reservation,
+        Err(error) => {
+            error!("failed to reserve exec retirement capacity (error={error:?})");
+            return false;
+        },
+    };
+    let old_credit: ThreadLifecycleTerminationCredit = broker.commit_thread_creation(reservation);
+    let pid: ProcessIdentifier = test_pid();
+    let old_tid: ThreadIdentifier = test_tid();
+    let new_tid: ThreadIdentifier = ThreadIdentifier::from(1001);
+
+    // SAFETY: process-manager tests run on one core with interrupts disabled and hold no other
+    // reference to either global manager.
+    let pm: &ProcessManager = unsafe { ProcessManager::get() };
+    let mm: &VirtMemoryManager = unsafe { VirtMemoryManager::get() };
+    let old_vmem: Vmem = match mm.new_vmem(pm.current_vmem()) {
+        Ok(vmem) => vmem,
+        Err(error) => {
+            error!("failed to create outgoing exec vmem (error={error:?})");
+            return false;
+        },
+    };
+    let new_vmem: Vmem = match mm.new_vmem(pm.current_vmem()) {
+        Ok(vmem) => vmem,
+        Err(error) => {
+            error!("failed to create replacement exec vmem (error={error:?})");
+            return false;
+        },
+    };
+    let old_thread: ReadyThread = ReadyThread::new(
+        old_tid,
+        Some(old_credit),
+        None,
+        None,
+        None,
+        ContextInformation::default(),
+        // SAFETY: calls to FpuState::new are synchronized by the single-threaded test runner.
+        unsafe { FpuState::new() },
+    );
+    let mut process: RunnableProcess =
+        RunnableProcess::new_uncommitted(pid, ProcessIdentifier::from(99), old_thread, old_vmem);
+    process.install_termination_credit(new_test_process_termination_credit());
+    let (mut running, reason, _ctx, _user_tda) = process.run();
+    if reason.is_some() {
+        error!("outgoing exec fixture was unexpectedly interrupted");
+        return false;
+    }
+    let new_thread: ReadyThread = ReadyThread::new(
+        new_tid,
+        Some(new_test_thread_termination_credit()),
+        None,
+        None,
+        None,
+        ContextInformation::default(),
+        // SAFETY: calls to FpuState::new are synchronized by the single-threaded test runner.
+        unsafe { FpuState::new() },
+    );
+    let (old_vmem, old_zombie, pending, _from_ctx, _to_ctx, _user_tda) =
+        running.replace_image(new_vmem, new_thread);
+    let (info, credit) = pending.into_parts();
+    let expected: ThreadTerminationInfo =
+        ThreadTerminationInfo::new(pid, old_tid, ExitStatus::ok());
+    if info != expected || old_zombie.status() != ExitStatus::ok() || running.get_tid() != new_tid {
+        error!("exec replacement changed retirement metadata or replacement identity");
+        return false;
+    }
+    broker.commit_thread_termination(credit, info);
+    if !receive_expected_lifecycle(
+        &mut broker,
+        MessageType::ThreadTerminationEvent,
+        &expected.to_ne_bytes(),
+    ) || broker.has_lifecycle()
+        || broker.capacity_in_use() != Some(0)
+    {
+        error!("exec replacement produced extra lifecycle state");
+        return false;
+    }
+    let _ = old_zombie.harvest();
+    drop(old_vmem);
     true
 }
 
@@ -660,6 +1182,10 @@ pub(super) fn test() -> bool {
     passed &= run_test!(test_cross_process_switch_resets_quantum);
     passed &= run_test!(test_create_process_reservation_failure_rolls_back);
     passed &= run_test!(test_duplicate_process_reservation_failure_rolls_back);
+    passed &= run_test!(test_create_thread_reservation_failure_rolls_back);
+    passed &= run_test!(test_execv_thread_reservation_failure_rolls_back);
+    passed &= run_test!(test_zombie_transitions_produce_ordered_lifecycle_records);
+    passed &= run_test!(test_exec_replacement_produces_thread_termination_only);
     passed &= run_test!(test_ipc_precedes_newer_lifecycle);
     passed &= run_test!(test_lifecycle_precedes_newer_ipc_after_failed_wakeup);
     passed &= run_test!(test_other_thread_ipc_does_not_block_lifecycle);

--- a/src/kernel/src/pm/process/mod.rs
+++ b/src/kernel/src/pm/process/mod.rs
@@ -104,19 +104,72 @@ impl LifecycleTerminationCredit {
     }
 }
 
-/// Harvested process termination awaiting either lifecycle commit or explicit release.
+/// Capacity credit reserved for the future termination of a live thread.
+#[derive(Debug)]
+#[must_use]
+pub(crate) struct ThreadLifecycleTerminationCredit {
+    _private: (),
+}
+
+/// Reservation for the future termination record of a thread being created.
+#[derive(Debug)]
+#[must_use]
+pub(super) struct ThreadLifecycleReservation {
+    termination_credit: ThreadLifecycleTerminationCredit,
+}
+
+impl ThreadLifecycleReservation {
+    ///
+    /// # Description
+    ///
+    /// Creates a thread lifecycle reservation.
+    ///
+    /// # Returns
+    ///
+    /// A thread lifecycle reservation.
+    ///
+    fn new() -> Self {
+        Self {
+            termination_credit: ThreadLifecycleTerminationCredit { _private: () },
+        }
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Converts this reservation into the credit owned by a committed thread.
+    ///
+    /// # Returns
+    ///
+    /// A thread-termination capacity credit.
+    ///
+    fn into_credit(self) -> ThreadLifecycleTerminationCredit {
+        self.termination_credit
+    }
+}
+
+/// Process termination metadata retained through resource harvest.
 #[must_use]
 pub(crate) struct HarvestedProcess {
     info: ProcessTerminationInfo,
-    termination_credit: LifecycleTerminationCredit,
 }
 
 impl HarvestedProcess {
-    fn new(info: ProcessTerminationInfo, termination_credit: LifecycleTerminationCredit) -> Self {
-        Self {
-            info,
-            termination_credit,
-        }
+    ///
+    /// # Description
+    ///
+    /// Creates harvested process metadata from a process-termination record.
+    ///
+    /// # Parameters
+    ///
+    /// - `info`: Process-termination record retained through resource harvest.
+    ///
+    /// # Returns
+    ///
+    /// Harvested process metadata containing `info`.
+    ///
+    fn new(info: ProcessTerminationInfo) -> Self {
+        Self { info }
     }
 
     /// Returns the harvested process-termination information.
@@ -124,8 +177,17 @@ impl HarvestedProcess {
         &self.info
     }
 
-    fn into_parts(self) -> (ProcessTerminationInfo, LifecycleTerminationCredit) {
-        (self.info, self.termination_credit)
+    ///
+    /// # Description
+    ///
+    /// Consumes this harvested process and returns its termination information.
+    ///
+    /// # Returns
+    ///
+    /// The harvested process-termination information.
+    ///
+    pub(crate) fn into_info(self) -> ProcessTerminationInfo {
+        self.info
     }
 }
 
@@ -135,6 +197,32 @@ impl HarvestedProcess {
 
 #[cfg(feature = "test")]
 pub(crate) use manager::new_test_delivery_sequence;
+///
+/// # Description
+///
+/// Creates a synthetic thread-termination credit for an in-kernel test fixture.
+///
+/// # Returns
+///
+/// A synthetic thread-termination credit.
+///
+#[cfg(feature = "test")]
+pub(crate) fn new_test_thread_termination_credit() -> ThreadLifecycleTerminationCredit {
+    ThreadLifecycleTerminationCredit { _private: () }
+}
+///
+/// # Description
+///
+/// Creates a synthetic process-termination credit for an in-kernel test fixture.
+///
+/// # Returns
+///
+/// A synthetic process-termination credit.
+///
+#[cfg(feature = "test")]
+pub(crate) fn new_test_process_termination_credit() -> LifecycleTerminationCredit {
+    LifecycleTerminationCredit { _private: () }
+}
 pub(crate) use manager::DeliverySequence;
 pub use manager::{
     ExceptionGuard,

--- a/src/kernel/src/pm/process/state/kill_test.rs
+++ b/src/kernel/src/pm/process/state/kill_test.rs
@@ -19,6 +19,7 @@ use crate::{
         Vmem,
     },
     pm::{
+        process::new_test_thread_termination_credit,
         thread::{
             InterruptReason,
             InterruptedThread,
@@ -87,9 +88,18 @@ fn make_process_state() -> Option<Box<ProcessState>> {
 ///
 /// Creates a [`ReadyThread`] with the given identifier and an otherwise empty context.
 ///
+/// # Parameters
+///
+/// - `tid`: Raw thread identifier to assign to the fixture.
+///
+/// # Returns
+///
+/// A ready thread fixture with the specified identifier.
+///
 fn make_ready_thread(tid: i32) -> ReadyThread {
     ReadyThread::new(
         ThreadIdentifier::from(tid),
+        Some(new_test_thread_termination_credit()),
         None,
         None,
         None,

--- a/src/kernel/src/pm/process/state/mod.rs
+++ b/src/kernel/src/pm/process/state/mod.rs
@@ -97,6 +97,10 @@ pub use running::RunningProcess;
 pub use signal::exception_to_signal;
 pub use sleeping::SleepingProcess;
 pub use zombie::ZombieProcess;
+pub(crate) use zombie::{
+    PendingProcessTermination,
+    ZombieProcessTransition,
+};
 
 ///
 /// # Description

--- a/src/kernel/src/pm/process/state/runnable.rs
+++ b/src/kernel/src/pm/process/state/runnable.rs
@@ -17,13 +17,15 @@ use crate::{
                 InterruptedProcess,
                 ProcessState,
                 RunningProcess,
-                ZombieProcess,
+                ZombieProcessTransition,
             },
             LifecycleTerminationCredit,
+            ThreadLifecycleTerminationCredit,
         },
         thread::{
             InterruptReason,
             InterruptedThread,
+            PendingThreadTermination,
             ReadyThread,
             RunningThread,
             SleepingThread,
@@ -111,6 +113,31 @@ impl RunnableProcess {
         credit: LifecycleTerminationCredit,
     ) {
         self.state.install_termination_credit(credit);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Installs the termination credit in the sole thread of a newly prepared process.
+    ///
+    /// # Parameters
+    ///
+    /// - `credit`: Capacity credit reserved for the main thread's termination record.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the process has no ready main thread or if that thread already owns
+    /// a termination credit.
+    ///
+    pub(in crate::pm::process) fn install_thread_termination_credit(
+        &mut self,
+        credit: ThreadLifecycleTerminationCredit,
+    ) {
+        let thread: &mut ReadyThread = match self.ready_threads.iter_mut().next() {
+            Some(thread) => thread,
+            None => unreachable!("newly prepared process has no main thread"),
+        };
+        thread.thread_state_mut().install_termination_credit(credit);
     }
 
     pub(in crate::pm::process) fn new_kernel(
@@ -212,10 +239,39 @@ impl RunnableProcess {
         )
     }
 
-    pub fn terminate(mut self) -> Result<InterruptedProcess, ZombieProcess> {
+    ///
+    /// # Description
+    ///
+    /// Terminates every ready thread and marks sleeping or interrupted threads for termination.
+    /// Each immediate live-to-zombie transition is reported through `on_thread_termination`.
+    ///
+    /// # Parameters
+    ///
+    /// - `on_thread_termination`: Callback that commits each pending thread-termination record.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(process)` if interrupted threads must resume before they can terminate, or
+    /// `Err(transition)` if the process immediately becomes a zombie.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if a thread that transitions to zombie state does not own a thread
+    /// termination credit, or if an immediate process transition lacks its process termination
+    /// credit.
+    ///
+    pub(in crate::pm) fn terminate(
+        mut self,
+        on_thread_termination: &mut impl FnMut(PendingThreadTermination),
+    ) -> Result<InterruptedProcess, ZombieProcessTransition> {
+        let pid: ProcessIdentifier = self.state.pid();
         // Terminate all ready threads.
         let mut more_zombie_threads: NonEmptyVecDeque<ZombieThread> =
-            NonEmptyVecDeque::map(self.ready_threads, ReadyThread::terminate);
+            NonEmptyVecDeque::map(self.ready_threads, |thread| {
+                let (zombie, pending) = thread.terminate(pid).into_parts();
+                on_thread_termination(pending);
+                zombie
+            });
 
         // Collect zombie threads.
         let zombie_threads: NonEmptyVecDeque<ZombieThread> = match self.zombie_threads.take() {
@@ -248,7 +304,7 @@ impl RunnableProcess {
                 .state
                 .take_pending_exit_status()
                 .unwrap_or_else(|| ErrorCode::Interrupted.into());
-            Err(ZombieProcess::new(self.state, zombie_threads, final_status))
+            Err(ZombieProcessTransition::new(self.state, zombie_threads, final_status))
         }
     }
 

--- a/src/kernel/src/pm/process/state/running.rs
+++ b/src/kernel/src/pm/process/state/running.rs
@@ -15,11 +15,12 @@ use crate::{
             InterruptedProcess,
             ProcessState,
             RunnableProcess,
-            ZombieProcess,
+            ZombieProcessTransition,
         },
         sync::condvar::Condvar,
         thread::{
             InterruptedThread,
+            PendingThreadTermination,
             ReadyThread,
             RunningThread,
             SleepingThread,
@@ -36,7 +37,10 @@ use ::sys::{
         ErrorCode,
     },
     mm::VirtualAddress,
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
     time::SystemTime,
     ExitStatus,
 };
@@ -153,17 +157,23 @@ impl RunningProcess {
     /// A tuple of:
     /// - The outgoing address space, for deferred reclamation.
     /// - The outgoing thread as a zombie, for deferred kernel-stack reaping.
+    /// - The pending termination record for the outgoing thread.
     /// - A pointer to the outgoing thread's context (the "from" side of the switch).
     /// - A pointer to the new thread's context (the "to" side of the switch).
     /// - The optional thread data area of the new thread.
     ///
-    pub fn replace_image(
+    /// # Panics
+    ///
+    /// This function panics if the outgoing thread does not own a thread termination credit.
+    ///
+    pub(in crate::pm) fn replace_image(
         &mut self,
         new_vmem: Vmem,
         new_thread: ReadyThread,
     ) -> (
         Vmem,
         ZombieThread,
+        PendingThreadTermination,
         *mut ContextInformation,
         *mut ContextInformation,
         Option<VirtualAddress>,
@@ -178,7 +188,9 @@ impl RunningProcess {
         // Retire the outgoing thread. Its kernel stack and context survive inside the returned
         // zombie until the deferred reap that runs after the switch; its user-stack handle is
         // dropped so the harvest does not touch the new address space.
-        let (old_zombie, from_ctx) = old_thread.exit_for_exec();
+        let pid: ProcessIdentifier = self.state.pid();
+        let (transition, from_ctx) = old_thread.exit_for_exec(pid);
+        let (old_zombie, pending) = transition.into_parts();
 
         // Swap in the new address space, returning the old one for deferred reclamation.
         let old_vmem: Vmem = self.state.replace_vmem(new_vmem);
@@ -188,7 +200,7 @@ impl RunningProcess {
         // is cleared, and the restorer is dropped so the new image re-registers it at startup.
         self.state.signals_mut().reset_for_exec();
 
-        (old_vmem, old_zombie, from_ctx, to_ctx, user_tda)
+        (old_vmem, old_zombie, pending, from_ctx, to_ctx, user_tda)
     }
 
     pub fn schedule(mut self) -> (RunnableProcess, *mut ContextInformation) {
@@ -262,11 +274,37 @@ impl RunningProcess {
         Err((SleepingProcess::new(self.state, sleeping_threads, self.zombie.take()), ctx))
     }
 
-    pub fn exit(
+    ///
+    /// # Description
+    ///
+    /// Terminates the running process with the specified status. The running thread and every
+    /// ready thread transition immediately to zombie state, while sleeping and interrupted threads
+    /// are marked for termination. Each immediate thread transition is reported through
+    /// `on_thread_termination`.
+    ///
+    /// # Parameters
+    ///
+    /// - `status`: Exit status of the process and its running thread.
+    /// - `on_thread_termination`: Callback that commits each pending thread-termination record.
+    ///
+    /// # Returns
+    ///
+    /// `Ok((process, context))` if interrupted threads must resume before termination completes, or
+    /// `Err((transition, context))` if the process immediately becomes a zombie.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if an immediately terminated thread lacks its thread termination credit,
+    /// or if an immediate process transition lacks its process termination credit.
+    ///
+    pub(in crate::pm) fn exit(
         mut self,
         status: ExitStatus,
-    ) -> Result<(RunnableProcess, *mut ContextInformation), (ZombieProcess, *mut ContextInformation)>
-    {
+        on_thread_termination: &mut impl FnMut(PendingThreadTermination),
+    ) -> Result<
+        (RunnableProcess, *mut ContextInformation),
+        (ZombieProcessTransition, *mut ContextInformation),
+    > {
         // Save the exit status before terminating any threads. This ensures that the intended
         // exit code from the first exit() call is preserved, even if subsequent thread cleanup
         // triggers additional exit() calls with different status values (e.g., ESRCH from
@@ -274,7 +312,10 @@ impl RunningProcess {
         // pending status is already set, so only the first caller's status is retained.
         self.state.set_pending_exit_status(status);
 
-        let (zombie_thread, ctx) = self.running.exit(status);
+        let pid: ProcessIdentifier = self.state.pid();
+        let (transition, ctx) = self.running.exit(pid, status);
+        let (zombie_thread, pending) = transition.into_parts();
+        on_thread_termination(pending);
         let mut zombie_threads: NonEmptyVecDeque<ZombieThread> = match self.zombie.take() {
             Some(mut zombie_threads) => {
                 zombie_threads.push_back(zombie_thread);
@@ -285,7 +326,11 @@ impl RunningProcess {
 
         // Terminate all ready threads.
         if let Some(ready_threads) = self.ready.take() {
-            let more_zombie_threads = NonEmptyVecDeque::map(ready_threads, ReadyThread::terminate);
+            let more_zombie_threads = NonEmptyVecDeque::map(ready_threads, |thread| {
+                let (zombie, pending) = thread.terminate(pid).into_parts();
+                on_thread_termination(pending);
+                zombie
+            });
             zombie_threads.append(more_zombie_threads);
         }
 
@@ -316,7 +361,7 @@ impl RunningProcess {
             // should never be reached because set_pending_exit_status is called above, but is
             // kept as a defensive measure.
             let final_status: ExitStatus = self.state.take_pending_exit_status().unwrap_or(status);
-            Err((ZombieProcess::new(self.state, zombie_threads, final_status), ctx))
+            Err((ZombieProcessTransition::new(self.state, zombie_threads, final_status), ctx))
         }
     }
 
@@ -328,25 +373,31 @@ impl RunningProcess {
     /// # Parameters
     ///
     /// - `status`: Exit status.
+    /// - `on_thread_termination`: Callback that commits the pending thread-termination record.
     ///
     /// # Returns
     ///
-    /// If the process becomes a runnable process, a tuple containing the runnable process and the
-    /// context information of the running thread is returned. If the process becomes a sleeping
-    /// process, a tuple containing the sleeping process and the context information of the running
-    /// thread is returned. If the process becomes a zombie process, a tuple containing the zombie
-    /// process and the context information of the running thread is returned.
+    /// A tuple containing the process-state transition and an optional detached zombie for deferred
+    /// reaping is returned. The transition contains a runnable process when ready or interrupted
+    /// threads remain, a sleeping process when only sleeping threads remain, or a zombie-process
+    /// transition when no live threads remain.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the exiting thread does not own a thread termination credit, or if a
+    /// final process transition lacks its process termination credit.
     ///
     #[allow(clippy::type_complexity)]
-    pub fn exit_thread(
+    pub(in crate::pm) fn exit_thread(
         self,
         status: ExitStatus,
+        on_thread_termination: &mut impl FnMut(PendingThreadTermination),
     ) -> (
         Result<
             (Condvar, RunnableProcess, *mut ContextInformation),
             Result<
                 (Condvar, SleepingProcess, *mut ContextInformation),
-                (Condvar, ZombieProcess, *mut ContextInformation),
+                (Condvar, ZombieProcessTransition, *mut ContextInformation),
             >,
         >,
         Option<ZombieThread>, // Detached zombie that must be reaped after the context switch.
@@ -362,7 +413,10 @@ impl RunningProcess {
         let sleeping_threads: Option<NonEmptyVecDeque<SleepingThread>> = self.sleeping_threads;
         let existing_zombies: Option<NonEmptyVecDeque<ZombieThread>> = self.zombie;
 
-        let (zombie_thread, ctx) = self.running.exit(status);
+        let pid: ProcessIdentifier = state.pid();
+        let (transition, ctx) = self.running.exit(pid, status);
+        let (zombie_thread, pending) = transition.into_parts();
+        on_thread_termination(pending);
 
         // Determine whether other threads remain. If so, a detached zombie must NOT be dropped
         // here — it owns the ContextInformation that `ctx` points to, and the context switch
@@ -435,7 +489,7 @@ impl RunningProcess {
                     (
                         Err(Err((
                             join_cond,
-                            ZombieProcess::new(state, zombie_threads, final_status),
+                            ZombieProcessTransition::new(state, zombie_threads, final_status),
                             ctx,
                         ))),
                         deferred_zombie,

--- a/src/kernel/src/pm/process/state/test_detach.rs
+++ b/src/kernel/src/pm/process/state/test_detach.rs
@@ -19,6 +19,10 @@ use crate::{
         Vmem,
     },
     pm::{
+        process::{
+            new_test_process_termination_credit,
+            new_test_thread_termination_credit,
+        },
         thread::{
             InterruptReason,
             InterruptedThread,
@@ -33,6 +37,7 @@ use crate::{
 use ::alloc::boxed::Box;
 use ::sys::{
     error::ErrorCode,
+    event::ThreadTerminationInfo,
     pm::{
         ProcessIdentifier,
         ThreadIdentifier,
@@ -74,9 +79,18 @@ fn make_test_vmem() -> Option<Vmem> {
 ///
 /// Creates a [`ReadyThread`] with the given identifier and an otherwise empty context.
 ///
+/// # Parameters
+///
+/// - `tid`: Raw thread identifier to assign to the fixture.
+///
+/// # Returns
+///
+/// A ready thread fixture with the specified identifier.
+///
 fn make_ready_thread(tid: i32) -> ReadyThread {
     ReadyThread::new(
         ThreadIdentifier::from(tid),
+        Some(new_test_thread_termination_credit()),
         None,
         None,
         None,
@@ -100,8 +114,18 @@ fn make_running_thread(tid: i32) -> RunningThread {
 ///
 /// Creates a [`ZombieThread`] with the given identifier.
 ///
+/// # Parameters
+///
+/// - `tid`: Raw thread identifier to assign to the fixture.
+///
+/// # Returns
+///
+/// A zombie thread fixture with the specified identifier.
+///
 fn make_zombie_thread(tid: i32) -> ZombieThread {
-    make_running_thread(tid).exit(ExitStatus::from(0u32)).0
+    let (transition, _ctx) =
+        make_running_thread(tid).exit(ProcessIdentifier::from(1), ExitStatus::from(0u32));
+    transition.into_parts().0
 }
 
 ///
@@ -110,10 +134,19 @@ fn make_zombie_thread(tid: i32) -> ZombieThread {
 /// Creates a detached [`ZombieThread`] with the given identifier by detaching the running thread
 /// before it exits.
 ///
+/// # Parameters
+///
+/// - `tid`: Raw thread identifier to assign to the fixture.
+///
+/// # Returns
+///
+/// A detached zombie thread fixture with the specified identifier.
+///
 fn make_detached_zombie_thread(tid: i32) -> ZombieThread {
     let mut running: RunningThread = make_running_thread(tid);
     running.set_detached();
-    running.exit(ExitStatus::from(0u32)).0
+    let (transition, _ctx) = running.exit(ProcessIdentifier::from(1), ExitStatus::from(0u32));
+    transition.into_parts().0
 }
 
 ///
@@ -140,6 +173,14 @@ fn make_interrupted_thread(tid: i32) -> InterruptedThread {
 /// Wraps [`RunningProcess::new`] with a stub [`ProcessState`], assembling a running process from
 /// the supplied running thread and optional thread queues.
 ///
+/// # Parameters
+///
+/// - `running`: Running thread to install in the process.
+/// - `ready`: Optional ready-thread queue.
+/// - `interrupted`: Optional interrupted-thread queue.
+/// - `sleeping`: Optional sleeping-thread queue.
+/// - `zombie`: Optional zombie-thread queue.
+///
 /// # Returns
 ///
 /// Upon success, the new [`RunningProcess`] is returned. Otherwise, [`None`] is returned.
@@ -155,7 +196,7 @@ fn make_test_process(
     let state: Box<ProcessState> = Box::new(ProcessState::new(
         ProcessIdentifier::from(1),
         ProcessIdentifier::from(0),
-        None,
+        Some(new_test_process_termination_credit()),
         vmem,
     ));
     Some(RunningProcess::new(state, running, ready, interrupted, sleeping, zombie))
@@ -602,6 +643,11 @@ fn test_detach_nonexistent_tid() -> bool {
 /// (returned for deferred reaping) instead of enqueuing it, and the process transitions to a
 /// runnable process that does not retain the detached thread.
 ///
+/// # Returns
+///
+/// `true` if the detached thread produces one termination record and is deferred for reaping,
+/// otherwise `false`.
+///
 fn test_exit_detached_thread_auto_drops() -> bool {
     let mut running: RunningThread = make_running_thread(1);
     running.set_detached();
@@ -613,10 +659,29 @@ fn test_exit_detached_thread_auto_drops() -> bool {
         None => return false,
     };
 
-    let (result, deferred) = process.exit_thread(ExitStatus::from(0u32));
+    let status: ExitStatus = ExitStatus::from(0u32);
+    let mut termination: Option<ThreadTerminationInfo> = None;
+    let (result, deferred) = process.exit_thread(status, &mut |pending| {
+        let (info, _credit) = pending.into_parts();
+        termination = Some(info);
+    });
 
-    if deferred.is_none() {
-        error!("expected detached zombie to be returned for deferred reaping");
+    if termination
+        != Some(ThreadTerminationInfo::new(ProcessIdentifier::from(1), running_tid, status))
+    {
+        error!("detached thread produced an incorrect termination record");
+        return false;
+    }
+    let deferred: ZombieThread = match deferred {
+        Some(zombie) => zombie,
+        None => {
+            error!("expected detached zombie to be returned for deferred reaping");
+            return false;
+        },
+    };
+    let _ = deferred.harvest();
+    if termination.is_none() {
+        error!("deferred reap changed the committed thread termination record");
         return false;
     }
 
@@ -647,6 +712,10 @@ fn test_exit_detached_thread_auto_drops() -> bool {
 /// for deferred reaping and transitions the process to a sleeping process that does not retain the
 /// detached thread.
 ///
+/// # Returns
+///
+/// `true` if the detached thread is deferred and the process becomes sleeping, otherwise `false`.
+///
 fn test_exit_detached_thread_auto_drops_with_sleeping() -> bool {
     let mut running: RunningThread = make_running_thread(1);
     running.set_detached();
@@ -659,7 +728,7 @@ fn test_exit_detached_thread_auto_drops_with_sleeping() -> bool {
         None => return false,
     };
 
-    let (result, deferred) = process.exit_thread(ExitStatus::from(0u32));
+    let (result, deferred) = process.exit_thread(ExitStatus::from(0u32), &mut |_pending| {});
 
     if deferred.is_none() {
         error!("expected detached zombie to be returned for deferred reaping");
@@ -693,6 +762,10 @@ fn test_exit_detached_thread_auto_drops_with_sleeping() -> bool {
 /// zombie for deferred reaping and transitions the process to a runnable process that does not
 /// retain the detached thread.
 ///
+/// # Returns
+///
+/// `true` if the detached thread is deferred and the process becomes runnable, otherwise `false`.
+///
 fn test_exit_detached_thread_auto_drops_with_interrupted() -> bool {
     let mut running: RunningThread = make_running_thread(1);
     running.set_detached();
@@ -706,7 +779,7 @@ fn test_exit_detached_thread_auto_drops_with_interrupted() -> bool {
             None => return false,
         };
 
-    let (result, deferred) = process.exit_thread(ExitStatus::from(0u32));
+    let (result, deferred) = process.exit_thread(ExitStatus::from(0u32), &mut |_pending| {});
 
     if deferred.is_none() {
         error!("expected detached zombie to be returned for deferred reaping");
@@ -739,6 +812,10 @@ fn test_exit_detached_thread_auto_drops_with_interrupted() -> bool {
 /// Exiting a detached running thread that is the last thread preserves the zombie (so the zombie
 /// process can be constructed) and returns no deferred zombie.
 ///
+/// # Returns
+///
+/// `true` if the zombie is retained in the zombie-process transition, otherwise `false`.
+///
 fn test_exit_detached_last_thread_keeps_zombie() -> bool {
     let mut running: RunningThread = make_running_thread(1);
     running.set_detached();
@@ -748,7 +825,7 @@ fn test_exit_detached_last_thread_keeps_zombie() -> bool {
         None => return false,
     };
 
-    let (result, deferred) = process.exit_thread(ExitStatus::from(0u32));
+    let (result, deferred) = process.exit_thread(ExitStatus::from(0u32), &mut |_pending| {});
 
     if deferred.is_some() {
         error!("unexpected deferred zombie for last detached thread");
@@ -756,7 +833,8 @@ fn test_exit_detached_last_thread_keeps_zombie() -> bool {
     }
 
     match result {
-        Err(Err((_join_cond, zombie_process, _ctx))) => {
+        Err(Err((_join_cond, transition, _ctx))) => {
+            let (zombie_process, _pending) = transition.into_parts();
             if zombie_process.find_thread(running_tid).is_none() {
                 error!("zombie thread not preserved in zombie process");
                 return false;

--- a/src/kernel/src/pm/process/state/zombie.rs
+++ b/src/kernel/src/pm/process/state/zombie.rs
@@ -6,7 +6,10 @@
 //==================================================================================================
 
 use crate::pm::{
-    process::state::ProcessState,
+    process::{
+        state::ProcessState,
+        LifecycleTerminationCredit,
+    },
     thread::{
         ThreadRef,
         ThreadRefMut,
@@ -15,7 +18,10 @@ use crate::pm::{
 };
 use ::alloc::boxed::Box;
 use ::sys::{
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
     ExitStatus,
 };
 use ::type_safe::NonEmptyVecDeque;
@@ -37,19 +43,101 @@ pub struct ZombieProcess {
     status: ExitStatus,
 }
 
-impl ZombieProcess {
+/// Process-termination data and capacity transferred at zombie-process creation.
+#[must_use]
+pub(crate) struct PendingProcessTermination {
+    pid: ProcessIdentifier,
+    parent: ProcessIdentifier,
+    status: ExitStatus,
+    credit: LifecycleTerminationCredit,
+}
+
+impl PendingProcessTermination {
+    ///
+    /// # Description
+    ///
+    /// Splits this pending termination into its metadata and reserved capacity credit.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing the process identifier, parent identifier, exit status, and termination
+    /// capacity credit.
+    ///
+    pub(crate) fn into_parts(
+        self,
+    ) -> (ProcessIdentifier, ProcessIdentifier, ExitStatus, LifecycleTerminationCredit) {
+        (self.pid, self.parent, self.status, self.credit)
+    }
+}
+
+/// Result of the authoritative transition into zombie-process state.
+#[must_use]
+pub(crate) struct ZombieProcessTransition {
+    zombie: ZombieProcess,
+    pending: PendingProcessTermination,
+}
+
+impl ZombieProcessTransition {
+    ///
+    /// # Description
+    ///
+    /// Creates a zombie process transition and transfers its termination credit.
+    ///
+    /// # Parameters
+    ///
+    /// - `process`: Process state that is transitioning to zombie state.
+    /// - `zombie_threads`: Non-empty collection of the process's zombie threads.
+    /// - `status`: Final exit status of the process.
+    ///
+    /// # Returns
+    ///
+    /// A transition containing the zombie process and its pending termination record.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the process does not own a termination credit.
+    ///
     pub(super) fn new(
-        process: Box<ProcessState>,
+        mut process: Box<ProcessState>,
         zombie_threads: NonEmptyVecDeque<ZombieThread>,
         status: ExitStatus,
     ) -> Self {
+        let pid: ProcessIdentifier = process.pid();
+        let parent: ProcessIdentifier = process.ppid();
+        let credit: LifecycleTerminationCredit = match process.take_termination_credit() {
+            Some(credit) => credit,
+            None => unreachable!("zombie user process must own a termination credit"),
+        };
         Self {
-            zombie_threads,
-            process,
-            status,
+            zombie: ZombieProcess {
+                zombie_threads,
+                process,
+                status,
+            },
+            pending: PendingProcessTermination {
+                pid,
+                parent,
+                status,
+                credit,
+            },
         }
     }
 
+    ///
+    /// # Description
+    ///
+    /// Splits this transition into the zombie process and its pending termination record.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing the zombie process and its pending termination record.
+    ///
+    pub(crate) fn into_parts(self) -> (ZombieProcess, PendingProcessTermination) {
+        (self.zombie, self.pending)
+    }
+}
+
+impl ZombieProcess {
     pub fn state(&self) -> &ProcessState {
         &self.process
     }

--- a/src/kernel/src/pm/thread/mod.rs
+++ b/src/kernel/src/pm/thread/mod.rs
@@ -48,6 +48,10 @@ pub use running::RunningThread;
 pub use sleeping::SleepingThread;
 pub use state::KcallRestart;
 pub use zombie::ZombieThread;
+pub(crate) use zombie::{
+    PendingThreadTermination,
+    ZombieThreadTransition,
+};
 
 //==================================================================================================
 // Thread Reference
@@ -190,6 +194,7 @@ impl ThreadManager {
                 None,
                 None,
                 None,
+                None,
                 ContextInformation::default(),
                 // SAFETY: calls to FpuState::new are synchronized.
                 unsafe { FpuState::new() },
@@ -308,6 +313,7 @@ impl ThreadManager {
     ) -> ReadyThread {
         ReadyThread::new(
             id,
+            None,
             kernel_stack,
             user_stack,
             user_tda,

--- a/src/kernel/src/pm/thread/ready.rs
+++ b/src/kernel/src/pm/thread/ready.rs
@@ -16,11 +16,13 @@ use crate::{
     },
     pm::{
         clock,
+        process::ThreadLifecycleTerminationCredit,
         sync::condvar::Condvar,
         thread::{
             state::ThreadState,
             RunningThread,
             ZombieThread,
+            ZombieThreadTransition,
         },
         InterruptReason,
     },
@@ -30,7 +32,10 @@ use ::core::fmt::Debug;
 use ::sys::{
     error::ErrorCode,
     mm::VirtualAddress,
-    pm::ThreadIdentifier,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
     time::SystemTime,
 };
 
@@ -64,10 +69,12 @@ impl ReadyThread {
     /// # Parameters
     ///
     /// - `id`: Thread identifier.
+    /// - `termination_credit`: Optional reserved capacity for this thread's termination record.
     /// - `kernel_stack`: Optional kernel stack.
     /// - `user_stack`: Optional user stack.
     /// - `user_tda`: Optional base address for the user-space thread data area.
     /// - `context`: Execution context.
+    /// - `fpu_state`: Initial floating-point unit state.
     ///
     /// # Returns
     ///
@@ -75,6 +82,7 @@ impl ReadyThread {
     ///
     pub fn new(
         id: ThreadIdentifier,
+        termination_credit: Option<ThreadLifecycleTerminationCredit>,
         kernel_stack: Option<KernelStack>,
         user_stack: Option<UserStack>,
         user_tda: Option<VirtualAddress>,
@@ -84,6 +92,7 @@ impl ReadyThread {
         Self {
             state: Box::new(ThreadState::new(
                 id,
+                termination_credit,
                 kernel_stack,
                 user_stack,
                 user_tda,
@@ -181,12 +190,22 @@ impl ReadyThread {
     ///
     /// Terminates the ready thread and transitions it to zombie state.
     ///
+    /// The returned transition owns both the zombie and its pending lifecycle record.
+    ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the process that owns the thread.
+    ///
     /// # Returns
     ///
-    /// This function returns a [`ZombieThread`] instance.
+    /// This function returns the must-use zombie-thread transition.
     ///
-    pub fn terminate(self) -> ZombieThread {
-        ZombieThread::from_state(self.state, ErrorCode::Interrupted.into())
+    /// # Panics
+    ///
+    /// This function panics if the thread does not own a termination credit.
+    ///
+    pub fn terminate(self, pid: ProcessIdentifier) -> ZombieThreadTransition {
+        ZombieThread::from_state(pid, self.state, ErrorCode::Interrupted.into())
     }
 
     ///

--- a/src/kernel/src/pm/thread/running.rs
+++ b/src/kernel/src/pm/thread/running.rs
@@ -17,6 +17,7 @@ use crate::{
             ReadyThread,
             SleepingThread,
             ZombieThread,
+            ZombieThreadTransition,
         },
     },
 };
@@ -27,6 +28,7 @@ use ::sys::{
     mm::VirtualAddress,
     pm::{
         MutexAddress,
+        ProcessIdentifier,
         ThreadIdentifier,
     },
     time::SystemTime,
@@ -186,41 +188,62 @@ impl RunningThread {
     ///
     /// # Parameters
     ///
+    /// - `pid`: Identifier of the process that owns this thread.
     /// - `status`: The exit status of the thread.
     ///
     /// # Returns
     ///
-    /// This function returns a tuple containing the zombie thread and a mutable pointer to the execution context.
+    /// This function returns the must-use zombie-thread transition and a mutable pointer to the
+    /// execution context.
     ///
-    pub fn exit(mut self, status: ExitStatus) -> (ZombieThread, *mut ContextInformation) {
+    /// # Panics
+    ///
+    /// This function panics if the thread does not own a termination credit.
+    ///
+    pub fn exit(
+        mut self,
+        pid: ProcessIdentifier,
+        status: ExitStatus,
+    ) -> (ZombieThreadTransition, *mut ContextInformation) {
         let ctx: *mut ContextInformation = self.state.context_mut();
-        (ZombieThread::from_state(self.state, status), ctx)
+        (ZombieThread::from_state(pid, self.state, status), ctx)
     }
 
     ///
     /// # Description
     ///
-    /// Retires the running thread as part of an `execv()`, returning a zombie thread that owns the
-    /// outgoing thread's kernel stack and execution context together with a pointer to that
-    /// context.
+    /// Retires the running thread as part of an `execv()`, returning a transition whose zombie owns
+    /// the outgoing thread's kernel stack and execution context and whose pending record owns the
+    /// termination reservation.
     ///
     /// Unlike [`Self::exit`], this drops the thread's user-stack handle before zombifying it. The
     /// user stack lives in the outgoing address space, which `execv()` reclaims wholesale; keeping
     /// the handle would cause the later zombie harvest to unmap the stack's virtual range from the
     /// *new* address space, since every image places its stack at the same fixed virtual address.
     ///
+    /// # Parameters
+    ///
+    /// - `pid`: Identifier of the process that owns this thread.
+    ///
     /// # Returns
     ///
-    /// A tuple with the zombie thread and a pointer to its execution context. The context remains
-    /// valid until the zombie is harvested, which the caller defers until after the context switch
-    /// into the new image.
+    /// A tuple with the must-use zombie-thread transition and a pointer to its execution context.
+    /// The context remains valid until the zombie is harvested, which the caller defers until after
+    /// the context switch into the new image.
     ///
-    pub fn exit_for_exec(mut self) -> (ZombieThread, *mut ContextInformation) {
+    /// # Panics
+    ///
+    /// This function panics if the thread does not own a termination credit.
+    ///
+    pub fn exit_for_exec(
+        mut self,
+        pid: ProcessIdentifier,
+    ) -> (ZombieThreadTransition, *mut ContextInformation) {
         let ctx: *mut ContextInformation = self.state.context_mut();
         // Drop the user-stack handle (a frame-less address holder) so harvest will not attempt to
         // unmap its range from the new address space.
         let _ = self.state.take_user_stack();
-        (ZombieThread::from_state(self.state, ExitStatus::ok()), ctx)
+        (ZombieThread::from_state(pid, self.state, ExitStatus::ok()), ctx)
     }
 
     ///

--- a/src/kernel/src/pm/thread/state.rs
+++ b/src/kernel/src/pm/thread/state.rs
@@ -15,6 +15,7 @@ use crate::{
         ustack::UserStack,
     },
     pm::{
+        process::ThreadLifecycleTerminationCredit,
         sync::{
             condvar::Condvar,
             mutex::MutexGuard,
@@ -69,6 +70,8 @@ pub struct KcallRestart {
 pub struct ThreadState {
     /// Thread identifier.
     id: ThreadIdentifier,
+    /// Capacity credit reserved for this thread's termination record.
+    termination_credit: Option<ThreadLifecycleTerminationCredit>,
     /// Kernel stack.
     kernel_stack: Option<KernelStack>,
     /// User stack.
@@ -123,10 +126,12 @@ impl ThreadState {
     /// # Parameters
     ///
     /// - `id`: Thread identifier.
+    /// - `termination_credit`: Optional reserved capacity for this thread's termination record.
     /// - `kernel_stack`: Optional kernel stack.
     /// - `user_stack`: Optional user stack.
-    /// - `user_tda`: Optional base address for the user-space user-space thread data area.
+    /// - `user_tda`: Optional base address for the user-space thread data area.
     /// - `context`: Execution context.
+    /// - `fpu_state`: Initial floating-point unit state.
     ///
     /// # Returns
     ///
@@ -134,6 +139,7 @@ impl ThreadState {
     ///
     pub(super) fn new(
         id: ThreadIdentifier,
+        termination_credit: Option<ThreadLifecycleTerminationCredit>,
         kernel_stack: Option<KernelStack>,
         user_stack: Option<UserStack>,
         user_tda: Option<VirtualAddress>,
@@ -142,6 +148,7 @@ impl ThreadState {
     ) -> Self {
         Self {
             id,
+            termination_credit,
             context: Box::pin(context),
             kernel_stack,
             user_stack,
@@ -195,6 +202,45 @@ impl ThreadState {
     ///
     pub(super) fn id(&self) -> ThreadIdentifier {
         self.id
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Installs the lifecycle capacity reserved for this thread's termination record.
+    ///
+    /// # Parameters
+    ///
+    /// - `credit`: Thread-termination capacity credit to install.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the thread already owns a termination credit.
+    ///
+    pub(crate) fn install_termination_credit(&mut self, credit: ThreadLifecycleTerminationCredit) {
+        assert!(self.termination_credit.is_none(), "thread termination credit installed twice");
+        self.termination_credit = Some(credit);
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Takes the lifecycle capacity reserved for this thread's termination record.
+    ///
+    /// # Returns
+    ///
+    /// The thread-termination capacity credit owned by this thread.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the thread does not own a termination credit. Only the permanent
+    /// bootstrap kernel thread may remain live without one.
+    ///
+    pub(super) fn take_termination_credit(&mut self) -> ThreadLifecycleTerminationCredit {
+        match self.termination_credit.take() {
+            Some(credit) => credit,
+            None => unreachable!("only the permanent bootstrap kernel thread may lack a credit"),
+        }
     }
 
     ///

--- a/src/kernel/src/pm/thread/zombie.rs
+++ b/src/kernel/src/pm/thread/zombie.rs
@@ -10,12 +10,19 @@ use crate::{
         kstack::KernelStack,
         ustack::UserStack,
     },
-    pm::thread::state::ThreadState,
+    pm::{
+        process::ThreadLifecycleTerminationCredit,
+        thread::state::ThreadState,
+    },
 };
 use ::alloc::boxed::Box;
 use ::core::fmt::Debug;
 use ::sys::{
-    pm::ThreadIdentifier,
+    event::ThreadTerminationInfo,
+    pm::{
+        ProcessIdentifier,
+        ThreadIdentifier,
+    },
     ExitStatus,
 };
 
@@ -36,6 +43,50 @@ pub struct ZombieThread {
     state: Box<ThreadState>,
 }
 
+/// Thread-termination record and the capacity credit transferred out of a live thread.
+#[must_use]
+pub(crate) struct PendingThreadTermination {
+    info: ThreadTerminationInfo,
+    credit: ThreadLifecycleTerminationCredit,
+}
+
+impl PendingThreadTermination {
+    ///
+    /// # Description
+    ///
+    /// Splits this pending termination into its record and reserved capacity credit.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing the thread-termination record and its reserved capacity credit.
+    ///
+    pub(crate) fn into_parts(self) -> (ThreadTerminationInfo, ThreadLifecycleTerminationCredit) {
+        (self.info, self.credit)
+    }
+}
+
+/// Result of the authoritative live-to-zombie thread transition.
+#[must_use]
+pub(crate) struct ZombieThreadTransition {
+    zombie: ZombieThread,
+    pending: PendingThreadTermination,
+}
+
+impl ZombieThreadTransition {
+    ///
+    /// # Description
+    ///
+    /// Splits this transition into the zombie and its pending termination record.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing the zombie thread and its pending termination record.
+    ///
+    pub(crate) fn into_parts(self) -> (ZombieThread, PendingThreadTermination) {
+        (self.zombie, self.pending)
+    }
+}
+
 //==================================================================================================
 // Implementations
 //==================================================================================================
@@ -48,15 +99,29 @@ impl ZombieThread {
     ///
     /// # Parameters
     ///
+    /// - `pid`: Identifier of the process that owns the thread.
     /// - `state`: The thread state.
     /// - `status`: The exit status of the terminated thread.
     ///
     /// # Returns
     ///
-    /// This function returns a new instance of a [`ZombieThread`].
+    /// This function returns the must-use zombie-thread transition.
     ///
-    pub(super) fn from_state(state: Box<ThreadState>, status: ExitStatus) -> Self {
-        Self { status, state }
+    /// # Panics
+    ///
+    /// This function panics if `state` does not own a thread termination credit.
+    ///
+    pub(super) fn from_state(
+        pid: ProcessIdentifier,
+        mut state: Box<ThreadState>,
+        status: ExitStatus,
+    ) -> ZombieThreadTransition {
+        let info: ThreadTerminationInfo = ThreadTerminationInfo::new(pid, state.id(), status);
+        let credit: ThreadLifecycleTerminationCredit = state.take_termination_credit();
+        ZombieThreadTransition {
+            zombie: Self { status, state },
+            pending: PendingThreadTermination { info, credit },
+        }
     }
 
     ///

--- a/src/libs/type-safe/src/vec_deque.rs
+++ b/src/libs/type-safe/src/vec_deque.rs
@@ -162,26 +162,26 @@ impl<T> NonEmptyVecDeque<T> {
     ///
     /// # Description
     ///
-    /// Maps a function over the elements of `self`.
+    /// Maps a function over the elements of a non-empty vector dequeue.
     ///
     /// # Parameters
     ///
-    /// - `f` - Mapping function.
+    /// - `vec_deque`: Non-empty vector dequeue whose elements are consumed.
+    /// - `f`: Stateful mapping function to apply to each element in order.
     ///
     /// # Returns
     ///
-    /// The function returns a new type-safe vector with the results of applying `f` to each element
-    /// of `self`.
+    /// A new non-empty vector dequeue containing the results of applying `f` to each element.
     ///
-    pub fn map<U, F>(mut vec_deque: NonEmptyVecDeque<U>, f: F) -> NonEmptyVecDeque<T>
+    pub fn map<U, F>(mut vec_deque: NonEmptyVecDeque<U>, mut f: F) -> NonEmptyVecDeque<T>
     where
-        F: Fn(U) -> T,
+        F: FnMut(U) -> T,
     {
         let new_head: T = f(vec_deque.head);
         let new_tail: Option<VecDeque<T>> = vec_deque
             .tail
             .take()
-            .map(|tail| tail.into_iter().map(&f).collect());
+            .map(|tail| tail.into_iter().map(&mut f).collect());
         NonEmptyVecDeque {
             head: new_head,
             tail: new_tail,
@@ -460,6 +460,27 @@ mod test {
             NonEmptyVecDeque::map(vec_deque, |value| value + 1);
         assert_eq!(new_vec_deque.head, 1);
         assert_eq!(new_vec_deque.tail, Some(VecDeque::from([2])));
+    }
+
+    ///
+    /// # Description
+    ///
+    /// Verifies that [`NonEmptyVecDeque::map`] accepts a stateful closure and invokes it once for
+    /// every element in order.
+    ///
+    #[test]
+    fn test_map_with_stateful_closure() {
+        let mut vec_deque = NonEmptyVecDeque::new(0);
+        vec_deque.push_back(1);
+        vec_deque.push_back(2);
+        let mut calls: i32 = 0;
+        let new_vec_deque: NonEmptyVecDeque<i32> = NonEmptyVecDeque::map(vec_deque, |value| {
+            calls += 1;
+            value + calls
+        });
+        assert_eq!(new_vec_deque.head, 1);
+        assert_eq!(new_vec_deque.tail, Some(VecDeque::from([3, 5])));
+        assert_eq!(calls, 3);
     }
 
     #[test]

--- a/src/tests/integration/test-rust-kernel/src/source_spoofing.rs
+++ b/src/tests/integration/test-rust-kernel/src/source_spoofing.rs
@@ -50,16 +50,34 @@ use ::sys::{
 // Test Cases
 //==================================================================================================
 
+///
+/// # Description
+///
 /// Verifies that the kernel overwrites a forged `source` with the caller's true identity.
 ///
 /// The forged source impersonates a different privileged daemon. A correct kernel stamps the
 /// caller's authoritative [`ProcessIdentifier`] over it, so the delivered message must carry the
 /// caller's own pid — never the forged one.
+///
+/// # Returns
+///
+/// Upon successful completion, empty is returned. Otherwise, an error is returned instead.
+///
+/// # Errors
+///
+/// This function returns an error if the message cannot be sent or received, or if the kernel does
+/// not stamp the caller's authoritative process identifier on the message.
+///
+/// # Panics
+///
+/// This function panics if the forged process identifier unexpectedly equals the caller's process
+/// identifier.
+///
 fn test_spoofed_source_is_overwritten() -> Result<(), Error> {
     let my_pid: ProcessIdentifier = pm::getpid_uncached()?;
 
-    // Impersonate a privileged daemon other than ourselves. In the test-kernel environment this
-    // process runs as PROCD, so forge VFSD; if it ever runs as VFSD, forge PROCD instead.
+    // Impersonate a privileged daemon other than ourselves. The test image includes procd as the
+    // lifecycle consumer, so the test process normally forges VFSD.
     let forged_pid: ProcessIdentifier = if my_pid == ProcessIdentifier::VFSD {
         ProcessIdentifier::PROCD
     } else {

--- a/test/test-standalone-windows.toml
+++ b/test/test-standalone-windows.toml
@@ -50,7 +50,7 @@ iterations = 2
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
-program = "./bin/test-rust-kernel.elf"
+program = "./bin/test-rust-kernel.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 expect_empty_output = true
 expected_exit_code = 13
@@ -208,7 +208,7 @@ expected_output = "GETENV:HOME=(null) NVX_GETENV_A=(null) NVX_GETENV_B=(null) NV
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
-program = "./bin/test-rust-kernel.elf"
+program = "./bin/test-rust-kernel.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 expect_empty_output = true
 expected_exit_code = 13

--- a/test/test-standalone.toml
+++ b/test/test-standalone.toml
@@ -38,7 +38,7 @@ iterations = 2
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "http"
-program = "./bin/test-rust-kernel.elf"
+program = "./bin/test-rust-kernel.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 expect_empty_output = true
 expected_exit_code = 13
@@ -171,7 +171,7 @@ expected_output = "ok"
 [[tests]]
 build_modes = ["debug", "release"]
 executor = "terminal"
-program = "./bin/test-rust-kernel.elf"
+program = "./bin/test-rust-kernel.initrd"
 extra_nanvixd_args = "-ramfs ./bin/test-kernel-ramfs.img"
 expect_empty_output = true
 expected_exit_code = 13


### PR DESCRIPTION
## Summary

Emit thread-termination lifecycle records at the authoritative live-to-zombie transition so every committed thread reports exactly once.

- Reserve bounded termination capacity before thread, process, fork, and `execv()` creation commits, with rollback on preparation failure.
- Transfer each thread's linear credit into an ordered `ThreadTerminationInfo` record carrying the exact PID, TID, and zombie status.
- Emit the final thread event before process termination while keeping join, detach, reap, and harvest limited to resource reclamation.
- Extend broker accounting, shutdown disposal, transition tests, and the standalone kernel-test harness with a procd-only lifecycle consumer.

## Validation

- `./z build -- format-check`
- `./z build -- lint-check`
- `./z build -- check-test-kernel check-guest-rlibs`
- `./z build -- run-unit-tests`
- `./z build -- run-kernel-tests`
- `./z build -- run-nanvix-tests`

Closes #3054