### PR TITLE
[sys] E: Define Root Identity Defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ dependencies = [
 name = "libc_grp"
 version = "0.24.4"
 dependencies = [
+ "sys",
  "sysapi",
  "syslog",
 ]
@@ -1648,8 +1649,8 @@ dependencies = [
 name = "libc_pwd"
 version = "0.24.4"
 dependencies = [
+ "sys",
  "sysapi",
- "syscall",
  "syslog",
 ]
 

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -40,8 +40,10 @@ use ::sys::{
         MessageType,
     },
     pm::{
+        GroupIdentifier,
         ProcessIdentifier,
         ThreadIdentifier,
+        UserIdentifier,
     },
 };
 use ::syscall::unistd::message::ChangeDirectoryResponse;
@@ -1250,8 +1252,8 @@ fn complete_stat(
         } else {
             STAT_NLINK_FILE
         },
-        st_uid: 0,
-        st_gid: 0,
+        st_uid: usize::from(UserIdentifier::ROOT) as _,
+        st_gid: usize::from(GroupIdentifier::ROOT) as _,
         st_rdev: 0,
         st_size: resp.size as off_t,
         st_atim: timespec {
@@ -1474,8 +1476,8 @@ fn complete_lstat(
         } else {
             STAT_NLINK_FILE
         },
-        st_uid: 0,
-        st_gid: 0,
+        st_uid: usize::from(UserIdentifier::ROOT) as _,
+        st_gid: usize::from(GroupIdentifier::ROOT) as _,
         st_rdev: 0,
         st_size: resp.size as off_t,
         st_atim: timespec {

--- a/src/libs/libc_grp/Cargo.toml
+++ b/src/libs/libc_grp/Cargo.toml
@@ -14,6 +14,7 @@ homepage.workspace = true
 crate-type = ["lib"]
 
 [dependencies]
+sys = { workspace = true }
 sysapi = { workspace = true }
 syslog = { workspace = true, default-features = true }
 

--- a/src/libs/libc_grp/src/bindings.rs
+++ b/src/libs/libc_grp/src/bindings.rs
@@ -6,12 +6,15 @@
 //==================================================================================================
 
 use ::core::{
+    cell::UnsafeCell,
+    ffi::CStr,
     ptr,
     sync::atomic::{
         AtomicBool,
         Ordering,
     },
 };
+use ::sys::pm::GroupIdentifier;
 use ::sysapi::{
     ffi::{
         c_char,
@@ -26,7 +29,7 @@ use ::syslog::trace_libcall;
 // Static Storage
 //==================================================================================================
 
-/// Group name reported for the single-user Nanvix system.
+/// Name of the synthetic root group.
 static GR_NAME: [u8; 5] = *b"root\0";
 
 /// Placeholder password field (POSIX convention is a single `x`).
@@ -35,14 +38,19 @@ static GR_PASSWD: [u8; 2] = *b"x\0";
 /// Empty, null-terminated member list shared by every returned entry.
 static mut GR_MEM: [*const c_char; 1] = [ptr::null()];
 
-/// Static `group` entry returned by [`getgrgid`] and [`getgrnam`]. POSIX allows the result to point
-/// at static storage that is overwritten by subsequent calls.
-static mut GR_ENTRY: group = group {
-    gr_name: ptr::null(),
-    gr_passwd: ptr::null(),
-    gr_gid: 0,
-    gr_mem: ptr::null(),
-};
+/// Shared storage for the synthetic root entry.
+struct GroupEntry(UnsafeCell<group>);
+
+// SAFETY: callers must serialize access to the POSIX static entry.
+unsafe impl Sync for GroupEntry {}
+
+/// Static root entry returned by the group database functions.
+static GR_ENTRY: GroupEntry = GroupEntry(UnsafeCell::new(group {
+    gr_name: GR_NAME.as_ptr() as *const c_char,
+    gr_passwd: GR_PASSWD.as_ptr() as *const c_char,
+    gr_gid: GroupIdentifier::ROOT.as_usize() as gid_t,
+    gr_mem: ptr::addr_of!(GR_MEM) as *const *const c_char,
+}));
 
 /// Tracks whether the sequential enumeration started by [`setgrent`]/[`getgrent`] has already
 /// yielded the single synthetic `root` group. Reset by [`setgrent`] and [`endgrent`].
@@ -52,30 +60,19 @@ static GR_ENUM_DONE: AtomicBool = AtomicBool::new(false);
 // Private Functions
 //==================================================================================================
 
-///
-/// # Description
-///
-/// Populates the shared static [`group`] entry describing the `root` group with the supplied group
-/// ID and returns a pointer to it.
-///
-/// # Safety
-///
-/// The returned pointer aliases mutable static storage and must not be used concurrently from
-/// multiple threads.
-///
-unsafe fn fill_group(gid: gid_t) -> *mut group {
-    // Populate the static entry through a raw pointer. `addr_of_mut!` avoids constructing a
-    // reference to the mutable static (see `static_mut_refs`).
-    let entry: *mut group = ptr::addr_of_mut!(GR_ENTRY);
-    // SAFETY: `entry` points to the live, aligned `GR_ENTRY` static and the string/array pointers
-    // refer to NUL-terminated static buffers that outlive any use of the returned entry.
-    unsafe {
-        (*entry).gr_name = GR_NAME.as_ptr() as *const c_char;
-        (*entry).gr_passwd = GR_PASSWD.as_ptr() as *const c_char;
-        (*entry).gr_gid = gid;
-        (*entry).gr_mem = ptr::addr_of!(GR_MEM) as *const *const c_char;
+/// Checks whether `name` identifies root.
+unsafe fn is_root_name(name: *const c_char) -> bool {
+    if name.is_null() {
+        return false;
     }
-    entry
+
+    // SAFETY: the caller provides a valid NUL-terminated name.
+    unsafe { CStr::from_ptr(name) }.to_bytes() == b"root"
+}
+
+/// Returns the root group identifier at the POSIX boundary.
+fn root_gid() -> gid_t {
+    GroupIdentifier::ROOT.as_usize() as gid_t
 }
 
 //==================================================================================================
@@ -85,14 +82,11 @@ unsafe fn fill_group(gid: gid_t) -> *mut group {
 ///
 /// # Description
 ///
-/// Returns the group database entry for the group identified by `gid`. Nanvix is effectively a
-/// single-user system, so rather than consulting an `/etc/group` database this function returns a
-/// statically-allocated [`group`] entry describing the `root` group, reporting the supplied `gid`
-/// verbatim in `gr_gid`.
+/// Returns the synthetic `root` group entry. Other group IDs return a null pointer.
 ///
 /// # Parameters
 ///
-/// - `gid`: The group ID to report in the returned entry.
+/// - `gid`: The group ID to look up.
 ///
 /// # Returns
 ///
@@ -108,8 +102,11 @@ unsafe fn fill_group(gid: gid_t) -> *mut group {
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn getgrgid(gid: gid_t) -> *mut group {
-    // SAFETY: `fill_group()` only writes to the shared static entry and returns a pointer to it.
-    unsafe { fill_group(gid) }
+    if gid != root_gid() {
+        return ptr::null_mut();
+    }
+
+    GR_ENTRY.0.get()
 }
 
 //==================================================================================================
@@ -119,13 +116,11 @@ pub unsafe extern "C" fn getgrgid(gid: gid_t) -> *mut group {
 ///
 /// # Description
 ///
-/// Returns the group database entry for the group with the name `name`. Nanvix only has the `root`
-/// group, so the lookup ignores `name` and returns the statically-allocated [`group`] entry for the
-/// root group (GID `0`).
+/// Returns the synthetic `root` group entry. Other names return a null pointer.
 ///
 /// # Parameters
 ///
-/// - `name`: The group name to look up. Ignored on Nanvix.
+/// - `name`: The group name to look up.
 ///
 /// # Returns
 ///
@@ -134,17 +129,20 @@ pub unsafe extern "C" fn getgrgid(gid: gid_t) -> *mut group {
 ///
 /// # Safety
 ///
-/// This function returns a pointer to static storage that must not be freed by the caller and may be
-/// overwritten by subsequent calls. It is not thread-safe.
+/// `name` must point to a readable NUL-terminated string. This function returns a pointer to static
+/// storage that must not be freed by the caller and may be overwritten by subsequent calls. It is
+/// not thread-safe.
 ///
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn getgrnam(name: *const c_char) -> *mut group {
-    // Nanvix only has the `root` group; the looked-up name is ignored.
-    let _ = name;
-    // SAFETY: `fill_group()` only writes to the shared static entry and returns a pointer to it.
-    unsafe { fill_group(0) }
+    // SAFETY: the caller provides a valid NUL-terminated group name.
+    if !unsafe { is_root_name(name) } {
+        return ptr::null_mut();
+    }
+
+    GR_ENTRY.0.get()
 }
 
 //==================================================================================================
@@ -154,13 +152,12 @@ pub unsafe extern "C" fn getgrnam(name: *const c_char) -> *mut group {
 ///
 /// # Description
 ///
-/// Computes the list of group IDs that the user `user` belongs to. Nanvix is a single-user system
-/// with no supplementary group memberships, so the resulting list contains only the caller-supplied
-/// primary group `group`.
+/// Computes the group list for root. Nanvix has no supplementary groups, so the result contains
+/// only the root group.
 ///
 /// # Parameters
 ///
-/// - `user`: The user whose groups are queried. Ignored on Nanvix.
+/// - `user`: The user whose groups are queried.
 /// - `group`: The primary group ID to include in the result.
 /// - `groups`: Buffer that receives the group IDs.
 /// - `ngroups`: On input, the number of elements `groups` can hold; on output, the number of groups
@@ -173,8 +170,9 @@ pub unsafe extern "C" fn getgrnam(name: *const c_char) -> *mut group {
 ///
 /// # Safety
 ///
-/// The caller must ensure that `ngroups` points to a valid `int`, and that `groups` points to at
-/// least `*ngroups` elements.
+/// `user` must point to a readable NUL-terminated string. The caller must ensure that `ngroups`
+/// points to a valid `int`, and that `groups` points to at least `*ngroups` elements when the input
+/// capacity is positive.
 ///
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
@@ -185,8 +183,10 @@ pub unsafe extern "C" fn getgrouplist(
     groups: *mut gid_t,
     ngroups: *mut c_int,
 ) -> c_int {
-    // Nanvix has no supplementary group memberships; the user is ignored.
-    let _ = user;
+    // SAFETY: the caller provides a valid NUL-terminated user name.
+    if !unsafe { is_root_name(user) } || group != root_gid() {
+        return -1;
+    }
 
     if ngroups.is_null() {
         return -1;
@@ -261,9 +261,9 @@ pub unsafe extern "C" fn endgrent() {
 ///
 /// # Description
 ///
-/// Returns the next entry from the group database. Nanvix is a single-user system whose synthetic
-/// database holds only the `root` group, so the first call after a [`setgrent`] returns that entry
-/// and subsequent calls return a null pointer until the enumeration is rewound.
+/// Returns the next entry from the group database. The synthetic database currently holds only the
+/// `root` group, so the first call after a [`setgrent`] returns that entry and subsequent calls
+/// return a null pointer until the enumeration is rewound.
 ///
 /// # Returns
 ///
@@ -284,8 +284,7 @@ pub unsafe extern "C" fn getgrent() -> *mut group {
         return ptr::null_mut();
     }
 
-    // SAFETY: `fill_group()` only writes to the shared static entry and returns a pointer to it.
-    unsafe { fill_group(0) }
+    GR_ENTRY.0.get()
 }
 
 //==================================================================================================
@@ -295,15 +294,13 @@ pub unsafe extern "C" fn getgrent() -> *mut group {
 ///
 /// # Description
 ///
-/// Initializes the supplementary group access list of the calling process from the group database
-/// for `user`, together with the additional group `group`. Nanvix is a single-user system with no
-/// supplementary group memberships, so the access list is already correct and this operation
-/// succeeds without modifying any state.
+/// Initializes the supplementary group access list for root. Nanvix has no supplementary groups,
+/// so valid root arguments succeed without modifying any state.
 ///
 /// # Parameters
 ///
-/// - `user`: The user whose group memberships would be consulted. Ignored on Nanvix.
-/// - `group`: An additional group ID to include. Ignored on Nanvix.
+/// - `user`: The user whose group memberships would be consulted.
+/// - `group`: An additional group ID to include.
 ///
 /// # Returns
 ///
@@ -311,13 +308,16 @@ pub unsafe extern "C" fn getgrent() -> *mut group {
 ///
 /// # Safety
 ///
-/// This function does not dereference its arguments and is safe to call with any values.
+/// `user` must point to a readable NUL-terminated string.
 ///
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn initgroups(user: *const c_char, group: gid_t) -> c_int {
-    // Nanvix has no supplementary group memberships; the arguments are ignored.
-    let _ = (user, group);
-    0
+    // SAFETY: the caller provides a valid NUL-terminated user name.
+    if unsafe { is_root_name(user) } && group == root_gid() {
+        0
+    } else {
+        -1
+    }
 }

--- a/src/libs/libc_pwd/Cargo.toml
+++ b/src/libs/libc_pwd/Cargo.toml
@@ -14,8 +14,8 @@ homepage.workspace = true
 crate-type = ["lib"]
 
 [dependencies]
+sys = { workspace = true }
 sysapi = { workspace = true }
-syscall = { workspace = true, features = ["syscall"] }
 syslog = { workspace = true, default-features = true }
 
 [features]

--- a/src/libs/libc_pwd/src/bindings.rs
+++ b/src/libs/libc_pwd/src/bindings.rs
@@ -7,12 +7,16 @@
 
 use super::syscall::{
     pw_dir_copy_len,
-    resolve_gid,
     PW_DIR_CAP,
 };
 use ::core::{
+    cell::UnsafeCell,
     ffi::CStr,
     ptr,
+};
+use ::sys::pm::{
+    GroupIdentifier,
+    UserIdentifier,
 };
 use ::sysapi::{
     ffi::c_char,
@@ -28,7 +32,7 @@ use ::syslog::trace_libcall;
 // Static Storage
 //==================================================================================================
 
-/// Username reported for the single-user Nanvix system.
+/// Name of the synthetic root user.
 static PW_NAME: [u8; 5] = *b"root\0";
 
 /// Placeholder password field (POSIX convention is a single `x`).
@@ -44,19 +48,28 @@ static PW_SHELL: [u8; 8] = *b"/bin/sh\0";
 static HOME_KEY: [u8; 5] = *b"HOME\0";
 
 /// Backing storage for the home directory returned in `pw_dir`.
-static mut PW_DIR: [u8; PW_DIR_CAP] = [0u8; PW_DIR_CAP];
-
-/// Static `passwd` entry returned by [`getpwuid`]. POSIX allows the result to
-/// point at static storage that is overwritten by subsequent calls.
-static mut PW_ENTRY: passwd = passwd {
-    pw_name: ptr::null(),
-    pw_passwd: ptr::null(),
-    pw_uid: 0,
-    pw_gid: 0,
-    pw_gecos: ptr::null(),
-    pw_dir: ptr::null(),
-    pw_shell: ptr::null(),
+static mut PW_DIR: [u8; PW_DIR_CAP] = {
+    let mut dir: [u8; PW_DIR_CAP] = [0u8; PW_DIR_CAP];
+    dir[0] = b'/';
+    dir
 };
+
+/// Shared storage for the synthetic root entry.
+struct PasswdEntry(UnsafeCell<passwd>);
+
+// SAFETY: callers must serialize access to the POSIX static entry.
+unsafe impl Sync for PasswdEntry {}
+
+/// Static root entry returned by [`getpwuid`] and [`getpwnam`].
+static PW_ENTRY: PasswdEntry = PasswdEntry(UnsafeCell::new(passwd {
+    pw_name: PW_NAME.as_ptr() as *const c_char,
+    pw_passwd: PW_PASSWD.as_ptr() as *const c_char,
+    pw_uid: UserIdentifier::ROOT.as_usize() as uid_t,
+    pw_gid: GroupIdentifier::ROOT.as_usize() as gid_t,
+    pw_gecos: PW_GECOS.as_ptr() as *const c_char,
+    pw_dir: ptr::addr_of!(PW_DIR) as *const c_char,
+    pw_shell: PW_SHELL.as_ptr() as *const c_char,
+}));
 
 //==================================================================================================
 // External Functions
@@ -76,17 +89,13 @@ unsafe extern "C" {
 ///
 /// # Description
 ///
-/// Returns the password database entry for the user identified by `uid`. Nanvix is
-/// effectively a single-user system, so rather than consulting an `/etc/passwd`
-/// database this function returns a statically-allocated [`passwd`] entry describing
-/// the `root` user. The home directory (`pw_dir`) is taken from the `HOME` environment
-/// variable when set, and falls back to `"/"` otherwise. The supplied `uid` is reported
-/// verbatim in `pw_uid`, and `pw_gid` is populated from the real group ID returned by
-/// `getgid()`, falling back to `0` (root) when that lookup fails.
+/// Returns the synthetic `root` password database entry. Lookups for other user IDs return a null
+/// pointer. The home directory (`pw_dir`) is taken from the `HOME` environment variable when set,
+/// and falls back to `"/"` otherwise.
 ///
 /// # Parameters
 ///
-/// - `uid`: The user ID to report in the returned entry.
+/// - `uid`: The user ID to look up.
 ///
 /// # Returns
 ///
@@ -104,6 +113,10 @@ unsafe extern "C" {
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn getpwuid(uid: uid_t) -> *mut passwd {
+    if uid != UserIdentifier::ROOT.as_usize() as uid_t {
+        return ptr::null_mut();
+    }
+
     // Resolve the home directory from the environment (Layer 2), falling back to "/"
     // when HOME is unset or holds an invalid (e.g. empty) value.
     let home_ptr: *mut c_char = unsafe { getenv(HOME_KEY.as_ptr() as *const c_char) };
@@ -120,9 +133,6 @@ pub unsafe extern "C" fn getpwuid(uid: uid_t) -> *mut passwd {
         }
     };
 
-    // Resolve the real group ID, falling back to 0 (root) on error.
-    let gid: gid_t = resolve_gid();
-
     // Copy the home directory into the static buffer, truncating to fit and always
     // NUL-terminating. Raw-pointer writes are used to avoid taking references to the
     // mutable static (see `static_mut_refs`).
@@ -135,24 +145,7 @@ pub unsafe extern "C" fn getpwuid(uid: uid_t) -> *mut passwd {
         dir.add(n).write(0);
     }
 
-    // Populate the static entry through a raw pointer. `addr_of_mut!` avoids constructing a
-    // reference to the mutable static (see `static_mut_refs`). `passwd` is `#[repr(C)]`, so the
-    // static is naturally aligned and plain field stores produce a correctly-aligned
-    // `*mut passwd` for C callers.
-    let entry: *mut passwd = ptr::addr_of_mut!(PW_ENTRY);
-    // SAFETY: `entry` points to the live, aligned `PW_ENTRY` static and the string pointers refer
-    // to NUL-terminated static buffers that outlive any use of the returned entry.
-    unsafe {
-        (*entry).pw_name = PW_NAME.as_ptr() as *const c_char;
-        (*entry).pw_passwd = PW_PASSWD.as_ptr() as *const c_char;
-        (*entry).pw_uid = uid;
-        (*entry).pw_gid = gid;
-        (*entry).pw_gecos = PW_GECOS.as_ptr() as *const c_char;
-        (*entry).pw_dir = ptr::addr_of!(PW_DIR) as *const c_char;
-        (*entry).pw_shell = PW_SHELL.as_ptr() as *const c_char;
-    }
-
-    entry
+    PW_ENTRY.0.get()
 }
 
 //==================================================================================================
@@ -162,14 +155,11 @@ pub unsafe extern "C" fn getpwuid(uid: uid_t) -> *mut passwd {
 ///
 /// # Description
 ///
-/// Returns the password database entry for the user with the login name `name`. Nanvix is
-/// effectively a single-user system whose only account is `root`, so the lookup ignores `name` and
-/// returns the same statically-allocated [`passwd`] entry produced by [`getpwuid`] for the root
-/// user (UID `0`).
+/// Returns the synthetic `root` password database entry. Other names return a null pointer.
 ///
 /// # Parameters
 ///
-/// - `name`: The login name to look up. Ignored on Nanvix.
+/// - `name`: The login name to look up.
 ///
 /// # Returns
 ///
@@ -178,15 +168,24 @@ pub unsafe extern "C" fn getpwuid(uid: uid_t) -> *mut passwd {
 ///
 /// # Safety
 ///
-/// This function returns a pointer to static storage that must not be freed by the caller and may
-/// be overwritten by subsequent calls. It is not thread-safe: callers must ensure no other thread
-/// calls `getpwnam()` or `getpwuid()` while the returned pointer is still in use.
+/// `name` must point to a readable NUL-terminated string. This function returns a pointer to static
+/// storage that must not be freed by the caller and may be overwritten by subsequent calls. It is
+/// not thread-safe: callers must ensure no other thread calls `getpwnam()` or `getpwuid()` while the
+/// returned pointer is still in use.
 ///
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 #[trace_libcall]
 pub unsafe extern "C" fn getpwnam(name: *const c_char) -> *mut passwd {
-    // Nanvix has a single account (`root`, UID 0); the looked-up name is ignored.
-    let _ = name;
-    unsafe { getpwuid(0) }
+    if name.is_null() {
+        return ptr::null_mut();
+    }
+
+    // SAFETY: the caller provides a valid NUL-terminated login name.
+    if unsafe { CStr::from_ptr(name) }.to_bytes() != b"root" {
+        return ptr::null_mut();
+    }
+
+    let root_uid: uid_t = UserIdentifier::ROOT.as_usize() as uid_t;
+    unsafe { getpwuid(root_uid) }
 }

--- a/src/libs/libc_pwd/src/syscall.rs
+++ b/src/libs/libc_pwd/src/syscall.rs
@@ -6,7 +6,6 @@
 //==================================================================================================
 
 use ::core::cmp;
-use ::sysapi::sys_types::gid_t;
 
 //==================================================================================================
 // Constants
@@ -26,22 +25,6 @@ pub(super) const PW_DIR_CAP: usize = 256;
 /// write a NUL terminator at the returned offset.
 pub(super) fn pw_dir_copy_len(home: &[u8]) -> usize {
     cmp::min(home.len(), PW_DIR_CAP - 1)
-}
-
-//==================================================================================================
-// resolve_gid()
-//==================================================================================================
-
-/// Resolves the real group ID of the calling process, falling back to `0` (root)
-/// when the underlying `getgid()` lookup fails.
-pub(super) fn resolve_gid() -> gid_t {
-    match ::syscall::unistd::getgid() {
-        Ok(gid) => gid,
-        Err(error) => {
-            ::syslog::warn!("getpwuid(): getgid() failed (error={:?})", error);
-            0
-        },
-    }
 }
 
 //==================================================================================================

--- a/src/libs/sys/src/sys/pm/gid.rs
+++ b/src/libs/sys/src/sys/pm/gid.rs
@@ -19,6 +19,9 @@ use crate::error::{
 ///
 /// A type that represents a group identifier.
 ///
+/// Nanvix supports one group. Every process and filesystem object belongs to
+/// [`GroupIdentifier::ROOT`].
+///
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct GroupIdentifier(usize);
 
@@ -28,6 +31,11 @@ pub struct GroupIdentifier(usize);
 
 impl GroupIdentifier {
     pub const ROOT: GroupIdentifier = GroupIdentifier(0);
+
+    /// Returns the underlying identifier.
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
 }
 
 impl From<usize> for GroupIdentifier {
@@ -44,7 +52,15 @@ impl From<u32> for GroupIdentifier {
 
 impl From<GroupIdentifier> for usize {
     fn from(gid: GroupIdentifier) -> usize {
-        gid.0
+        gid.as_usize()
+    }
+}
+
+impl TryFrom<GroupIdentifier> for u32 {
+    type Error = core::num::TryFromIntError;
+
+    fn try_from(gid: GroupIdentifier) -> Result<Self, Self::Error> {
+        u32::try_from(gid.as_usize())
     }
 }
 

--- a/src/libs/sys/src/sys/pm/uid.rs
+++ b/src/libs/sys/src/sys/pm/uid.rs
@@ -19,6 +19,9 @@ use crate::error::{
 ///
 /// A type that represents a user identifier.
 ///
+/// Nanvix supports one user. Every process and filesystem object belongs to
+/// [`UserIdentifier::ROOT`].
+///
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct UserIdentifier(usize);
 
@@ -28,6 +31,11 @@ pub struct UserIdentifier(usize);
 
 impl UserIdentifier {
     pub const ROOT: UserIdentifier = UserIdentifier(0);
+
+    /// Returns the underlying identifier.
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
 }
 
 impl From<usize> for UserIdentifier {
@@ -44,7 +52,15 @@ impl From<u32> for UserIdentifier {
 
 impl From<UserIdentifier> for usize {
     fn from(uid: UserIdentifier) -> usize {
-        uid.0
+        uid.as_usize()
+    }
+}
+
+impl TryFrom<UserIdentifier> for u32 {
+    type Error = core::num::TryFromIntError;
+
+    fn try_from(uid: UserIdentifier) -> Result<Self, Self::Error> {
+        u32::try_from(uid.as_usize())
     }
 }
 

--- a/src/libs/syscall/src/unistd/syscall/getegid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getegid.rs
@@ -24,5 +24,5 @@ use ::sysapi::sys_types::gid_t;
 ///
 pub fn getegid() -> Result<gid_t, Error> {
     ::syslog::trace!("getegid()");
-    Ok(usize::from(::sys::pm::GroupIdentifier::ROOT) as gid_t)
+    Ok(::sys::pm::GroupIdentifier::ROOT.as_usize() as gid_t)
 }

--- a/src/libs/syscall/src/unistd/syscall/geteuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/geteuid.rs
@@ -24,5 +24,5 @@ use ::sysapi::sys_types::uid_t;
 ///
 pub fn geteuid() -> Result<uid_t, Error> {
     ::syslog::trace!("geteuid()");
-    Ok(usize::from(::sys::pm::UserIdentifier::ROOT) as uid_t)
+    Ok(::sys::pm::UserIdentifier::ROOT.as_usize() as uid_t)
 }

--- a/src/libs/syscall/src/unistd/syscall/getgid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getgid.rs
@@ -24,5 +24,5 @@ use ::sysapi::sys_types::gid_t;
 ///
 pub fn getgid() -> Result<gid_t, Error> {
     ::syslog::trace!("getgid()");
-    Ok(usize::from(::sys::pm::GroupIdentifier::ROOT) as gid_t)
+    Ok(::sys::pm::GroupIdentifier::ROOT.as_usize() as gid_t)
 }

--- a/src/libs/syscall/src/unistd/syscall/getuid.rs
+++ b/src/libs/syscall/src/unistd/syscall/getuid.rs
@@ -24,5 +24,5 @@ use ::sysapi::sys_types::uid_t;
 ///
 pub fn getuid() -> Result<uid_t, Error> {
     ::syslog::trace!("getuid()");
-    Ok(usize::from(::sys::pm::UserIdentifier::ROOT) as uid_t)
+    Ok(::sys::pm::UserIdentifier::ROOT.as_usize() as uid_t)
 }

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -68,7 +68,11 @@ use ::fat32::{
     FAT_EPOCH_SECS,
 };
 use ::spin::Mutex;
-use ::sys::pm::ProcessIdentifier;
+use ::sys::pm::{
+    GroupIdentifier,
+    ProcessIdentifier,
+    UserIdentifier,
+};
 use ::sysapi::{
     fcntl::{
         atflags::AT_SYMLINK_NOFOLLOW,
@@ -135,6 +139,12 @@ const FILE_PERMISSION_BITS: mode_t = file_mode::S_IRWXU | file_mode::S_IRWXG | f
 
 /// Shared console device retained independently of process descriptor tables.
 static CONSOLE_TERMINAL: Mutex<Option<Arc<Mutex<LineDiscipline>>>> = Mutex::new(None);
+
+/// Assigns the single Nanvix identity to a POSIX stat result.
+fn set_root_ownership(buf: &mut ::sysapi::sys_stat::stat) {
+    buf.st_uid = UserIdentifier::ROOT.as_usize() as uid_t;
+    buf.st_gid = GroupIdentifier::ROOT.as_usize() as gid_t;
+}
 
 /// Returns the process-global console terminal, creating it on first use.
 fn console_device() -> Arc<Mutex<LineDiscipline>> {
@@ -1254,6 +1264,7 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
             buf.update_from_vfs(&info);
         },
     }
+    set_root_ownership(buf);
 
     Ok(())
 }
@@ -1405,6 +1416,7 @@ pub fn vfs_stat(path: &str, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
     }
 
     buf.update_from_vfs(&info);
+    set_root_ownership(buf);
 
     Ok(())
 }

--- a/src/tests/integration/test-c-file/mkdir.c
+++ b/src/tests/integration/test-c-file/mkdir.c
@@ -48,9 +48,8 @@ void test_mkdir(void)
     assert(st.st_atime != 0); // Access time should not be zero.
     assert(st.st_mtime != 0); // Modification time should not be zero.
     assert(st.st_ctime != 0); // Change time should not be zero.
-    // TODO: Uncomment the following lines when user/group ID checks are supported.
-    // assert(st.st_uid == getuid()); // User ID of the owner.
-    // assert(st.st_gid == getgid()); // Group ID of the owner.
+    assert(st.st_uid == getuid()); // User ID of the owner.
+    assert(st.st_gid == getgid()); // Group ID of the owner.
 
     // Remove test directory.
     assert(unlinkat(AT_FDCWD, dirname, AT_REMOVEDIR) == 0);

--- a/src/tests/integration/test-c-file/mkdirat.c
+++ b/src/tests/integration/test-c-file/mkdirat.c
@@ -48,9 +48,8 @@ void test_mkdirat(void)
     assert(st.st_atime != 0); // Access time should not be zero.
     assert(st.st_mtime != 0); // Modification time should not be zero.
     assert(st.st_ctime != 0); // Change time should not be zero.
-    // TODO: Uncomment the following lines when user/group ID checks are supported.
-    // assert(st.st_uid == getuid()); // User ID of the owner.
-    // assert(st.st_gid == getgid()); // Group ID of the owner.
+    assert(st.st_uid == getuid()); // User ID of the owner.
+    assert(st.st_gid == getgid()); // Group ID of the owner.
 
     // Remove test directory.
     assert(unlinkat(AT_FDCWD, dirname, AT_REMOVEDIR) == 0);

--- a/src/tests/integration/test-c-file/stat.c
+++ b/src/tests/integration/test-c-file/stat.c
@@ -40,6 +40,8 @@ void test_stat(void)
     assert(st.st_blocks > 0);
     assert(st.st_dev != 0);
     assert(st.st_ino != 0);
+    assert(st.st_uid == getuid());
+    assert(st.st_gid == getgid());
 
     // Clean up.
     assert(unlink(filename) == 0);

--- a/src/tests/integration/test-c-misc/common.h
+++ b/src/tests/integration/test-c-misc/common.h
@@ -104,6 +104,9 @@ extern void test_setgroups(void);
 // Tests whether `initgroups()` initializes the supplementary group access list.
 extern void test_initgroups(void);
 
+// Tests whether the synthetic user and group databases describe the root identity.
+extern void test_user_group(void);
+
 // Tests whether we can retrieve process times with `times()`.
 extern void test_times(void);
 

--- a/src/tests/integration/test-c-misc/getegid.c
+++ b/src/tests/integration/test-c-misc/getegid.c
@@ -21,7 +21,7 @@ void test_getegid(void)
 {
     fprintf(stderr, "testing getegid() ... ");
 
-    assert(getegid() != (gid_t)-1);
+    assert(getegid() == getgid());
 
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-misc/geteuid.c
+++ b/src/tests/integration/test-c-misc/geteuid.c
@@ -21,7 +21,7 @@ void test_geteuid(void)
 {
     fprintf(stderr, "testing geteuid() ... ");
 
-    assert(geteuid() != (uid_t)-1);
+    assert(geteuid() == getuid());
 
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-misc/getgid.c
+++ b/src/tests/integration/test-c-misc/getgid.c
@@ -21,7 +21,7 @@ void test_getgid(void)
 {
     fprintf(stderr, "testing getgid() ... ");
 
-    assert(getgid() != (gid_t)-1);
+    assert(getgid() == 0);
 
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-misc/getuid.c
+++ b/src/tests/integration/test-c-misc/getuid.c
@@ -21,7 +21,7 @@ void test_getuid(void)
 {
     fprintf(stderr, "testing getuid() ... ");
 
-    assert(getuid() != (uid_t)-1);
+    assert(getuid() == 0);
 
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-misc/main.c
+++ b/src/tests/integration/test-c-misc/main.c
@@ -49,6 +49,7 @@ int main(int argc, const char *argv[])
     test_setresgid();
     test_setgroups();
     test_initgroups();
+    test_user_group();
     test_clock_getres();
     test_clock_gettime();
 #ifndef __hyperlight__

--- a/src/tests/integration/test-c-misc/setegid.c
+++ b/src/tests/integration/test-c-misc/setegid.c
@@ -31,5 +31,9 @@ void test_setegid(void)
     gid_t gid = getgid();
     assert(setegid(gid) == 0);
 
+    errno = 0;
+    assert(setegid(gid + 1) == -1);
+    assert(errno == EPERM);
+
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-misc/seteuid.c
+++ b/src/tests/integration/test-c-misc/seteuid.c
@@ -31,5 +31,9 @@ void test_seteuid(void)
     uid_t uid = getuid();
     assert(seteuid(uid) == 0);
 
+    errno = 0;
+    assert(seteuid(uid + 1) == -1);
+    assert(errno == EPERM);
+
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-misc/setgid.c
+++ b/src/tests/integration/test-c-misc/setgid.c
@@ -25,5 +25,9 @@ void test_setgid(void)
     gid_t gid = getgid();
     assert(setgid(gid) == 0);
 
+    errno = 0;
+    assert(setgid(gid + 1) == -1);
+    assert(errno == EPERM);
+
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-misc/setuid.c
+++ b/src/tests/integration/test-c-misc/setuid.c
@@ -25,5 +25,9 @@ void test_setuid(void)
     uid_t uid = getuid();
     assert(setuid(uid) == 0);
 
+    errno = 0;
+    assert(setuid(uid + 1) == -1);
+    assert(errno == EPERM);
+
     fprintf(stderr, "passed\n");
 }

--- a/src/tests/integration/test-c-misc/user_group.c
+++ b/src/tests/integration/test-c-misc/user_group.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <assert.h>
+#include <grp.h>
+#include <pwd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests whether the synthetic user and group databases describe the root identity.
+void test_user_group(void)
+{
+    const char *home = getenv("HOME");
+    struct passwd *pw = getpwnam("root");
+    assert(pw != NULL);
+    assert(strcmp(pw->pw_name, "root") == 0);
+    assert(pw->pw_uid == getuid());
+    assert(pw->pw_gid == getgid());
+    assert(strcmp(pw->pw_dir, home == NULL || home[0] == '\0' ? "/" : home) == 0);
+    assert(strcmp(pw->pw_shell, "/bin/sh") == 0);
+
+    pw = getpwuid(getuid());
+    assert(pw != NULL);
+    assert(pw->pw_uid == getuid());
+    assert(pw->pw_gid == getgid());
+
+    assert(getpwuid(getuid() + 1) == NULL);
+    assert(getpwnam("user") == NULL);
+
+    struct group *gr = getgrgid(getgid());
+    assert(gr != NULL);
+    assert(strcmp(gr->gr_name, "root") == 0);
+    assert(gr->gr_gid == getgid());
+    assert(gr->gr_mem != NULL);
+    assert(gr->gr_mem[0] == NULL);
+
+    gr = getgrnam("root");
+    assert(gr != NULL);
+    assert(gr->gr_gid == getgid());
+
+    assert(getgrgid(getgid() + 1) == NULL);
+    assert(getgrnam("user") == NULL);
+
+    gid_t groups[1] = {0};
+    int ngroups = 1;
+    assert(getgrouplist("root", getgid(), groups, &ngroups) == 1);
+    assert(ngroups == 1);
+    assert(groups[0] == getgid());
+    assert(initgroups("root", getgid()) == 0);
+    assert(getgrouplist("user", getgid(), groups, &ngroups) == -1);
+    assert(getgrouplist("root", getgid() + 1, groups, &ngroups) == -1);
+    assert(initgroups("user", getgid()) == -1);
+    assert(initgroups("root", getgid() + 1) == -1);
+}


### PR DESCRIPTION
Closes #3123.

## Summary

- establish typed root UID/GID defaults with checked POSIX conversions
- construct synthetic passwd and group entries safely with `MaybeUninit`
- preserve parameterized lookup behavior for future multi-user support
- report explicit root ownership for VFS and hostfs metadata
- expand coverage for identity getters, credential setters, account/group lookups, and file ownership

## Testing

- formatting, linting, and spellcheck pass
- all POSIX test binaries compile
- full `posix/test-c-misc` suite passes
- full `posix/test-c-file` suite passes through the test harness
- coverage includes non-root lookup parameters, root-only setter rejection, and file/directory ownership across RAMFS and hostfs paths
