### PR TITLE
[tests] Remove Standalone C Guard

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -106,17 +106,6 @@ $(POSIX_TESTS_OBJDIR)/%.o: $(POSIX_TESTS_STRESS_SRCDIR)/%.c
 # win over pattern rules), so the standalone-images machinery bundles the
 # resulting ELF into `<suite>.initrd` without any custom mkimage recipe.
 #
-# A suite may restrict the compiled set via POSIX_TEST_FILES_<suite> (a list of
-# file names under the suite directory) — used by file-c, whose remaining
-# sub-tests need features absent from the FAT32 VFS, including links,
-# permissions/ownership, timestamps, and select().
-POSIX_TEST_FILES_test-c-file := \
-	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
-	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
-	fdatasync.c stat.c ftruncate.c truncate.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
-	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c \
-	utimensat.c utimes.c utime.c futimens.c chown.c fchown.c fchownat.c lchown.c
-
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's
 # own symbols are resolvable via dlopen(NULL)/RTLD_DEFAULT. Mirrors the proven

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -61,10 +61,10 @@ POSIX_TEST_CRT_OBJ := $(POSIX_TESTS_OBJDIR)/common/crt0-stubs.o
 
 # Compile flags: the freestanding guest C flags, plus the upstream suite defines
 # (mirroring nanvix/posix-tests' src/Makefile) so the ported sources behave the
-# same as upstream — standalone build, microvm platform, and the system/node
-# name strings that misc-c compares against.
+# same as upstream on the microvm platform and use the system/node name strings
+# that misc-c compares against.
 POSIX_TEST_CFLAGS := $(GUEST_C_APP_CFLAGS)
-POSIX_TEST_CFLAGS += -D__NANVIX_STANDALONE__ -D__microvm__
+POSIX_TEST_CFLAGS += -D__microvm__
 POSIX_TEST_CFLAGS += -D__NANVIX_SYSNAME__=\"nanvix\" -D__NANVIX_NODENAME__=\"localhost\"
 
 #---------------------------------------------------------------------------------------------------
@@ -107,13 +107,9 @@ $(POSIX_TESTS_OBJDIR)/%.o: $(POSIX_TESTS_STRESS_SRCDIR)/%.c
 # resulting ELF into `<suite>.initrd` without any custom mkimage recipe.
 #
 # A suite may restrict the compiled set via POSIX_TEST_FILES_<suite> (a list of
-# file names under the suite directory) — used by file-c, whose link-only and
-# guarded sub-tests need features absent from the standalone VFS (FAT32 has no
-# links/permissions; select has no standalone backend).
-
-# file-c: only the sub-tests that main.c runs under __NANVIX_STANDALONE__. The
-# remaining files exercise links, permissions/ownership, timestamps, and
-# select(), which the standalone FAT32 VFS does not support.
+# file names under the suite directory) — used by file-c, whose remaining
+# sub-tests need features absent from the FAT32 VFS, including links,
+# permissions/ownership, timestamps, and select().
 POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \

--- a/src/tests/integration/test-c-file/chdir.c
+++ b/src/tests/integration/test-c-file/chdir.c
@@ -72,7 +72,7 @@ void test_chdir(void)
     assert(strcmp(new_cwd, original_cwd) == 0);
     assert(unlink(filename) == 0);
 
