### PR TITLE
[syscall] F: Implement select over poll

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -112,10 +112,10 @@ $(POSIX_TESTS_OBJDIR)/%.o: $(POSIX_TESTS_STRESS_SRCDIR)/%.c
 # links/permissions; select has no standalone backend).
 
 # file-c: only the sub-tests that main.c runs under __NANVIX_STANDALONE__. The
-# remaining files exercise links, permissions/ownership, timestamps, and
-# select(), which the standalone FAT32 VFS does not support.
+# remaining files exercise links, permissions/ownership, and timestamps, which
+# the standalone FAT32 VFS does not support.
 POSIX_TEST_FILES_test-c-file := \
-	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
+	main.c open_close.c create_unlink.c write_read.c poll.c select.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c device_namespace.c ftruncate.c truncate.c link.c linkat.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
 	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c \

--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -18,6 +18,16 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
+/* `restrict` is C99-only; expand it to the keyword in C and to nothing in C++,
+   where it is a parse error (even as `__restrict`) inside array parameters. */
+#ifndef __nanvix_restrict
+#ifdef __cplusplus
+#define __nanvix_restrict
+#else
+#define __nanvix_restrict restrict
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -56,8 +66,11 @@ typedef struct {
  * Functions
  *==================================================================================================*/
 
-extern int select(
-    int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
+extern int select(int nfds,
+                  fd_set *__nanvix_restrict readfds,
+                  fd_set *__nanvix_restrict writefds,
+                  fd_set *__nanvix_restrict exceptfds,
+                  struct timeval *__nanvix_restrict timeout);
 
 #ifdef __cplusplus
 }

--- a/src/libs/sysapi/headers/sys_select.toml
+++ b/src/libs/sysapi/headers/sys_select.toml
@@ -53,5 +53,8 @@ functions = ["select"]
 
 [overrides]
 select = '''
-extern int select(
-    int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);'''
+extern int select(int nfds,
+                  fd_set *restrict readfds,
+                  fd_set *restrict writefds,
+                  fd_set *restrict exceptfds,
+                  struct timeval *restrict timeout);'''

--- a/src/libs/syscall/src/poll/mod.rs
+++ b/src/libs/syscall/src/poll/mod.rs
@@ -12,7 +12,12 @@ pub mod socket_message;
 cfg_if::cfg_if! {
     if #[cfg(feature = "syscall")] {
         mod syscall;
-        pub use syscall::poll;
+        pub(crate) use syscall::{
+            poll,
+            PollEvents,
+            PollFd,
+            PollTimeout,
+        };
         pub mod bindings;
     }
 }

--- a/src/libs/syscall/src/poll/syscall.rs
+++ b/src/libs/syscall/src/poll/syscall.rs
@@ -151,11 +151,6 @@ impl PollFd {
     pub fn fd(&self) -> RawFileDescriptor {
         self.fd
     }
-
-    /// Returns the input events.
-    pub fn events(&self) -> &PollEvents {
-        &self.events
-    }
 }
 
 //==================================================================================================
@@ -174,10 +169,13 @@ impl PollFd {
 ///
 /// # Returns
 ///
-/// Upon success, this function returns a tuple containing the number of file descriptors that are
-/// ready for I/O and a vector of events that occurred on each file descriptor. If `zero` is
-/// returned, the timeout expired without any file descriptor becoming ready. On failure, this
-/// function returns an error.
+/// Upon success, this function returns one event mask for each input descriptor. If every mask is
+/// empty, the timeout expired without any descriptor becoming ready. On failure, this function
+/// returns an error.
+///
+/// # References
+///
+/// - [POSIX `poll()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/poll.html)
 ///
 pub fn poll(fds: &[PollFd], timeout: PollTimeout) -> Result<Vec<PollEvents>, Error> {
     ::syslog::trace!("poll(): fds={fds:?}, timeout={timeout:?}");
@@ -185,14 +183,23 @@ pub fn poll(fds: &[PollFd], timeout: PollTimeout) -> Result<Vec<PollEvents>, Err
     let timeout: c_int = timeout.into();
 
     if fds.is_empty() || fds.iter().all(|fd| fd.fd() < 0) {
+        const MAX_SLEEP: Duration = Duration::from_secs(u32::MAX as u64);
         if timeout < 0 {
-            const MAX_SLEEP: Duration = Duration::from_secs(u32::MAX as u64);
             loop {
                 ::sys::kcall::pm::__kcall_sleep(MAX_SLEEP)?;
             }
         }
         if timeout > 0 {
-            ::sys::kcall::pm::__kcall_sleep(Duration::from_millis(timeout as u64))?;
+            let mut remaining: Duration = Duration::from_millis(timeout as u64);
+            while remaining > MAX_SLEEP {
+                ::sys::kcall::pm::__kcall_sleep(MAX_SLEEP)?;
+                remaining = remaining.checked_sub(MAX_SLEEP).ok_or_else(|| {
+                    Error::new(ErrorCode::InvalidArgument, "poll timeout underflow")
+                })?;
+            }
+            if !remaining.is_zero() {
+                ::sys::kcall::pm::__kcall_sleep(remaining)?;
+            }
         }
         return Ok(fds.iter().map(|_| PollEvents(0)).collect());
     }

--- a/src/libs/syscall/src/sys/select/bindings/mod.rs
+++ b/src/libs/syscall/src/sys/select/bindings/mod.rs
@@ -50,7 +50,8 @@ use ::syslog::trace_syscall;
 /// - If `readfds` is not null, it points to a valid `fd_set` structure.
 /// - If `writefds` is not null, it points to a valid `fd_set` structure.
 /// - If `errorfds` is not null, it points to a valid `fd_set` structure.
-/// - If `timeout` is not null, it points to a valid `timeval` structure
+/// - If `timeout` is not null, it points to a valid `timeval` structure.
+/// - All non-null pointer arguments refer to disjoint memory regions.
 ///
 #[unsafe(no_mangle)]
 #[trace_syscall]

--- a/src/libs/syscall/src/sys/select/syscall/mod.rs
+++ b/src/libs/syscall/src/sys/select/syscall/mod.rs
@@ -5,19 +5,191 @@
 // Imports
 //==================================================================================================
 
+use crate::poll::{
+    poll,
+    PollEvents,
+    PollFd,
+    PollTimeout,
+};
+use ::alloc::vec::Vec;
+use ::core::{
+    cmp,
+    time::Duration,
+};
 use ::sys::error::{
     Error,
     ErrorCode,
 };
-use ::sysapi::sys_select::{
-    fd_set,
-    timeval,
-    FD_SETSIZE,
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_short,
+    },
+    poll::{
+        poll_errors::{
+            POLLERR,
+            POLLHUP,
+            POLLNVAL,
+        },
+        poll_flags::{
+            POLLIN,
+            POLLOUT,
+            POLLPRI,
+            POLLRDBAND,
+            POLLRDNORM,
+            POLLWRBAND,
+            POLLWRNORM,
+        },
+    },
+    sys_select::{
+        fd_set,
+        timeval,
+        FD_SETSIZE,
+    },
 };
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Initial delay between readiness probes.
+const INITIAL_PROBE_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Maximum delay between readiness probes.
+const MAX_PROBE_INTERVAL: Duration = Duration::from_millis(32);
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Descriptor sets in which one polled descriptor appears.
+#[derive(Clone, Copy, Debug)]
+struct SelectInterests {
+    read: bool,
+    write: bool,
+    error: bool,
+}
 
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
+
+/// Converts a `select()` timeout to a duration, or `None` for an infinite wait.
+fn select_timeout(timeout: &Option<timeval>) -> Result<Option<Duration>, Error> {
+    let Some(timeout) = timeout else {
+        return Ok(None);
+    };
+    if timeout.tv_sec < 0 || timeout.tv_usec < 0 || timeout.tv_usec >= 1_000_000 {
+        return Err(Error::new(ErrorCode::InvalidArgument, "invalid select timeout"));
+    }
+
+    let seconds: u64 = u64::try_from(timeout.tv_sec)
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid select timeout"))?;
+    let nanoseconds: u32 = u32::try_from(timeout.tv_usec * 1_000)
+        .map_err(|_| Error::new(ErrorCode::InvalidArgument, "invalid select timeout"))?;
+    Ok(Some(Duration::new(seconds, nanoseconds)))
+}
+
+/// Builds one polling entry per descriptor present in any input set.
+fn poll_fds(
+    nfds: usize,
+    readfds: Option<&fd_set>,
+    writefds: Option<&fd_set>,
+    errorfds: Option<&fd_set>,
+) -> Result<(Vec<PollFd>, Vec<SelectInterests>), Error> {
+    let mut poll_fds: Vec<PollFd> = Vec::new();
+    let mut interests: Vec<SelectInterests> = Vec::new();
+    for fd in 0..nfds {
+        let read: bool = readfds.is_some_and(|fds| fds.is_set(fd).unwrap_or(false));
+        let write: bool = writefds.is_some_and(|fds| fds.is_set(fd).unwrap_or(false));
+        let error: bool = errorfds.is_some_and(|fds| fds.is_set(fd).unwrap_or(false));
+        if !read && !write && !error {
+            continue;
+        }
+
+        let mut events: c_short = 0;
+        if read {
+            events |= POLLIN | POLLRDNORM | POLLRDBAND;
+        }
+        if write {
+            events |= POLLOUT | POLLWRNORM | POLLWRBAND;
+        }
+        if error {
+            events |= POLLPRI;
+        }
+        let fd: c_int = c_int::try_from(fd)
+            .map_err(|_| Error::new(ErrorCode::InvalidArgument, "descriptor overflows"))?;
+        poll_fds.push(PollFd::new(fd, PollEvents::from(events)));
+        interests.push(SelectInterests { read, write, error });
+    }
+    Ok((poll_fds, interests))
+}
+
+/// Replaces input sets with the descriptors reported ready by `poll()`.
+fn update_sets(
+    poll_fds: &[PollFd],
+    interests: &[SelectInterests],
+    events: &[PollEvents],
+    mut readfds: Option<&mut fd_set>,
+    mut writefds: Option<&mut fd_set>,
+    mut errorfds: Option<&mut fd_set>,
+) -> Result<usize, Error> {
+    if poll_fds.len() != interests.len() || poll_fds.len() != events.len() {
+        return Err(Error::new(ErrorCode::InvalidMessage, "poll result length mismatch"));
+    }
+    if events
+        .iter()
+        .any(|events| c_short::from(events) & POLLNVAL != 0)
+    {
+        return Err(Error::new(ErrorCode::BadFile, "select contains an invalid descriptor"));
+    }
+
+    if let Some(fds) = readfds.as_deref_mut() {
+        fds.zero();
+    }
+    if let Some(fds) = writefds.as_deref_mut() {
+        fds.zero();
+    }
+    if let Some(fds) = errorfds.as_deref_mut() {
+        fds.zero();
+    }
+
+    let mut ready: usize = 0;
+    for ((poll_fd, interests), events) in poll_fds.iter().zip(interests).zip(events) {
+        let events: c_short = events.into();
+        let fd: usize = usize::try_from(poll_fd.fd())
+            .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid poll descriptor"))?;
+        let read_ready: bool =
+            interests.read && events & (POLLIN | POLLRDNORM | POLLRDBAND | POLLHUP | POLLERR) != 0;
+        let write_ready: bool = interests.write
+            && events & (POLLOUT | POLLWRNORM | POLLWRBAND | POLLHUP | POLLERR) != 0;
+        let error_ready: bool = interests.error && events & POLLPRI != 0;
+
+        if read_ready {
+            let fds: &mut fd_set = readfds.as_deref_mut().ok_or_else(|| {
+                Error::new(ErrorCode::InvalidMessage, "read interest has no descriptor set")
+            })?;
+            fds.set_bit(fd)
+                .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid read descriptor"))?;
+        }
+        if write_ready {
+            let fds: &mut fd_set = writefds.as_deref_mut().ok_or_else(|| {
+                Error::new(ErrorCode::InvalidMessage, "write interest has no descriptor set")
+            })?;
+            fds.set_bit(fd)
+                .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid write descriptor"))?;
+        }
+        if error_ready {
+            let fds: &mut fd_set = errorfds.as_deref_mut().ok_or_else(|| {
+                Error::new(ErrorCode::InvalidMessage, "error interest has no descriptor set")
+            })?;
+            fds.set_bit(fd)
+                .map_err(|_| Error::new(ErrorCode::InvalidMessage, "invalid error descriptor"))?;
+        }
+        ready += usize::from(read_ready) + usize::from(write_ready) + usize::from(error_ready);
+    }
+    Ok(ready)
+}
 
 ///
 /// # Description
@@ -29,13 +201,17 @@ use ::sysapi::sys_select::{
 /// - `nfds`: Highest-numbered file descriptor plus one.
 /// - `readfds`: Set of file descriptors to be checked for readability.
 /// - `writefds`: Set of file descriptors to be checked for writability.
-/// - `errorfds`: Set of file descriptors to be checked for errors.
+/// - `errorfds`: Set of file descriptors to be checked for exceptional conditions.
+/// - `timeout`: Maximum time to wait, or `None` to wait indefinitely.
 ///
 /// # Return Value
 ///
-/// On success, this function returns the number of file descriptors contained in the
-/// three returned descriptor sets that are ready for I/O. On failure, an error code is
-/// returned instead.
+/// On success, this function returns the total number of ready bits across the returned sets. On
+/// failure, an error code is returned instead.
+///
+/// # References
+///
+/// - [POSIX `select()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/select.html)
 ///
 pub fn select(
     nfds: usize,
@@ -60,6 +236,182 @@ pub fn select(
         ));
     }
 
-    let _ = (readfds, writefds, errorfds, timeout);
-    Err(Error::new(ErrorCode::OperationNotSupported, "select not available"))
+    let mut remaining: Option<Duration> = select_timeout(timeout)?;
+    let (poll_fds, interests): (Vec<PollFd>, Vec<SelectInterests>) =
+        poll_fds(nfds, readfds.as_deref(), writefds.as_deref(), errorfds.as_deref())?;
+    let mut probe_interval: Duration = INITIAL_PROBE_INTERVAL;
+    let (ready, result_readfds, result_writefds, result_errorfds): (
+        usize,
+        Option<fd_set>,
+        Option<fd_set>,
+        Option<fd_set>,
+    ) = loop {
+        let events: Vec<PollEvents> = poll(&poll_fds, PollTimeout::from(0))?;
+        let mut result_readfds: Option<fd_set> = readfds.as_deref().map(|_| fd_set::default());
+        let mut result_writefds: Option<fd_set> = writefds.as_deref().map(|_| fd_set::default());
+        let mut result_errorfds: Option<fd_set> = errorfds.as_deref().map(|_| fd_set::default());
+        let ready: usize = update_sets(
+            &poll_fds,
+            &interests,
+            &events,
+            result_readfds.as_mut(),
+            result_writefds.as_mut(),
+            result_errorfds.as_mut(),
+        )?;
+        if ready != 0 || remaining.is_some_and(|duration| duration.is_zero()) {
+            break (ready, result_readfds, result_writefds, result_errorfds);
+        }
+
+        let sleep: Duration = match remaining {
+            Some(duration) => cmp::min(probe_interval, duration),
+            None => probe_interval,
+        };
+        ::sys::kcall::pm::__kcall_sleep(sleep)?;
+        if let Some(duration) = remaining.as_mut() {
+            *duration = duration.checked_sub(sleep).ok_or_else(|| {
+                Error::new(ErrorCode::InvalidArgument, "select timeout underflow")
+            })?;
+        }
+        probe_interval = cmp::min(
+            probe_interval
+                .checked_add(probe_interval)
+                .unwrap_or(MAX_PROBE_INTERVAL),
+            MAX_PROBE_INTERVAL,
+        );
+    };
+
+    if let (Some(destination), Some(result)) = (readfds, result_readfds) {
+        *destination = result;
+    }
+    if let (Some(destination), Some(result)) = (writefds, result_writefds) {
+        *destination = result;
+    }
+    if let (Some(destination), Some(result)) = (errorfds, result_errorfds) {
+        *destination = result;
+    }
+    Ok(ready)
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_timeout() {
+        let timeout: Option<timeval> = Some(timeval {
+            tv_sec: 2,
+            tv_usec: 1,
+        });
+        assert_eq!(select_timeout(&timeout).unwrap(), Some(Duration::new(2, 1_000)));
+        assert_eq!(select_timeout(&None).unwrap(), None);
+
+        let maximum_timeout: Option<timeval> = Some(timeval {
+            tv_sec: i64::MAX,
+            tv_usec: 999_999,
+        });
+        assert_eq!(
+            select_timeout(&maximum_timeout).unwrap(),
+            Some(Duration::new(i64::MAX as u64, 999_999_000))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_timeout() {
+        for timeout in [
+            timeval {
+                tv_sec: -1,
+                tv_usec: 0,
+            },
+            timeval {
+                tv_sec: 0,
+                tv_usec: -1,
+            },
+            timeval {
+                tv_sec: 0,
+                tv_usec: 1_000_000,
+            },
+        ] {
+            assert_eq!(
+                select_timeout(&Some(timeout)).unwrap_err().code,
+                ErrorCode::InvalidArgument
+            );
+        }
+    }
+
+    #[test]
+    fn counts_each_ready_set() {
+        let mut readfds: fd_set = fd_set::default();
+        let mut writefds: fd_set = fd_set::default();
+        readfds.set_bit(3).unwrap();
+        writefds.set_bit(3).unwrap();
+        let (poll_fds, interests) = poll_fds(4, Some(&readfds), Some(&writefds), None).unwrap();
+        let events: [PollEvents; 1] = [PollEvents::from(POLLIN | POLLOUT)];
+
+        assert_eq!(
+            update_sets(
+                &poll_fds,
+                &interests,
+                &events,
+                Some(&mut readfds),
+                Some(&mut writefds),
+                None,
+            )
+            .unwrap(),
+            2
+        );
+        assert!(readfds.is_set(3).unwrap());
+        assert!(writefds.is_set(3).unwrap());
+    }
+
+    #[test]
+    fn counts_hangup_as_write_ready() {
+        let mut writefds: fd_set = fd_set::default();
+        writefds.set_bit(3).unwrap();
+        let (poll_fds, interests) = poll_fds(4, None, Some(&writefds), None).unwrap();
+        let events: [PollEvents; 1] = [PollEvents::from(POLLHUP)];
+
+        assert_eq!(
+            update_sets(&poll_fds, &interests, &events, None, Some(&mut writefds), None).unwrap(),
+            1
+        );
+        assert!(writefds.is_set(3).unwrap());
+    }
+
+    #[test]
+    fn clears_descriptors_that_are_not_ready() {
+        let mut readfds: fd_set = fd_set::default();
+        readfds.set_bit(2).unwrap();
+        let (poll_fds, interests) = poll_fds(3, Some(&readfds), None, None).unwrap();
+        let events: [PollEvents; 1] = [PollEvents::from(0)];
+
+        assert_eq!(
+            update_sets(&poll_fds, &interests, &events, Some(&mut readfds), None, None).unwrap(),
+            0
+        );
+        assert!(!readfds.is_set(2).unwrap());
+    }
+
+    #[test]
+    fn rejects_invalid_descriptors() {
+        let poll_fds: [PollFd; 1] = [PollFd::new(7, PollEvents::from(POLLIN))];
+        let interests: [SelectInterests; 1] = [SelectInterests {
+            read: true,
+            write: false,
+            error: false,
+        }];
+        let events: [PollEvents; 1] = [PollEvents::from(POLLNVAL)];
+        let mut readfds: fd_set = fd_set::default();
+        readfds.set_bit(7).unwrap();
+
+        assert_eq!(
+            update_sets(&poll_fds, &interests, &events, Some(&mut readfds), None, None)
+                .unwrap_err()
+                .code,
+            ErrorCode::BadFile
+        );
+    }
 }

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -117,10 +117,7 @@ int main(int argc, const char *argv[])
     test_create_unlink(); // tests open() and unlink().
     test_write_read();    // tests open(), close() and unlink.
     test_poll();          // tests open(), close(), write(), read(), poll() and unlink().
-#ifndef __NANVIX_STANDALONE__
-    // select() has no VFS implementation.
     test_select(); // tests open(), close(), write(), read(), select() and unlink().
-#endif             // __NANVIX_STANDALONE__
     test_posix_fadvise();   // requires open(), close() and unlink().
     test_lseek();           // requires open(), close(), read(), write() and unlink().
     test_posix_fallocate(); // requires open(), close(), lseek and unlink().

--- a/src/tests/integration/test-c-file/select.c
+++ b/src/tests/integration/test-c-file/select.c
@@ -50,8 +50,11 @@ void test_select(void)
     assert(fd != -1);
 
     //----------------------------------------------------------------------------------------------
-    // Write readiness (select on writefds).
+    // Read and write readiness. A descriptor ready in both sets contributes two to the result.
     //----------------------------------------------------------------------------------------------
+    fd_set readfds;
+    FD_ZERO(&readfds);
+    FD_SET(fd, &readfds);
     fd_set writefds;
     FD_ZERO(&writefds);
     FD_SET(fd, &writefds);
@@ -59,8 +62,9 @@ void test_select(void)
     tvw.tv_sec = SELECT_TIMEOUT_SECS;
     tvw.tv_usec = 0;
 
-    int ret = select(fd + 1, NULL, &writefds, NULL, &tvw);
-    assert(ret == 1);
+    int ret = select(fd + 1, &readfds, &writefds, NULL, &tvw);
+    assert(ret == 2);
+    assert(FD_ISSET(fd, &readfds));
     assert(FD_ISSET(fd, &writefds));
 
     // Write data.
@@ -73,7 +77,6 @@ void test_select(void)
     //----------------------------------------------------------------------------------------------
     // Read readiness (select on readfds).
     //----------------------------------------------------------------------------------------------
-    fd_set readfds;
     FD_ZERO(&readfds);
     FD_SET(fd, &readfds);
     struct timeval tvr;
@@ -108,16 +111,45 @@ void test_select(void)
     tve.tv_sec = SELECT_TIMEOUT_SECS;
     tve.tv_usec = 0;
 
-    // For regular files POSIX specifies they are always ready; but we tolerate a timeout for
-    // implementation-specific behavior while still asserting correctness when ready.
+    // Regular files are ready when an I/O request would not block, including at EOF.
     ret = select(fd + 1, &readfds, NULL, NULL, &tve);
-    assert(ret == 0 || (ret == 1 && FD_ISSET(fd, &readfds)));
+    assert(ret == 1);
+    assert(FD_ISSET(fd, &readfds));
 
     // Close file descriptor.
     assert(close(fd) == 0);
 
+    // A descriptor that is not open fails with EBADF.
+    FD_ZERO(&readfds);
+    FD_SET(fd, &readfds);
+    struct timeval invalid_tv = {0};
+    errno = 0;
+    assert(select(fd + 1, &readfds, NULL, NULL, &invalid_tv) == -1);
+    assert(errno == EBADF);
+    errno = 0;
+
     // Remove test file.
     assert(unlink(filename) == 0);
+
+    // An empty pipe is not readable before data arrives. Check immediate and finite timeouts.
+    int pipefds[2];
+    assert(pipe(pipefds) == 0);
+    FD_ZERO(&readfds);
+    FD_SET(pipefds[0], &readfds);
+    struct timeval zero_tv = {0};
+    assert(select(pipefds[0] + 1, &readfds, NULL, NULL, &zero_tv) == 0);
+    assert(!FD_ISSET(pipefds[0], &readfds));
+
+    FD_ZERO(&readfds);
+    FD_SET(pipefds[0], &readfds);
+    struct timeval finite_tv = {
+        .tv_sec = 0,
+        .tv_usec = 10000,
+    };
+    assert(select(pipefds[0] + 1, &readfds, NULL, NULL, &finite_tv) == 0);
+    assert(!FD_ISSET(pipefds[0], &readfds));
+    assert(close(pipefds[0]) == 0);
+    assert(close(pipefds[1]) == 0);
 
     fprintf(stderr, "passed\n");
 }


### PR DESCRIPTION
## Summary

- Implement POSIX `select()` over the existing routed polling backend.
- Support read, write, and exceptional-condition sets with full-range timeouts and `EBADF` handling.
- Add the POSIX `restrict` contract and compile the `select()` C test so it actually runs.

## Testing

Verified against the full lifecycle in debug and release modes.

## Related

Closes #3130.
