### PR TITLE
[vfsd] F: Forward ownership changes

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -118,7 +118,8 @@ POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c ftruncate.c truncate.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
-	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c utimensat.c utime.c
+	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c utimensat.c utime.c \
+	chown.c fchown.c fchownat.c lchown.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's

--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -209,7 +209,8 @@ impl HostFsHandler {
             | SystemCallMessageKind::HostFsSymlinkRequestPart
             | SystemCallMessageKind::HostFsReadlinkRequestPart
             | SystemCallMessageKind::HostFsLstatRequestPart
-            | SystemCallMessageKind::HostFsPathStatRequestPart => self.handle_long_part(
+            | SystemCallMessageKind::HostFsPathStatRequestPart
+            | SystemCallMessageKind::HostFsChownAtRequestPart => self.handle_long_part(
                 syscall_msg.kind(),
                 OperationId::from_le_bytes(syscall_msg.request_id().raw().to_le_bytes()),
                 &syscall_msg.payload,
@@ -238,6 +239,7 @@ impl HostFsHandler {
             SystemCallMessageKind::HostFsReadlinkRequest => run(self, Self::handle_readlink),
             SystemCallMessageKind::HostFsLstatRequest => run(self, Self::handle_lstat),
             SystemCallMessageKind::HostFsPathStatRequest => run(self, Self::handle_pathstat),
+            SystemCallMessageKind::HostFsChownRequest => run(self, Self::handle_chown),
             other => {
                 log::error!("hostfsd: unexpected message header: {:?}", other);
                 let mut response = [0u8; Message::PAYLOAD_SIZE];
@@ -420,6 +422,15 @@ impl HostFsHandler {
                 } else {
                     log::error!("hostfsd: failed to deserialize long pathstat request");
                     set_kind(&mut response, SystemCallMessageKind::HostFsPathStatResponse as u16);
+                    set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
+                }
+            },
+            SystemCallMessageKind::HostFsChownAtRequestPart => {
+                if let Some(req) = long_msg::deserialize_long_chownat(&assembled) {
+                    self.handle_long_chownat(req, &mut response);
+                } else {
+                    log::error!("hostfsd: failed to deserialize long chownat request");
+                    set_kind(&mut response, SystemCallMessageKind::HostFsChownResponse as u16);
                     set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
                 }
             },
@@ -755,6 +766,51 @@ impl HostFsHandler {
         response: &mut [u8; Message::PAYLOAD_SIZE],
     ) {
         self.do_pathstat(req.op_id, &req.path, response);
+    }
+
+    /// Handles a fully assembled path-based ownership request.
+    fn handle_long_chownat(
+        &mut self,
+        req: long_msg::LongChownAtRequest,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        set_kind(response, SystemCallMessageKind::HostFsChownResponse as u16);
+        let nofollow: i32 = ::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW;
+        if req.flags != 0 && req.flags != nofollow {
+            set_payload_data(response, &HOSTFS_ERR_INVALID.to_le_bytes());
+            return;
+        }
+
+        let host_path: PathBuf = match if req.flags == nofollow {
+            self.sandbox.resolve_nofollow(&req.path)
+        } else {
+            self.sandbox.resolve(&req.path)
+        } {
+            Some(path) => path,
+            None => {
+                set_payload_data(response, &HOSTFS_ERR_PERMISSION.to_le_bytes());
+                return;
+            },
+        };
+
+        #[cfg(unix)]
+        let result: io::Result<()> = {
+            let owner: Option<u32> = (req.owner != u32::MAX).then_some(req.owner);
+            let group: Option<u32> = (req.group != u32::MAX).then_some(req.group);
+            if req.flags == nofollow {
+                ::std::os::unix::fs::lchown(&host_path, owner, group)
+            } else {
+                ::std::os::unix::fs::chown(&host_path, owner, group)
+            }
+        };
+        #[cfg(not(unix))]
+        let result: io::Result<()> = {
+            let _ = host_path;
+            Err(io::Error::new(io::ErrorKind::Unsupported, "ownership changes are not supported"))
+        };
+
+        let status: i32 = result.as_ref().map_or_else(io_error_to_code, |_| 0);
+        set_payload_data(response, &status.to_le_bytes());
     }
 
     /// Handles an inline single-message READLINK request.
@@ -1933,6 +1989,37 @@ impl HostFsHandler {
         }
     }
 
+    fn handle_chown(
+        &mut self,
+        payload: &[u8; Message::PAYLOAD_SIZE],
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        let req: ChownRequest = ChownRequest::decode(payload);
+        set_kind(response, SystemCallMessageKind::HostFsChownResponse as u16);
+        let entry: &FdEntry = match self.fd_table.get(req.fd) {
+            Some(entry) => entry,
+            None => {
+                set_payload_data(response, &HOSTFS_ERR_IO.to_le_bytes());
+                return;
+            },
+        };
+
+        #[cfg(unix)]
+        let result: io::Result<()> = {
+            let owner: Option<u32> = (req.owner != u32::MAX).then_some(req.owner);
+            let group: Option<u32> = (req.group != u32::MAX).then_some(req.group);
+            ::std::os::unix::fs::fchown(&entry.file, owner, group)
+        };
+        #[cfg(not(unix))]
+        let result: io::Result<()> = {
+            let _ = entry;
+            Err(io::Error::new(io::ErrorKind::Unsupported, "ownership changes are not supported"))
+        };
+
+        let status: i32 = result.as_ref().map_or_else(io_error_to_code, |_| 0);
+        set_payload_data(response, &status.to_le_bytes());
+    }
+
     fn handle_flush(
         &mut self,
         payload: &[u8; Message::PAYLOAD_SIZE],
@@ -1972,6 +2059,10 @@ impl HostFsHandler {
 fn io_error_to_code(e: &io::Error) -> i32 {
     // ELOOP-style errors do not have a stable `ErrorKind`, so probe the raw OS code.
     if let Some(raw) = e.raw_os_error() {
+        #[cfg(unix)]
+        if raw == ::sysapi::errno::EPERM {
+            return HOSTFS_ERR_NOT_PERMITTED;
+        }
         #[cfg(target_os = "linux")]
         const ELOOP_RAW: i32 = 40;
         #[cfg(target_os = "macos")]
@@ -1996,6 +2087,7 @@ fn io_error_to_code(e: &io::Error) -> i32 {
         io::ErrorKind::NotADirectory => HOSTFS_ERR_NOT_DIR,
         io::ErrorKind::IsADirectory => HOSTFS_ERR_IS_DIR,
         io::ErrorKind::DirectoryNotEmpty => HOSTFS_ERR_NOT_EMPTY,
+        io::ErrorKind::Unsupported => HOSTFS_ERR_NOT_SUPPORTED,
         _ => HOSTFS_ERR_IO,
     }
 }

--- a/src/daemons/vfsd/src/assembler.rs
+++ b/src/daemons/vfsd/src/assembler.rs
@@ -385,7 +385,8 @@ fn dispatch_assembled_request(
         },
         SystemCallMessageKind::FileChownAtRequestPart => {
             match FileChownAtRequest::from_parts(parts) {
-                Ok(req) => handler::handle_fchownat(source, req),
+                Ok(req) => handler::handle_fchownat_with_hostfs(response_context, req, pending)
+                    .unwrap_or_default(),
                 Err(e) => {
                     ::syslog::error!("dispatch: fchownat from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -368,6 +368,45 @@ pub(crate) fn handle_ftruncate_with_hostfs(
 // HostFs-Aware Read/Write Handlers
 //==================================================================================================
 
+pub(crate) fn handle_fchown_with_hostfs(
+    response_context: ResponseContext,
+    msg: SystemCallMessage,
+    pending: &mut PendingQueue,
+) -> Option<Message> {
+    let source_pid: ProcessIdentifier = response_context.source_pid();
+    let source: ThreadIdentifier = response_context.source_tid();
+    let req: ::syscall::unistd::message::FileChownRequest =
+        ::syscall::unistd::message::FileChownRequest::from_bytes(msg.payload);
+
+    if let Some(remote_fd) = ::vfs::fd::vfs_hostfs_remote_fd(req.fd) {
+        if !pending.has_capacity() {
+            return Some(build_error(source, ErrorCode::ResourceBusy));
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        if pending
+            .insert(
+                op_id,
+                PendingOp {
+                    response_context,
+                    source_tid: source,
+                    source_pid,
+                    kind: PendingOpKind::Chown,
+                },
+            )
+            .is_err()
+        {
+            return Some(build_error(source, ErrorCode::ResourceBusy));
+        }
+        if hostfs::send_chown_request(remote_fd, req.owner, req.group, op_id).is_err() {
+            pending.remove(op_id);
+            return Some(build_error(source, ErrorCode::IoErr));
+        }
+        return None;
+    }
+
+    Some(super::short::handle_fchown(source, msg))
+}
+
 pub(crate) fn handle_fstat_with_hostfs(
     response_context: ResponseContext,
     msg: SystemCallMessage,
@@ -657,6 +696,7 @@ use ::syscall::{
         MakeDirectoryAtRequest,
     },
     unistd::message::{
+        FileChownAtRequest,
         ReadLinkAtRequest,
         SymbolicLinkAtRequest,
     },
@@ -746,6 +786,53 @@ pub(crate) fn handle_getdents_with_hostfs(
     }
 
     Some(super::long::handle_getdents(source, msg))
+}
+
+pub(crate) fn handle_fchownat_with_hostfs(
+    response_context: ResponseContext,
+    request: FileChownAtRequest,
+    pending: &mut PendingQueue,
+) -> Option<Vec<Message>> {
+    let source_pid: ProcessIdentifier = response_context.source_pid();
+    let source: ThreadIdentifier = response_context.source_tid();
+    let resolved = match vfs_resolve_path(request.dirfd, &request.path) {
+        Ok(resolved) => resolved,
+        Err(e) => return Some(vec![build_error(source, fat32_to_error_code(&e))]),
+    };
+
+    if hostfs::is_hostfs_path(resolved.as_str()) {
+        if !pending.has_capacity() {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        if pending
+            .insert(
+                op_id,
+                PendingOp {
+                    response_context,
+                    source_tid: source,
+                    source_pid,
+                    kind: PendingOpKind::ChownAt,
+                },
+            )
+            .is_err()
+        {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        if let Err(e) = hostfs::send_chownat_request(
+            &resolved,
+            request.owner,
+            request.group,
+            request.flag,
+            op_id,
+        ) {
+            pending.remove(op_id);
+            return Some(vec![build_error(source, e)]);
+        }
+        return None;
+    }
+
+    Some(super::long::handle_fchownat(source, request))
 }
 
 pub(crate) fn handle_openat_with_hostfs(

--- a/src/daemons/vfsd/src/handler/short.rs
+++ b/src/daemons/vfsd/src/handler/short.rs
@@ -275,6 +275,9 @@ pub(crate) fn handle_fchdir(source: ThreadIdentifier, msg: SystemCallMessage) ->
 pub(crate) fn handle_fchown(source: ThreadIdentifier, msg: SystemCallMessage) -> Message {
     let req: FileChownRequest = FileChownRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
+    if ::vfs::fd::vfs_resolve(fd).is_none() {
+        return build_error(source, ErrorCode::BadFile);
+    }
     // fchown is a no-op in our VFS.
     ::syslog::trace!("handle_fchown(): stubbed (fd={})", fd);
     FileChownResponse::build(source, ProcessIdentifier::VFSD, MessageType::Ipc)

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -292,6 +292,27 @@ pub fn send_truncate_request(
     }
 }
 
+/// Sends a descriptor-based CHOWN request to hostfsd.
+pub fn send_chown_request(
+    remote_fd: i32,
+    owner: u32,
+    group: u32,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let payload: [u8; Message::PAYLOAD_SIZE] = ChownRequest {
+        fd: remote_fd,
+        owner,
+        group,
+    }
+    .serialize(SystemCallMessageKind::HostFsChownRequest as u16, op_id);
+
+    if send_request(&payload) {
+        Ok(())
+    } else {
+        Err(::sys::error::ErrorCode::IoErr)
+    }
+}
+
 /// Sends a FLUSH (fsync) request to hostfsd.
 pub fn send_flush_request(
     remote_fd: i32,
@@ -459,6 +480,22 @@ pub fn send_readlink_request(
         .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
 
     send_long_request(&buf, SystemCallMessageKind::HostFsReadlinkRequestPart, op_id)
+}
+
+/// Sends a path-based CHOWN request to hostfsd.
+pub fn send_chownat_request(
+    path: &ResolvedPath,
+    owner: u32,
+    group: u32,
+    flags: i32,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path.as_str());
+    let buf: alloc::vec::Vec<u8> =
+        long_msg::serialize_long_chownat_request(op_id, owner, group, flags, relative.as_bytes())
+            .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
+
+    send_long_request(&buf, SystemCallMessageKind::HostFsChownAtRequestPart, op_id)
 }
 
 /// Sends an LSTAT request to hostfsd.

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -497,8 +497,11 @@ pub(crate) fn handle_ipc_message(
             response_context.send(&response);
         },
         SystemCallMessageKind::FileChownRequest => {
-            let response: Message = handler::handle_fchown(source_tid, syscall_msg);
-            response_context.send(&response);
+            if let Some(response) =
+                handler::handle_fchown_with_hostfs(response_context, syscall_msg, pending)
+            {
+                response_context.send(&response);
+            }
         },
         SystemCallMessageKind::FileChdirRequest => {
             let response: Message = handler::handle_fchdir(source_tid, syscall_msg);

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -98,6 +98,10 @@ pub(crate) enum PendingOpKind {
     Unlink,
     /// rename — response is a status code.
     Rename,
+    /// fchown — response is a status code.
+    Chown,
+    /// fchownat — response is a status code.
+    ChownAt,
     /// stat/fstat — waiting for size, mode, and kind.
     Stat,
     /// stat/fstat — metadata arrived; waiting for timestamps.
@@ -545,6 +549,10 @@ pub(crate) fn complete_pending_op(
         PendingOpKind::Rename => {
             complete_status(response_context, response_payload, OpGroup::Rename)
         },
+        PendingOpKind::Chown => complete_status(response_context, response_payload, OpGroup::Chown),
+        PendingOpKind::ChownAt => {
+            complete_status(response_context, response_payload, OpGroup::ChownAt)
+        },
         PendingOpKind::Stat => complete_stat(response_context, response_payload, None),
         PendingOpKind::Symlink => {
             complete_status(response_context, response_payload, OpGroup::Symlink)
@@ -978,6 +986,8 @@ fn validate_response_header(kind: &PendingOpKind, payload: &[u8; Message::PAYLOA
             | (PendingOpKind::Rmdir, SystemCallMessageKind::HostFsRmdirResponse)
             | (PendingOpKind::Unlink, SystemCallMessageKind::HostFsUnlinkResponse)
             | (PendingOpKind::Rename, SystemCallMessageKind::HostFsRenameResponse)
+            | (PendingOpKind::Chown, SystemCallMessageKind::HostFsChownResponse)
+            | (PendingOpKind::ChownAt, SystemCallMessageKind::HostFsChownResponse)
             | (PendingOpKind::Stat, SystemCallMessageKind::HostFsStatResponse)
             | (PendingOpKind::Symlink, SystemCallMessageKind::HostFsSymlinkResponse)
             | (PendingOpKind::Readlink { .. }, SystemCallMessageKind::HostFsReadlinkResponse)
@@ -1129,6 +1139,8 @@ enum OpGroup {
     Rmdir,
     Unlink,
     Rename,
+    Chown,
+    ChownAt,
     Symlink,
 }
 
@@ -1165,6 +1177,14 @@ fn complete_status(
             use ::syscall::fcntl::message::RenameAtResponse;
             RenameAtResponse::build(source_tid, 0, ProcessIdentifier::VFSD, MessageType::Ipc)
         },
+        OpGroup::Chown => {
+            use ::syscall::unistd::message::FileChownResponse;
+            FileChownResponse::build(source_tid, ProcessIdentifier::VFSD, MessageType::Ipc)
+        },
+        OpGroup::ChownAt => {
+            use ::syscall::unistd::message::FileChownAtResponse;
+            FileChownAtResponse::build(source_tid, ProcessIdentifier::VFSD, MessageType::Ipc)
+        },
         OpGroup::Symlink => {
             use ::syscall::unistd::message::SymbolicLinkAtResponse;
             SymbolicLinkAtResponse::build(source_tid, 0, ProcessIdentifier::VFSD, MessageType::Ipc)
@@ -1178,6 +1198,7 @@ fn complete_status(
 /// These codes are defined in the `hostfs-api` crate as `HOSTFS_ERR_*` constants.
 fn hostfs_error_to_code(code: i32) -> ErrorCode {
     match code {
+        ::hostfs_api::HOSTFS_ERR_NOT_PERMITTED => ErrorCode::OperationNotPermitted,
         ::hostfs_api::HOSTFS_ERR_NOT_FOUND => ErrorCode::NoSuchEntry,
         ::hostfs_api::HOSTFS_ERR_PERMISSION => ErrorCode::PermissionDenied,
         ::hostfs_api::HOSTFS_ERR_EXISTS => ErrorCode::EntryExists,

--- a/src/libs/hostfs-api/src/chown.rs
+++ b/src/libs/hostfs-api/src/chown.rs
@@ -1,0 +1,71 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Descriptor-based ownership request wire format.
+
+use crate::{
+    set_kind,
+    set_op_id,
+    OperationId,
+    HOSTFS_DATA_START,
+};
+use ::sys::ipc::Message;
+
+/// Changes the ownership of an open hostfs file.
+#[derive(Debug, Clone, Copy)]
+pub struct ChownRequest {
+    /// Remote file descriptor.
+    pub fd: i32,
+    /// New user identifier, or `u32::MAX` to leave it unchanged.
+    pub owner: u32,
+    /// New group identifier, or `u32::MAX` to leave it unchanged.
+    pub group: u32,
+}
+
+impl ChownRequest {
+    /// Serializes this request into a complete message payload.
+    pub fn serialize(&self, kind_value: u16, op_id: OperationId) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_kind(&mut payload, kind_value);
+        set_op_id(&mut payload, op_id);
+        let data_start: usize = HOSTFS_DATA_START;
+        payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
+        payload[data_start + 4..data_start + 8].copy_from_slice(&self.owner.to_le_bytes());
+        payload[data_start + 8..data_start + 12].copy_from_slice(&self.group.to_le_bytes());
+        payload
+    }
+
+    /// Decodes a descriptor-based ownership request.
+    pub fn decode(payload: &[u8; Message::PAYLOAD_SIZE]) -> Self {
+        let data_start: usize = HOSTFS_DATA_START;
+        let fd: i32 = i32::from_le_bytes(payload[data_start..data_start + 4].try_into().unwrap());
+        let owner: u32 =
+            u32::from_le_bytes(payload[data_start + 4..data_start + 8].try_into().unwrap());
+        let group: u32 =
+            u32::from_le_bytes(payload[data_start + 8..data_start + 12].try_into().unwrap());
+        Self { fd, owner, group }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::get_op_id;
+
+    #[test]
+    fn request_round_trip_preserves_sentinels() {
+        let request = ChownRequest {
+            fd: 7,
+            owner: u32::MAX,
+            group: 42,
+        };
+        let op_id = OperationId::new(11);
+        let payload = request.serialize(123, op_id);
+        let decoded = ChownRequest::decode(&payload);
+
+        assert_eq!(get_op_id(&payload), op_id);
+        assert_eq!(decoded.fd, request.fd);
+        assert_eq!(decoded.owner, request.owner);
+        assert_eq!(decoded.group, request.group);
+    }
+}

--- a/src/libs/hostfs-api/src/error.rs
+++ b/src/libs/hostfs-api/src/error.rs
@@ -3,6 +3,8 @@
 
 //! Host filesystem error codes.
 
+/// Error code: operation not permitted.
+pub const HOSTFS_ERR_NOT_PERMITTED: i32 = -1;
 /// Error code: file or directory not found.
 pub const HOSTFS_ERR_NOT_FOUND: i32 = -2;
 /// Error code: generic I/O error.

--- a/src/libs/hostfs-api/src/lib.rs
+++ b/src/libs/hostfs-api/src/lib.rs
@@ -33,6 +33,7 @@ use ::sys::ipc::Message;
 // Modules
 //==================================================================================================
 
+mod chown;
 mod close;
 mod error;
 mod flush;
@@ -53,6 +54,7 @@ mod unlink;
 mod write;
 
 pub use self::{
+    chown::ChownRequest,
     close::CloseRequest,
     flush::FlushRequest,
     lseek::{
@@ -288,6 +290,7 @@ pub use self::error::{
     HOSTFS_ERR_NOT_DIR,
     HOSTFS_ERR_NOT_EMPTY,
     HOSTFS_ERR_NOT_FOUND,
+    HOSTFS_ERR_NOT_PERMITTED,
     HOSTFS_ERR_NOT_SUPPORTED,
     HOSTFS_ERR_PERMISSION,
 };

--- a/src/libs/hostfs-api/src/long_msg.rs
+++ b/src/libs/hostfs-api/src/long_msg.rs
@@ -25,6 +25,7 @@
 //! - **Symlink**: `[op_id:4][target_len:2][linkpath_len:2][target:N][linkpath:M]`
 //! - **Readlink**: `[op_id:4][path_len:2][path:N]`
 //! - **Lstat**: `[op_id:4][path_len:2][path:N]`
+//! - **ChownAt**: `[op_id:4][owner:4][group:4][flags:4][path_len:2][path:N]`
 //!
 //! # Long Response Format
 //!
@@ -78,6 +79,9 @@ pub const READLINK_HEADER_SIZE: usize = 6;
 
 /// Header size for long lstat: op_id(4) + path_len(2) = 6
 pub const LSTAT_HEADER_SIZE: usize = 6;
+
+/// Header size for long chownat: op_id(4) + owner(4) + group(4) + flags(4) + path_len(2) = 18.
+pub const CHOWNAT_HEADER_SIZE: usize = 18;
 
 /// Header size for the long Readlink *response* body:
 /// `op_id(4) + status(4) + target_len(2) = 10`.
@@ -569,6 +573,43 @@ pub fn deserialize_long_lstat(bytes: &[u8]) -> Option<LongLstatRequest> {
     Some(LongLstatRequest { op_id, path })
 }
 
+/// Result of deserializing a long CHOWNAT request.
+#[cfg(feature = "std")]
+pub struct LongChownAtRequest {
+    pub op_id: OperationId,
+    pub owner: u32,
+    pub group: u32,
+    pub flags: i32,
+    pub path: std::string::String,
+}
+
+/// Deserializes a long CHOWNAT request from assembled bytes.
+#[cfg(feature = "std")]
+pub fn deserialize_long_chownat(bytes: &[u8]) -> Option<LongChownAtRequest> {
+    if bytes.len() < CHOWNAT_HEADER_SIZE {
+        return None;
+    }
+    let op_id = OperationId::new(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
+    let owner = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+    let group = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+    let flags = i32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]);
+    let path_len = u16::from_le_bytes([bytes[16], bytes[17]]) as usize;
+    if bytes.len() < CHOWNAT_HEADER_SIZE + path_len {
+        return None;
+    }
+    let path = std::string::String::from_utf8(
+        bytes[CHOWNAT_HEADER_SIZE..CHOWNAT_HEADER_SIZE + path_len].to_vec(),
+    )
+    .ok()?;
+    Some(LongChownAtRequest {
+        op_id,
+        owner,
+        group,
+        flags,
+        path,
+    })
+}
+
 //==================================================================================================
 // Serialization (vfsd, no_std + alloc)
 //==================================================================================================
@@ -694,6 +735,27 @@ pub fn serialize_long_lstat_request(op_id: OperationId, path: &[u8]) -> Option<V
     let path_len: u16 = u16::try_from(path.len()).ok()?;
     let mut buf: Vec<u8> = Vec::with_capacity(LSTAT_HEADER_SIZE + path.len());
     buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&path_len.to_le_bytes());
+    buf.extend_from_slice(path);
+    Some(buf)
+}
+
+/// Serializes the body of a long CHOWNAT request.
+///
+/// Wire format: `[op_id:4][owner:4][group:4][flags:4][path_len:2][path:N]`.
+pub fn serialize_long_chownat_request(
+    op_id: OperationId,
+    owner: u32,
+    group: u32,
+    flags: i32,
+    path: &[u8],
+) -> Option<Vec<u8>> {
+    let path_len: u16 = u16::try_from(path.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(CHOWNAT_HEADER_SIZE + path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&owner.to_le_bytes());
+    buf.extend_from_slice(&group.to_le_bytes());
+    buf.extend_from_slice(&flags.to_le_bytes());
     buf.extend_from_slice(&path_len.to_le_bytes());
     buf.extend_from_slice(path);
     Some(buf)

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -359,6 +359,12 @@ pub enum SystemCallMessageKind {
     PipeReadRetry,
     /// Timestamp continuation for successful hostfs stat operations.
     HostFsStatTimesResponse,
+    /// Descriptor-based hostfs ownership request.
+    HostFsChownRequest,
+    /// Multi-part path-based hostfs ownership request.
+    HostFsChownAtRequestPart,
+    /// Hostfs ownership response.
+    HostFsChownResponse,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageKind.
 impl TryFrom<u16> for SystemCallMessageKind {
@@ -549,6 +555,9 @@ impl TryFrom<u16> for SystemCallMessageKind {
             x if x == PipeOpCancelResponse as u16 => Ok(PipeOpCancelResponse),
             x if x == PipeReadRetry as u16 => Ok(PipeReadRetry),
             x if x == HostFsStatTimesResponse as u16 => Ok(HostFsStatTimesResponse),
+            x if x == HostFsChownRequest as u16 => Ok(HostFsChownRequest),
+            x if x == HostFsChownAtRequestPart as u16 => Ok(HostFsChownAtRequestPart),
+            x if x == HostFsChownResponse as u16 => Ok(HostFsChownResponse),
             _ => Err(()),
         }
     }
@@ -604,6 +613,9 @@ impl SystemCallMessageKind {
                 | Self::HostFsPathStatRequestPart
                 | Self::HostFsPathStatResponse
                 | Self::HostFsStatTimesResponse
+                | Self::HostFsChownRequest
+                | Self::HostFsChownAtRequestPart
+                | Self::HostFsChownResponse
         )
     }
 
@@ -644,6 +656,9 @@ impl SystemCallMessageKind {
             Self::HostFsPathStatRequest | Self::HostFsPathStatRequestPart => {
                 Some(Self::HostFsPathStatResponse)
             },
+            Self::HostFsChownRequest | Self::HostFsChownAtRequestPart => {
+                Some(Self::HostFsChownResponse)
+            },
             _ => None,
         }
     }
@@ -676,6 +691,7 @@ impl SystemCallMessageKind {
                 | Self::HostFsLstatResponse
                 | Self::HostFsPathStatResponse
                 | Self::HostFsStatTimesResponse
+                | Self::HostFsChownResponse
         )
     }
 

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -8,7 +8,10 @@
 //==================================================================================================
 
 #include "common.h"
+#include <assert.h>
 #include <dirent.h>
+#include <fcntl.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -147,6 +150,19 @@ int main(int argc, const char *argv[])
     test_mknod();      // mknod() is unsupported; verifies it fails with ENOTSUP.
     test_umask_ramfs(); // tests umask(), open(), close(), stat(), and unlink() on RAMFS.
     test_umask();      // tests umask(), open(), stat(), mkdir(), and unlinkat().
+
+    if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
+        int cwd = open(".", O_RDONLY | O_DIRECTORY);
+        assert(cwd != -1);
+        assert(chdir("/mnt") == 0);
+        test_fchownat();
+        test_chown();
+        test_fchown();
+        test_lchown();
+        assert(fchdir(cwd) == 0);
+        assert(close(cwd) == 0);
+    }
+
     test_poll_hostfs(); // requires test_umask() to mount hostfs.
     test_dirent();
     test_getcwd();


### PR DESCRIPTION
## Summary

- Forward `chown()`, `fchown()`, `fchownat()`, and `lchown()` operations through hostfs.
- Preserve independent `-1` owner and group values.
- Re-enable the existing ownership tests against the hostfs mount.

## Testing

- Full debug build
- Focused `posix/test-c-file` integration test
- Unit tests
- Format, lint, and spell checks

Closes #3133.