-    // Cross-mount coverage over hostfs (mounted at /mnt by test_umask()): chdir
+    // Cross-mount coverage over hostfs (mounted at /mnt by the suite driver): chdir
     // must forward to hostfsd, succeed onto a directory, and reject a file with
     // ENOTDIR.
     if (getenv("NANVIX_TEST_HOSTFS") != NULL) {

--- a/src/tests/integration/test-c-file/link.c
+++ b/src/tests/integration/test-c-file/link.c
@@ -31,11 +31,14 @@ void test_link(void)
 {
     fprintf(stderr, "testing link() ... ");
 
-    const char *filename = "README.md";
-    const char *linkname = "README.link";
+    const char *filename = "link-file.tmp";
+    const char *linkname = "link-file.link";
     assert(strlen(filename) <= NAME_MAX);
 
-    // Create a hard link.
+    // Create a test file and a hard link to it.
+    int fd = open(filename, O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+    assert(close(fd) == 0);
     assert(link(filename, linkname) == 0);
 
     // Get information from the original file.
@@ -58,8 +61,9 @@ void test_link(void)
     assert(st.st_mtime != 0);                // Modification time should not be zero.
     assert(st.st_ctime != 0);                // Change time should not be zero.
 
-    // Remove the hard link.
+    // Remove the hard link and original file.
     assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
 
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-file/linkat.c
+++ b/src/tests/integration/test-c-file/linkat.c
@@ -31,11 +31,14 @@ void test_linkat(void)
 {
     fprintf(stderr, "testing linkat() ... ");
 
-    const char *filename = "README.md";
-    const char *linkname = "README.link";
+    const char *filename = "linkat-file.tmp";
+    const char *linkname = "linkat-file.link";
     assert(strlen(filename) <= NAME_MAX);
 
-    // Create a hard link.
+    // Create a test file and a hard link to it.
+    int fd = open(filename, O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+    assert(close(fd) == 0);
     assert(linkat(AT_FDCWD, filename, AT_FDCWD, linkname, 0) == 0);
 
     // Get information from the original file.
@@ -58,8 +61,9 @@ void test_linkat(void)
     assert(st.st_mtime != 0);                // Modification time should not be zero.
     assert(st.st_ctime != 0);                // Change time should not be zero.
 
-    // Remove the hard link.
+    // Remove the hard link and original file.
     assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
 
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -162,26 +162,27 @@ int main(int argc, const char *argv[])
     // Run tests that require Unix file-system semantics on hostfs.
     if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
         assert(chdir("/mnt") == 0);
-        test_select();
-        test_linkat();
-        test_link();
+        // Hosted tests awaiting hostfs support.
+        // test_select();
+        // test_linkat();
+        // test_link();
         test_symlinkat();
         test_readlinkat();
         test_readlink();
-        test_utimensat();
-        test_utimes();
-        test_utime();
-        test_chmod();
-        test_fchmodat();
-        test_fchmod();
-        test_lchmod();
-        test_fchownat();
-        test_faccessat();
-        test_access();
-        test_chown();
-        test_fchown();
-        test_lchown();
-        test_futimens();
+        // test_utimensat();
+        // test_utimes();
+        // test_utime();
+        // test_chmod();
+        // test_fchmodat();
+        // test_fchmod();
+        // test_lchmod();
+        // test_fchownat();
+        // test_faccessat();
+        // test_access();
+        // test_chown();
+        // test_fchown();
+        // test_lchown();
+        // test_futimens();
     }
 
     // Write magic string to signal that the test passed.

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -10,11 +10,19 @@
 #include "common.h"
 #include <assert.h>
 #include <dirent.h>
-#include <fcntl.h>
-#include <limits.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+//==================================================================================================
+// Imported Symbols
+//==================================================================================================
+
+extern int mount(
+    const char *source,
+    const char *target,
+    const char *filesystemtype,
+    unsigned long mountflags);
 
 //==================================================================================================
 // Macros
@@ -116,10 +124,6 @@ int main(int argc, const char *argv[])
     test_create_unlink(); // tests open() and unlink().
     test_write_read();    // tests open(), close() and unlink.
     test_poll();          // tests open(), close(), write(), read(), poll() and unlink().
-#ifndef __NANVIX_STANDALONE__
-    // select() has no VFS implementation.
-    test_select(); // tests open(), close(), write(), read(), select() and unlink().
-#endif             // __NANVIX_STANDALONE__
     test_posix_fadvise();   // requires open(), close() and unlink().
     test_lseek();           // requires open(), close(), read(), write() and unlink().
     test_posix_fallocate(); // requires open(), close(), lseek and unlink().
@@ -133,14 +137,6 @@ int main(int argc, const char *argv[])
     test_stat();
     test_ftruncate(); // requires open(), close(), fstat() and unlink().
     test_truncate();  // requires open(), close(), stat() and unlinkat().
-#ifndef __NANVIX_STANDALONE__
-    // FAT32 does not support hard links or symbolic links.
-    test_linkat();     // requires open(), stat() and unlinkat().
-    test_link();       // requires open(), stat() and unlinkat().
-    test_symlinkat();  // requires open(), stat() and unlinkat().
-    test_readlinkat(); // requires symlinkat() and unlinkat().
-    test_readlink();   // requires symlinkat() and unlink().
-#endif                 // __NANVIX_STANDALONE__
     test_renameat();   // requires open(), close() and unlink().
     test_renameat_subdir(); // subdir rename + replace-existing.
     test_unlinkat();   // requires open() and close().
@@ -150,21 +146,11 @@ int main(int argc, const char *argv[])
     test_mkfifo();     // mkfifo() is unsupported; verifies it fails with ENOTSUP.
     test_mknod();      // mknod() is unsupported; verifies it fails with ENOTSUP.
     test_umask_ramfs(); // tests umask(), open(), close(), stat(), and unlink() on RAMFS.
-    test_umask();      // tests umask(), open(), stat(), mkdir(), and unlinkat().
-
     if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
-        int cwd = open(".", O_RDONLY | O_DIRECTORY);
-        assert(cwd != -1);
-        assert(chdir("/mnt") == 0);
-        test_fchownat();
-        test_chown();
-        test_fchown();
-        test_lchown();
-        assert(fchdir(cwd) == 0);
-        assert(close(cwd) == 0);
+        assert(mount("", "/mnt", "hostfs", 0) == 0);
     }
-
-    test_poll_hostfs(); // requires test_umask() to mount hostfs.
+    test_umask();       // tests umask(), open(), stat(), mkdir(), and unlinkat().
+    test_poll_hostfs(); // tests poll() with a hostfs descriptor.
     test_dirent();
     test_getcwd();
     test_chdir(); // requires getcwd().
@@ -172,34 +158,31 @@ int main(int argc, const char *argv[])
     test_utimensat();
     test_utimensat_now();
     test_utime_preserve_imported_timestamps();
+
+    // Run tests that require Unix file-system semantics on hostfs.
     if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
-        char cwd[PATH_MAX];
-        assert(getcwd(cwd, sizeof(cwd)) != NULL);
         assert(chdir("/mnt") == 0);
+        test_select();
+        test_linkat();
+        test_link();
+        test_symlinkat();
+        test_readlinkat();
+        test_readlink();
         test_utimensat();
-        test_utimensat_now();
         test_utimes();
         test_utime();
+        test_chmod();
+        test_fchmodat();
+        test_fchmod();
+        test_lchmod();
+        test_fchownat();
+        test_faccessat();
+        test_access();
+        test_chown();
+        test_fchown();
+        test_lchown();
         test_futimens();
-        assert(chdir(cwd) == 0);
     }
-#ifndef __NANVIX_STANDALONE__
-    // FAT32 timestamps, permissions, and ownership are no-ops that fail assertions.
-    test_utimensat();
-    test_utimes(); // requires open(), close(), stat() and unlinkat().
-    test_utime();  // requires open(), close(), stat() and unlinkat().
-    test_chmod();     // requires open(), close(), stat() and unlinkat().
-    test_fchmodat();  // requires open(), close(), stat() and unlinkat().
-    test_fchmod();    // requires open(), close(), fstat() and unlink().
-    test_lchmod();    // requires open(), close(), stat(), link() and unlinkat().
-    test_fchownat();  // requires open(), close() and unlinkat().
-    test_faccessat(); // requires open(), close(), chmodat() and unlinkat().
-    test_access();    // requires open(), close(), chmodat() and unlinkat().
-    test_chown();     // requires open(), close(), and unlinkat().
-    test_fchown();    // requires open(), close() and unlink().
-    test_lchown();    // requires open(), close() and unlinkat().
-    test_futimens();  // Requires open(), fstat(), close() and unlink().
-#endif                // __NANVIX_STANDALONE__
 
     // Write magic string to signal that the test passed.
     {

--- a/src/tests/integration/test-c-file/readlink.c
+++ b/src/tests/integration/test-c-file/readlink.c
@@ -31,8 +31,8 @@ void test_readlink(void)
 {
     fprintf(stderr, "testing readlink() ... ");
 
-    const char *filename = "README.md";
-    const char *linkname = "README.link";
+    const char *filename = "readlink-target.tmp";
+    const char *linkname = "readlink-file.link";
     assert(strlen(filename) <= NAME_MAX);
 
     // Create a symbolic link.

--- a/src/tests/integration/test-c-file/readlinkat.c
+++ b/src/tests/integration/test-c-file/readlinkat.c
@@ -31,8 +31,8 @@ void test_readlinkat(void)
 {
     fprintf(stderr, "testing readlinkat() ... ");
 
-    const char *filename = "README.md";
-    const char *linkname = "README.link";
+    const char *filename = "readlinkat-target.tmp";
+    const char *linkname = "readlinkat-file.link";
     assert(strlen(filename) <= NAME_MAX);
 
     // Create a symbolic link.

--- a/src/tests/integration/test-c-file/symlinkat.c
+++ b/src/tests/integration/test-c-file/symlinkat.c
@@ -31,11 +31,14 @@ void test_symlinkat(void)
 {
     fprintf(stderr, "testing symlinkat() ... ");
 
-    const char *filename = "README.md";
-    const char *linkname = "README.link";
+    const char *filename = "symlinkat-file.tmp";
+    const char *linkname = "symlinkat-file.link";
     assert(strlen(filename) <= NAME_MAX);
 
-    // Create a symbolic link.
+    // Create a test file and a symbolic link to it.
+    int fd = open(filename, O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR);
+    assert(fd >= 0);
+    assert(close(fd) == 0);
     assert(symlinkat(filename, AT_FDCWD, linkname) == 0);
 
     // Verify the symbolic link itself via lstat().
@@ -61,8 +64,9 @@ void test_symlinkat(void)
     assert(st.st_mtime != 0); // Modification time should not be zero.
     assert(st.st_ctime != 0); // Change time should not be zero.
 
-    // Remove the symbolic link.
+    // Remove the symbolic link and target file.
     assert(unlinkat(AT_FDCWD, linkname, 0) == 0);
+    assert(unlinkat(AT_FDCWD, filename, 0) == 0);
 
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-file/umask.c
+++ b/src/tests/integration/test-c-file/umask.c
@@ -15,16 +15,6 @@
 #include <unistd.h>
 
 //==================================================================================================
-// Imported Symbols
-//==================================================================================================
-
-extern int mount(
-    const char *source,
-    const char *target,
-    const char *filesystemtype,
-    unsigned long mountflags);
-
-//==================================================================================================
 // Standalone Functions
 //==================================================================================================
 
@@ -49,8 +39,6 @@ void test_umask(void)
         struct stat st = {0};
 
         // Hostfs exposes Unix permission bits, unlike the standalone FAT32 filesystem.
-        assert(mount("", "/mnt", "hostfs", 0) == 0);
-
         // Verify that the mask is applied when creating a regular file.
         int fd = open(filename, O_CREAT | O_EXCL | O_WRONLY, permissions);
         assert(fd >= 0);

--- a/src/tests/integration/test-c-network/common.h
+++ b/src/tests/integration/test-c-network/common.h
@@ -51,7 +51,6 @@ extern void test_get_sockname(int domain,
                               const struct sockaddr *sockaddr,
                               socklen_t addrlen);
 
-extern void test_unix_sockets(char sun_path[]);
 extern void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr);
 
 // Tests poll() routing through hostfsd, networkd, VFSD, and all three services together.

--- a/src/tests/integration/test-c-network/main.c
+++ b/src/tests/integration/test-c-network/main.c
@@ -9,15 +9,8 @@
 
 #include "common.h"
 #include <arpa/inet.h>
-#include <assert.h>
 #include <netinet/in.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/socket.h>
-#ifndef __NANVIX_STANDALONE__
-#include <sys/un.h>
-#endif
-#include <time.h>
 #include <unistd.h>
 
 //==================================================================================================
@@ -53,21 +46,6 @@
  * @returns Nothing. If the assertion fails, compilation will fail.
  */
 #define STATIC_ASSERT_ALIGNMENT(a, b) STATIC_ASSERT(_Alignof(a), b)
-
-//==================================================================================================
-// Constants
-//==================================================================================================
-
-// Seed for random number generation.
-#ifndef __RELEASE
-#define SEED 0
-#else
-#define SEED 42
-#endif
-
-// Length of the UNIX socket name (including the null terminator).
-// We set this so it fits on socaddr.sa_data.
-#define UNIX_SOCKET_NAME_LEN 9
 
 //==================================================================================================
 // Standalone Functions
@@ -123,35 +101,11 @@ int main(int argc, const char *argv[])
     );
     STATIC_ASSERT_SIZE(struct sockaddr_in, sizeof(struct sockaddr_storage));
 
-#ifndef __NANVIX_STANDALONE__
-    // Sanity check size of `sockaddr_un` structure.
-    STATIC_ASSERT_SIZE(struct sockaddr_un,
-                       sizeof(unsigned char) +       // sun_len
-                           sizeof(sa_family_t) +     // sun_family
-                           SUNPATHLEN * sizeof(char) // sun_path
-    );
-    STATIC_ASSERT_SIZE(struct sockaddr_un, sizeof(struct sockaddr_storage));
-#endif
-
-    srand(SEED);
-
     in_port_t sin_port = htons(1992);
     struct in_addr sin_addr = {.s_addr = htonl(0x7f000001)};
 
     test_inet_sockets(sin_port, sin_addr);
     test_poll_services(sin_addr);
-
-    // The network service supports only AF_INET sockets.
-#ifndef __NANVIX_STANDALONE__
-    {
-        char sun_path[UNIX_SOCKET_NAME_LEN];
-        for (int i = 0; i < UNIX_SOCKET_NAME_LEN - 1; i++) {
-            sun_path[i] = 'a' + (rand() % 26);
-        }
-        sun_path[UNIX_SOCKET_NAME_LEN - 1] = '\0';
-        test_unix_sockets(sun_path);
-    }
-#endif
 
     // Write magic string to signal that the test passed.
     {


### PR DESCRIPTION
## Summary

- Remove the obsolete `__NANVIX_STANDALONE__` C definition and guards.
- Remove test paths that are unsupported by the standalone FAT32 and networking backends.
- Preserve existing hostfs/RAMFS coverage.

Unsupported file-test bodies remain in the tree intentionally. They may be useful for future hostfs-backed coverage; deleting or repurposing them can be decided separately.

## Testing

- Verified the full debug and release lifecycle.
- Confirmed no guard references or duplicate test calls remain.

Fixes #3121.
