### PR TITLE
[fat32] Normalize invalid FAT timestamps

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -118,7 +118,7 @@ POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c ftruncate.c truncate.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
-	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c utimensat.c
+	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c utimensat.c utime.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's

--- a/src/libs/fat32/src/fat/time.rs
+++ b/src/libs/fat32/src/fat/time.rs
@@ -115,6 +115,10 @@ pub(crate) fn unix_to_datetime(secs: i64) -> DateTime {
 
 /// Converts a FAT `DateTime` back to Unix seconds.
 pub(crate) fn datetime_to_unix(dt: DateTime) -> i64 {
+    if !is_valid_date(dt.date) || dt.time.hour > 23 || dt.time.min > 59 || dt.time.sec > 59 {
+        return FAT_EPOCH_SECS;
+    }
+
     let days: i64 =
         days_from_civil(i64::from(dt.date.year), i64::from(dt.date.month), i64::from(dt.date.day));
     days * SECS_PER_DAY
@@ -125,7 +129,24 @@ pub(crate) fn datetime_to_unix(dt: DateTime) -> i64 {
 
 /// Converts a FAT `Date` (no time part) to Unix seconds at midnight.
 pub(crate) fn date_to_unix(date: Date) -> i64 {
+    if !is_valid_date(date) {
+        return FAT_EPOCH_SECS;
+    }
+
     days_from_civil(i64::from(date.year), i64::from(date.month), i64::from(date.day)) * SECS_PER_DAY
+}
+
+/// Returns whether a decoded FAT date has valid fields.
+fn is_valid_date(date: Date) -> bool {
+    let year: i64 = i64::from(date.year);
+    let max_day: u16 = match date.month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if (year % 4 == 0 && year % 100 != 0) || year % 400 == 0 => 29,
+        2 => 28,
+        _ => 0,
+    };
+    (MIN_FAT_YEAR..=MAX_FAT_YEAR).contains(&year) && date.day > 0 && date.day <= max_day
 }
 
 /// Civil (year, month, day) from days since the Unix epoch.
@@ -163,6 +184,7 @@ fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
+    use ::fatfs::NullTimeProvider;
 
     /// Round-trips a known timestamp through DateTime and back.
     #[test]
@@ -202,5 +224,13 @@ mod tests {
         assert_eq!(dt.date.year, 1980, "year");
         assert_eq!(dt.date.month, 1, "month");
         assert_eq!(dt.date.day, 1, "day");
+    }
+
+    /// Zero-valued FAT dates represent an unknown timestamp.
+    #[test]
+    fn null_date_uses_fat_epoch() {
+        let provider: NullTimeProvider = NullTimeProvider::new();
+        assert_eq!(date_to_unix(provider.get_current_date()), FAT_EPOCH_SECS);
+        assert_eq!(datetime_to_unix(provider.get_current_date_time()), FAT_EPOCH_SECS);
     }
 }

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -148,6 +148,9 @@ extern void test_utimes(void);
 // Tests whether we can update file timestamps with `utime()`.
 extern void test_utime(void);
 
+// Tests whether `utime()` preserves timestamps imported by mkramfs.
+extern void test_utime_preserve_imported_timestamps(void);
+
 // Tests whether we can write and read to/from a file.
 extern void test_write_read(void);
 

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -154,11 +154,12 @@ int main(int argc, const char *argv[])
     test_fchdir();
     // NULL times returns success even on FAT32 (timestamps are ignored).
     test_utimensat_now();
+    test_utime_preserve_imported_timestamps();
 #ifndef __NANVIX_STANDALONE__
     // FAT32 timestamps, permissions, and ownership are no-ops that fail assertions.
     test_utimensat();
-    test_utimes();    // requires open(), close(), stat() and unlinkat().
-    test_utime();     // requires open(), close(), stat() and unlinkat().
+    test_utimes(); // requires open(), close(), stat() and unlinkat().
+    test_utime();  // requires open(), close(), stat() and unlinkat().
     test_chmod();     // requires open(), close(), stat() and unlinkat().
     test_fchmodat();  // requires open(), close(), stat() and unlinkat().
     test_fchmod();    // requires open(), close(), fstat() and unlink().

--- a/src/tests/integration/test-c-file/utime.c
+++ b/src/tests/integration/test-c-file/utime.c
@@ -9,15 +9,12 @@
 
 #include "common.h"
 #include <assert.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <string.h>
 #include <sys/select.h>
 #include <sys/stat.h>
-#include <sys/utime.h>
-#include <time.h>
 #include <unistd.h>
+#include <utime.h>
 
 //==================================================================================================
 // Standalone Functions
@@ -41,14 +38,44 @@ void test_utime(void)
 
     // Set new timestamps.
     struct utimbuf times = {
-        .actime = st.st_atime + 20, // Access time.
-        .modtime = st.st_mtime + 10 // Modification time.
+        .actime = st.st_atime + 20,
+        .modtime = st.st_mtime + 10,
     };
-
-    // Update the file timestamps using utime and check the result.
     assert(utime(filename, &times) == 0);
 
     // Verify the updated timestamps.
+    assert(stat(filename, &st) == 0);
+    assert(st.st_atime == times.actime);
+    assert(st.st_mtime == times.modtime);
+
+    // Clean up.
+    assert(unlink(filename) == 0);
+
+    fprintf(stderr, "passed\n");
+}
+
+// Tests whether `utime()` preserves timestamps imported by mkramfs.
+void test_utime_preserve_imported_timestamps(void)
+{
+    fprintf(stderr, "testing utime() with imported timestamps ... ");
+
+    struct stat st = {0};
+    const char *filename = "testfile-imported.tmp";
+
+    // Create a temporary file.
+    int fd = open(filename, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+    assert(close(fd) == 0);
+
+    // Preserve timestamps from a file imported by mkramfs.
+    assert(stat("marker.txt", &st) == 0);
+    struct utimbuf times = {
+        .actime = st.st_atime,
+        .modtime = st.st_mtime,
+    };
+    assert(utime(filename, &times) == 0);
+
+    // Verify the preserved timestamps.
     assert(stat(filename, &st) == 0);
     assert(st.st_atime == times.actime);
     assert(st.st_mtime == times.modtime);


### PR DESCRIPTION
## Summary

Hotfix for bzip2 build failure.

- Normalize malformed FAT dates to the FAT epoch.
- Prevent zero-valued FAT dates from becoming pre-1980 Unix timestamps.
- Test timestamp preservation from files imported by `mkramfs`.

## Testing

- FAT32 unit tests
- POSIX file integration tests
- Full Nanvix build, lint, and test lifecycle
- Full downstream ecosystem lifecycle
