### PR TITLE
Implement Hostfs Timestamp Mutation

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -118,8 +118,8 @@ POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c ftruncate.c truncate.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
-	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c utimensat.c utime.c \
-	chown.c fchown.c fchownat.c lchown.c
+	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c \
+	utimensat.c utimes.c utime.c futimens.c chown.c fchown.c fchownat.c lchown.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's

--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -49,6 +49,7 @@ use std::{
     fs::{
         self,
         File,
+        FileTimes,
         OpenOptions,
     },
     io::{
@@ -59,6 +60,11 @@ use std::{
         Write,
     },
     path::PathBuf,
+    time::{
+        Duration,
+        SystemTime,
+        UNIX_EPOCH,
+    },
 };
 
 #[cfg(unix)]
@@ -66,11 +72,43 @@ use std::os::unix::fs::{
     MetadataExt,
     PermissionsExt,
 };
-#[cfg(not(unix))]
-use std::time::{
-    SystemTime,
-    UNIX_EPOCH,
-};
+fn timestamp_to_system_time(seconds: i64, nanoseconds: i64) -> io::Result<SystemTime> {
+    if !(0..1_000_000_000).contains(&nanoseconds) {
+        return Err(io::Error::from(io::ErrorKind::InvalidInput));
+    }
+
+    let time: Option<SystemTime> = if seconds >= 0 {
+        UNIX_EPOCH.checked_add(Duration::new(seconds as u64, nanoseconds as u32))
+    } else if nanoseconds == 0 {
+        UNIX_EPOCH.checked_sub(Duration::from_secs(seconds.unsigned_abs()))
+    } else {
+        UNIX_EPOCH.checked_sub(Duration::new(
+            seconds.unsigned_abs() - 1,
+            (1_000_000_000 - nanoseconds) as u32,
+        ))
+    };
+    time.ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))
+}
+
+fn file_times(times: &[::sysapi::time::timespec; 2]) -> io::Result<FileTimes> {
+    let now: SystemTime = SystemTime::now();
+    let resolve = |time: &::sysapi::time::timespec| -> io::Result<Option<SystemTime>> {
+        match time.tv_nsec {
+            n if n == ::sysapi::sys_stat::UTIME_NOW => Ok(Some(now)),
+            n if n == ::sysapi::sys_stat::UTIME_OMIT => Ok(None),
+            n => timestamp_to_system_time(time.tv_sec, n).map(Some),
+        }
+    };
+
+    let mut result: FileTimes = FileTimes::new();
+    if let Some(accessed) = resolve(&times[0])? {
+        result = result.set_accessed(accessed);
+    }
+    if let Some(modified) = resolve(&times[1])? {
+        result = result.set_modified(modified);
+    }
+    Ok(result)
+}
 
 fn open_regular_file(
     options: &OpenOptions,
@@ -210,7 +248,8 @@ impl HostFsHandler {
             | SystemCallMessageKind::HostFsReadlinkRequestPart
             | SystemCallMessageKind::HostFsLstatRequestPart
             | SystemCallMessageKind::HostFsPathStatRequestPart
-            | SystemCallMessageKind::HostFsChownAtRequestPart => self.handle_long_part(
+            | SystemCallMessageKind::HostFsChownAtRequestPart
+            | SystemCallMessageKind::HostFsUpdateTimesAtRequestPart => self.handle_long_part(
                 syscall_msg.kind(),
                 OperationId::from_le_bytes(syscall_msg.request_id().raw().to_le_bytes()),
                 &syscall_msg.payload,
@@ -236,6 +275,7 @@ impl HostFsHandler {
             SystemCallMessageKind::HostFsLseekRequest => run(self, Self::handle_lseek),
             SystemCallMessageKind::HostFsTruncateRequest => run(self, Self::handle_truncate),
             SystemCallMessageKind::HostFsFlushRequest => run(self, Self::handle_flush),
+            SystemCallMessageKind::HostFsUpdateTimesRequest => run(self, Self::handle_update_times),
             SystemCallMessageKind::HostFsReadlinkRequest => run(self, Self::handle_readlink),
             SystemCallMessageKind::HostFsLstatRequest => run(self, Self::handle_lstat),
             SystemCallMessageKind::HostFsPathStatRequest => run(self, Self::handle_pathstat),
@@ -434,6 +474,18 @@ impl HostFsHandler {
                     set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
                 }
             },
+            SystemCallMessageKind::HostFsUpdateTimesAtRequestPart => {
+                if let Some(req) = long_msg::deserialize_long_update_times(&assembled) {
+                    self.handle_long_update_times(req, &mut response);
+                } else {
+                    log::error!("hostfsd: failed to deserialize long timestamp request");
+                    set_kind(
+                        &mut response,
+                        SystemCallMessageKind::HostFsUpdateTimesAtResponse as u16,
+                    );
+                    set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
+                }
+            },
             _ => {
                 log::error!("hostfsd: unexpected assembled header: {:?}", dispatch_header);
                 if let Some(resp_header) = dispatch_header.hostfs_response_kind() {
@@ -475,6 +527,13 @@ impl HostFsHandler {
 
         if rdonly || rdwr {
             opts.read(true);
+        }
+        #[cfg(windows)]
+        if rdonly {
+            use std::os::windows::fs::OpenOptionsExt;
+            const GENERIC_READ: u32 = 0x8000_0000;
+            const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
+            opts.access_mode(GENERIC_READ | FILE_WRITE_ATTRIBUTES);
         }
         if wronly || rdwr {
             opts.write(true);
@@ -810,6 +869,46 @@ impl HostFsHandler {
         };
 
         let status: i32 = result.as_ref().map_or_else(io_error_to_code, |_| 0);
+        set_payload_data(response, &status.to_le_bytes());
+    }
+
+    /// Handles a path-based timestamp update.
+    fn handle_long_update_times(
+        &mut self,
+        req: long_msg::LongUpdateTimesRequest,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        set_kind(response, SystemCallMessageKind::HostFsUpdateTimesAtResponse as u16);
+
+        let no_follow: bool = req.flags & ::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW != 0;
+        if req.flags & !::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW != 0 {
+            set_payload_data(response, &HOSTFS_ERR_INVALID.to_le_bytes());
+            return;
+        }
+        let host_path: PathBuf = match if no_follow {
+            self.sandbox.resolve_nofollow(&req.path)
+        } else {
+            self.sandbox.resolve(&req.path)
+        } {
+            Some(path) => path,
+            None => {
+                set_payload_data(response, &HOSTFS_ERR_PERMISSION.to_le_bytes());
+                return;
+            },
+        };
+        let times: FileTimes = match file_times(&req.times) {
+            Ok(times) => times,
+            Err(error) => {
+                set_payload_data(response, &io_error_to_code(&error).to_le_bytes());
+                return;
+            },
+        };
+        let result: io::Result<()> = if no_follow {
+            fs::set_times_nofollow(host_path, times)
+        } else {
+            fs::set_times(host_path, times)
+        };
+        let status: i32 = result.map(|()| 0).unwrap_or_else(|e| io_error_to_code(&e));
         set_payload_data(response, &status.to_le_bytes());
     }
 
@@ -1255,6 +1354,13 @@ impl HostFsHandler {
 
         if rdonly || rdwr {
             opts.read(true);
+        }
+        #[cfg(windows)]
+        if rdonly {
+            use std::os::windows::fs::OpenOptionsExt;
+            const GENERIC_READ: u32 = 0x8000_0000;
+            const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
+            opts.access_mode(GENERIC_READ | FILE_WRITE_ATTRIBUTES);
         }
         if wronly || rdwr {
             opts.write(true);
@@ -2020,6 +2126,41 @@ impl HostFsHandler {
         set_payload_data(response, &status.to_le_bytes());
     }
 
+    fn handle_update_times(
+        &mut self,
+        payload: &[u8; Message::PAYLOAD_SIZE],
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        set_kind(response, SystemCallMessageKind::HostFsUpdateTimesResponse as u16);
+        let request: UpdateTimesRequest = match UpdateTimesRequest::decode(payload) {
+            Some(request) => request,
+            None => {
+                set_payload_data(response, &HOSTFS_ERR_INVALID.to_le_bytes());
+                return;
+            },
+        };
+        let times: FileTimes = match file_times(&request.times) {
+            Ok(times) => times,
+            Err(error) => {
+                set_payload_data(response, &io_error_to_code(&error).to_le_bytes());
+                return;
+            },
+        };
+        let entry: &FdEntry = match self.fd_table.get(request.fd) {
+            Some(entry) => entry,
+            None => {
+                set_payload_data(response, &HOSTFS_ERR_BAD_FD.to_le_bytes());
+                return;
+            },
+        };
+        let status: i32 = entry
+            .file
+            .set_times(times)
+            .map(|()| 0)
+            .unwrap_or_else(|error| io_error_to_code(&error));
+        set_payload_data(response, &status.to_le_bytes());
+    }
+
     fn handle_flush(
         &mut self,
         payload: &[u8; Message::PAYLOAD_SIZE],
@@ -2106,8 +2247,11 @@ fn open_dir_handle(path: &std::path::Path) -> io::Result<File> {
         // FILE_FLAG_BACKUP_SEMANTICS is required to obtain a handle on a
         // directory via CreateFileW.
         const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+        const GENERIC_READ: u32 = 0x8000_0000;
+        const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
         OpenOptions::new()
             .read(true)
+            .access_mode(GENERIC_READ | FILE_WRITE_ATTRIBUTES)
             .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
             .open(path)
     }

--- a/src/daemons/hostfsd/src/lib.rs
+++ b/src/daemons/hostfsd/src/lib.rs
@@ -13,6 +13,8 @@
 //! (e.g., `../`) that escape the root are rejected. Symlinks pointing outside the root are also
 //! rejected.
 
+#![feature(fs_set_times)]
+
 mod fd_table;
 mod handler;
 mod sandbox;

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -22,6 +22,7 @@ use std::{
 use sys::ipc::Message;
 use sysapi::{
     fcntl::{
+        atflags::AT_SYMLINK_NOFOLLOW,
         file_access_mode::{
             O_RDONLY,
             O_RDWR,
@@ -34,6 +35,11 @@ use sysapi::{
             O_TRUNC,
         },
     },
+    sys_stat::{
+        UTIME_NOW,
+        UTIME_OMIT,
+    },
+    time::timespec,
     unistd::file_seek::{
         SEEK_END,
         SEEK_SET,
@@ -173,6 +179,14 @@ fn make_flush_request(fd: i32) -> [u8; Message::PAYLOAD_SIZE] {
     let req: FlushRequest = FlushRequest { fd };
     req.serialize(
         SystemCallMessageKind::HostFsFlushRequest as u16,
+        OperationId::from_le_bytes([0; 4]),
+    )
+}
+
+/// Builds a descriptor-based timestamp update request payload.
+fn make_update_times_request(fd: i32, times: [timespec; 2]) -> [u8; Message::PAYLOAD_SIZE] {
+    UpdateTimesRequest { fd, times }.serialize(
+        SystemCallMessageKind::HostFsUpdateTimesRequest as u16,
         OperationId::from_le_bytes([0; 4]),
     )
 }
@@ -637,6 +651,103 @@ fn test_truncate_negative_length_fails() {
     let ds: usize = HOSTFS_DATA_START;
     let status: i32 = i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap());
     assert_eq!(status, HOSTFS_ERR_INVALID, "truncate with negative length should fail with EINVAL");
+}
+
+//==================================================================================================
+// Tests: Timestamps
+//==================================================================================================
+
+#[test]
+fn test_update_times_by_descriptor() {
+    let (mut handler, tmp) = setup();
+    let path: PathBuf = tmp.path().join("times.txt");
+    fs::write(&path, b"data").unwrap();
+    let fd: i32 = open_file(&mut handler, "times.txt", O_RDONLY);
+
+    let times: [timespec; 2] = [
+        timespec {
+            tv_sec: 1_700_000_000,
+            tv_nsec: 123_456_700,
+        },
+        timespec {
+            tv_sec: 1_700_000_010,
+            tv_nsec: 234_567_800,
+        },
+    ];
+    let response = handler
+        .handle_request(&make_update_times_request(fd, times))
+        .unwrap();
+    let ds: usize = HOSTFS_DATA_START;
+    assert_eq!(i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap()), 0);
+
+    let modified = fs::metadata(&path)
+        .unwrap()
+        .modified()
+        .unwrap()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    assert_eq!(modified.as_secs(), times[1].tv_sec as u64);
+    assert_eq!(modified.subsec_nanos(), times[1].tv_nsec as u32);
+
+    let now: [timespec; 2] = [
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_OMIT,
+        },
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_NOW,
+        },
+    ];
+    let before = std::time::SystemTime::now();
+    let response = handler
+        .handle_request(&make_update_times_request(fd, now))
+        .unwrap();
+    let after = std::time::SystemTime::now();
+    assert_eq!(i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap()), 0);
+    let modified = fs::metadata(path).unwrap().modified().unwrap();
+    assert!(modified >= before && modified <= after);
+}
+
+#[test]
+fn test_update_times_rejects_invalid_fd() {
+    let (mut handler, _tmp) = setup();
+    let times: [timespec; 2] = [
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_NOW,
+        },
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_NOW,
+        },
+    ];
+    let response = handler
+        .handle_request(&make_update_times_request(999, times))
+        .unwrap();
+    let ds: usize = HOSTFS_DATA_START;
+    assert_eq!(i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap()), HOSTFS_ERR_BAD_FD);
+}
+
+#[test]
+fn test_update_times_rejects_invalid_nanoseconds() {
+    let (mut handler, _tmp) = setup();
+    let fd: i32 = open_file(&mut handler, "invalid-times.txt", O_RDWR | O_CREAT);
+    let times: [timespec; 2] = [
+        timespec {
+            tv_sec: 0,
+            tv_nsec: -1,
+        },
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_OMIT,
+        },
+    ];
+    let response = handler
+        .handle_request(&make_update_times_request(fd, times))
+        .unwrap();
+    let ds: usize = HOSTFS_DATA_START;
+    assert_eq!(i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap()), HOSTFS_ERR_INVALID);
 }
 
 //==================================================================================================
@@ -1307,6 +1418,22 @@ fn make_long_mkdir_parts(
 }
 
 /// Serializes a long RENAME request: `[op_id:4][old_path_len:2][new_path_len:2][old_path][new_path]`.
+fn make_long_update_times_parts(
+    path: &str,
+    flags: i32,
+    times: &[timespec; 2],
+    op_id: OperationId,
+) -> Vec<[u8; Message::PAYLOAD_SIZE]> {
+    let data = hostfs_api::long_msg::serialize_long_update_times_request(
+        op_id,
+        flags,
+        times,
+        path.as_bytes(),
+    )
+    .unwrap();
+    split_into_parts(SystemCallMessageKind::HostFsUpdateTimesAtRequestPart, &data)
+}
+
 fn make_long_rename_parts(
     old_path: &str,
     new_path: &str,
@@ -1338,6 +1465,104 @@ fn feed_parts(
     handler
         .handle_request(parts.last().unwrap())
         .expect("final part should produce a response")
+}
+
+#[test]
+fn test_long_update_times_path() {
+    let (mut handler, tmp) = setup();
+    let path: String = format!("{}/file.txt", "t".repeat(60));
+    fs::create_dir(tmp.path().join("t".repeat(60))).unwrap();
+    fs::write(tmp.path().join(&path), b"data").unwrap();
+    let times: [timespec; 2] = [
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_OMIT,
+        },
+        timespec {
+            tv_sec: 1_700_000_020,
+            tv_nsec: 345_678_900,
+        },
+    ];
+    let parts = make_long_update_times_parts(&path, 0, &times, OperationId::from_raw(10));
+    let response = feed_parts(&mut handler, &parts);
+    let ds: usize = HOSTFS_DATA_START;
+    assert_eq!(i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap()), 0);
+    let modified = fs::metadata(tmp.path().join(path))
+        .unwrap()
+        .modified()
+        .unwrap()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    assert_eq!(modified.as_secs(), times[1].tv_sec as u64);
+    assert_eq!(modified.subsec_nanos(), times[1].tv_nsec as u32);
+}
+
+#[test]
+fn test_long_update_times_nofollow_updates_symlink() {
+    let (mut handler, tmp) = setup();
+    let target: PathBuf = tmp.path().join("target.txt");
+    let link: PathBuf = tmp.path().join("link.txt");
+    fs::write(&target, b"data").unwrap();
+    if let Err(error) = host_symlink(std::path::Path::new("target.txt"), &link) {
+        if is_privilege_error(&error) {
+            println!("skipping: host cannot create symlinks ({error})");
+            return;
+        }
+        panic!("host_symlink failed: {error}");
+    }
+
+    let target_times: [timespec; 2] = [
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_OMIT,
+        },
+        timespec {
+            tv_sec: 1_700_000_030,
+            tv_nsec: 0,
+        },
+    ];
+    let response = feed_parts(
+        &mut handler,
+        &make_long_update_times_parts("target.txt", 0, &target_times, OperationId::from_raw(14)),
+    );
+    let ds: usize = HOSTFS_DATA_START;
+    assert_eq!(i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap()), 0);
+
+    let link_times: [timespec; 2] = [
+        timespec {
+            tv_sec: 0,
+            tv_nsec: UTIME_OMIT,
+        },
+        timespec {
+            tv_sec: 1_700_000_040,
+            tv_nsec: 0,
+        },
+    ];
+    let response = feed_parts(
+        &mut handler,
+        &make_long_update_times_parts(
+            "link.txt",
+            AT_SYMLINK_NOFOLLOW,
+            &link_times,
+            OperationId::from_raw(15),
+        ),
+    );
+    assert_eq!(i32::from_le_bytes(response[ds..ds + 4].try_into().unwrap()), 0);
+
+    let target_modified = fs::metadata(target)
+        .unwrap()
+        .modified()
+        .unwrap()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    let link_modified = fs::symlink_metadata(link)
+        .unwrap()
+        .modified()
+        .unwrap()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    assert_eq!(target_modified.as_secs(), target_times[1].tv_sec as u64);
+    assert_eq!(link_modified.as_secs(), link_times[1].tv_sec as u64);
 }
 
 #[test]

--- a/src/daemons/vfsd/src/assembler.rs
+++ b/src/daemons/vfsd/src/assembler.rs
@@ -376,7 +376,8 @@ fn dispatch_assembled_request(
         },
         SystemCallMessageKind::UpdateFileAccessTimeAtRequestPart => {
             match UpdateFileAccessTimeAtRequest::from_parts(parts) {
-                Ok(req) => handler::handle_utimensat(source, req),
+                Ok(req) => handler::handle_utimensat_with_hostfs(response_context, req, pending)
+                    .unwrap_or_default(),
                 Err(e) => {
                     ::syslog::error!("dispatch: utimensat from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -323,6 +323,48 @@ pub(crate) fn handle_fsync_with_hostfs(
     Some(super::short::handle_fsync(source, msg))
 }
 
+pub(crate) fn handle_futimens_with_hostfs(
+    response_context: ResponseContext,
+    msg: SystemCallMessage,
+    pending: &mut PendingQueue,
+) -> Option<Message> {
+    let source_pid: ProcessIdentifier = response_context.source_pid();
+    let source: ThreadIdentifier = response_context.source_tid();
+    let request: UpdateFileAccessTimeRequest =
+        match UpdateFileAccessTimeRequest::from_bytes(msg.payload) {
+            Ok(request) => request,
+            Err(error) => return Some(build_error(source, error.code)),
+        };
+
+    if let Some(remote_fd) = ::vfs::fd::vfs_hostfs_remote_fd(request.fd) {
+        if !pending.has_capacity() {
+            return Some(build_error(source, ErrorCode::ResourceBusy));
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        if pending
+            .insert(
+                op_id,
+                PendingOp {
+                    response_context,
+                    source_tid: source,
+                    source_pid,
+                    kind: PendingOpKind::UpdateTimes,
+                },
+            )
+            .is_err()
+        {
+            return Some(build_error(source, ErrorCode::ResourceBusy));
+        }
+        if hostfs::send_update_times_request(remote_fd, &request.times, op_id).is_err() {
+            pending.remove(op_id);
+            return Some(build_error(source, ErrorCode::IoErr));
+        }
+        return None;
+    }
+
+    Some(super::short::handle_futimens(source, msg))
+}
+
 pub(crate) fn handle_ftruncate_with_hostfs(
     response_context: ResponseContext,
     msg: SystemCallMessage,
@@ -443,6 +485,59 @@ pub(crate) fn handle_fstat_with_hostfs(
     }
 
     Some(super::long::handle_fstat(source, msg))
+}
+
+pub(crate) fn handle_utimensat_with_hostfs(
+    response_context: ResponseContext,
+    request: UpdateFileAccessTimeAtRequest,
+    pending: &mut PendingQueue,
+) -> Option<Vec<Message>> {
+    let source_pid: ProcessIdentifier = response_context.source_pid();
+    let source: ThreadIdentifier = response_context.source_tid();
+    if request.flag & !::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW != 0 {
+        return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+    }
+    if request
+        .times
+        .iter()
+        .all(|time| time.tv_nsec == ::sysapi::sys_stat::UTIME_OMIT)
+    {
+        return Some(super::long::handle_utimensat(source, request));
+    }
+    let resolved = match vfs_resolve_path(request.dirfd, &request.path) {
+        Ok(resolved) => resolved,
+        Err(error) => return Some(vec![build_error(source, fat32_to_error_code(&error))]),
+    };
+
+    if hostfs::is_hostfs_path(resolved.as_str()) {
+        if !pending.has_capacity() {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        if pending
+            .insert(
+                op_id,
+                PendingOp {
+                    response_context,
+                    source_tid: source,
+                    source_pid,
+                    kind: PendingOpKind::UpdateTimesAt,
+                },
+            )
+            .is_err()
+        {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        if let Err(error) =
+            hostfs::send_update_times_at_request(&resolved, request.flag, &request.times, op_id)
+        {
+            pending.remove(op_id);
+            return Some(vec![build_error(source, error)]);
+        }
+        return None;
+    }
+
+    Some(super::long::handle_utimensat(source, request))
 }
 
 pub(crate) fn handle_fstatat_with_hostfs(
@@ -694,6 +789,8 @@ use ::syscall::{
         FileStatAtRequest,
         FileStatRequest,
         MakeDirectoryAtRequest,
+        UpdateFileAccessTimeAtRequest,
+        UpdateFileAccessTimeRequest,
     },
     unistd::message::{
         FileChownAtRequest,

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -328,6 +328,25 @@ pub fn send_flush_request(
     }
 }
 
+/// Sends a descriptor-based timestamp update request to hostfsd.
+pub fn send_update_times_request(
+    remote_fd: i32,
+    times: &[::sysapi::time::timespec; 2],
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let payload: [u8; Message::PAYLOAD_SIZE] = UpdateTimesRequest {
+        fd: remote_fd,
+        times: *times,
+    }
+    .serialize(SystemCallMessageKind::HostFsUpdateTimesRequest as u16, op_id);
+
+    if send_request(&payload) {
+        Ok(())
+    } else {
+        Err(::sys::error::ErrorCode::IoErr)
+    }
+}
+
 /// Sends a MKDIR request to hostfsd as a multi-part IKC message.
 pub fn send_mkdir_request(
     path: &ResolvedPath,
@@ -527,6 +546,21 @@ pub fn send_lstat_request(
         .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
 
     send_long_request(&buf, SystemCallMessageKind::HostFsLstatRequestPart, op_id)
+}
+
+/// Sends a path-based timestamp update request to hostfsd.
+pub fn send_update_times_at_request(
+    path: &ResolvedPath,
+    flags: i32,
+    times: &[::sysapi::time::timespec; 2],
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path.as_str());
+    let buf: alloc::vec::Vec<u8> =
+        long_msg::serialize_long_update_times_request(op_id, flags, times, relative.as_bytes())
+            .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
+
+    send_long_request(&buf, SystemCallMessageKind::HostFsUpdateTimesAtRequestPart, op_id)
 }
 
 /// Sends a path-based *following* STAT request to hostfsd.

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -508,8 +508,11 @@ pub(crate) fn handle_ipc_message(
             response_context.send(&response);
         },
         SystemCallMessageKind::UpdateFileAccessTimeRequest => {
-            let response: Message = handler::handle_futimens(source_tid, syscall_msg);
-            response_context.send(&response);
+            if let Some(response) =
+                handler::handle_futimens_with_hostfs(response_context, syscall_msg, pending)
+            {
+                response_context.send(&response);
+            }
         },
 
         //==========================================================================================

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -90,6 +90,10 @@ pub(crate) enum PendingOpKind {
     Flush,
     /// ftruncate — response is a status code.
     Truncate,
+    /// futimens — response is a status code.
+    UpdateTimes,
+    /// utimensat — response is a status code.
+    UpdateTimesAt,
     /// mkdir — response is a status code.
     Mkdir,
     /// rmdir — response is a status code.
@@ -541,6 +545,12 @@ pub(crate) fn complete_pending_op(
         PendingOpKind::Truncate => {
             complete_status(response_context, response_payload, OpGroup::Truncate)
         },
+        PendingOpKind::UpdateTimes => {
+            complete_status(response_context, response_payload, OpGroup::UpdateTimes)
+        },
+        PendingOpKind::UpdateTimesAt => {
+            complete_status(response_context, response_payload, OpGroup::UpdateTimesAt)
+        },
         PendingOpKind::Mkdir => complete_status(response_context, response_payload, OpGroup::Mkdir),
         PendingOpKind::Rmdir => complete_status(response_context, response_payload, OpGroup::Rmdir),
         PendingOpKind::Unlink => {
@@ -982,6 +992,8 @@ fn validate_response_header(kind: &PendingOpKind, payload: &[u8; Message::PAYLOA
             | (PendingOpKind::Seek, SystemCallMessageKind::HostFsLseekResponse)
             | (PendingOpKind::Flush, SystemCallMessageKind::HostFsFlushResponse)
             | (PendingOpKind::Truncate, SystemCallMessageKind::HostFsTruncateResponse)
+            | (PendingOpKind::UpdateTimes, SystemCallMessageKind::HostFsUpdateTimesResponse)
+            | (PendingOpKind::UpdateTimesAt, SystemCallMessageKind::HostFsUpdateTimesAtResponse,)
             | (PendingOpKind::Mkdir, SystemCallMessageKind::HostFsMkdirResponse)
             | (PendingOpKind::Rmdir, SystemCallMessageKind::HostFsRmdirResponse)
             | (PendingOpKind::Unlink, SystemCallMessageKind::HostFsUnlinkResponse)
@@ -1135,6 +1147,8 @@ fn complete_seek(
 enum OpGroup {
     Flush,
     Truncate,
+    UpdateTimes,
+    UpdateTimesAt,
     Mkdir,
     Rmdir,
     Unlink,
@@ -1164,6 +1178,24 @@ fn complete_status(
         OpGroup::Truncate => {
             use ::syscall::unistd::message::FileTruncateResponse;
             FileTruncateResponse::build(source_tid, 0, ProcessIdentifier::VFSD, MessageType::Ipc)
+        },
+        OpGroup::UpdateTimes => {
+            use ::syscall::sys::stat::message::UpdateFileAccessTimeResponse;
+            UpdateFileAccessTimeResponse::build(
+                source_tid,
+                0,
+                ProcessIdentifier::VFSD,
+                MessageType::Ipc,
+            )
+        },
+        OpGroup::UpdateTimesAt => {
+            use ::syscall::sys::stat::message::UpdateFileAccessTimeAtResponse;
+            UpdateFileAccessTimeAtResponse::build(
+                source_tid,
+                0,
+                ProcessIdentifier::VFSD,
+                MessageType::Ipc,
+            )
         },
         OpGroup::Mkdir => {
             use ::syscall::sys::stat::message::MakeDirectoryAtResponse;
@@ -1200,6 +1232,7 @@ fn hostfs_error_to_code(code: i32) -> ErrorCode {
     match code {
         ::hostfs_api::HOSTFS_ERR_NOT_PERMITTED => ErrorCode::OperationNotPermitted,
         ::hostfs_api::HOSTFS_ERR_NOT_FOUND => ErrorCode::NoSuchEntry,
+        ::hostfs_api::HOSTFS_ERR_BAD_FD => ErrorCode::BadFile,
         ::hostfs_api::HOSTFS_ERR_PERMISSION => ErrorCode::PermissionDenied,
         ::hostfs_api::HOSTFS_ERR_EXISTS => ErrorCode::EntryExists,
         ::hostfs_api::HOSTFS_ERR_NOT_DIR => ErrorCode::InvalidDirectory,

--- a/src/libs/hostfs-api/src/error.rs
+++ b/src/libs/hostfs-api/src/error.rs
@@ -9,6 +9,8 @@ pub const HOSTFS_ERR_NOT_PERMITTED: i32 = -1;
 pub const HOSTFS_ERR_NOT_FOUND: i32 = -2;
 /// Error code: generic I/O error.
 pub const HOSTFS_ERR_IO: i32 = -5;
+/// Error code: invalid file descriptor.
+pub const HOSTFS_ERR_BAD_FD: i32 = -9;
 /// Error code: permission denied.
 pub const HOSTFS_ERR_PERMISSION: i32 = -13;
 /// Error code: file or directory already exists.

--- a/src/libs/hostfs-api/src/lib.rs
+++ b/src/libs/hostfs-api/src/lib.rs
@@ -51,6 +51,7 @@ mod stat;
 mod stat_times;
 mod truncate;
 mod unlink;
+mod update_times;
 mod write;
 
 pub use self::{
@@ -96,6 +97,7 @@ pub use self::{
     },
     truncate::TruncateRequest,
     unlink::UnlinkRequest,
+    update_times::UpdateTimesRequest,
     write::{
         WriteRequest,
         WriteResponse,
@@ -282,6 +284,7 @@ pub const MAX_DIR_ENTRY_NAME_LEN: usize = Message::PAYLOAD_SIZE - HOSTFS_DATA_ST
 //==================================================================================================
 
 pub use self::error::{
+    HOSTFS_ERR_BAD_FD,
     HOSTFS_ERR_EXISTS,
     HOSTFS_ERR_INVALID,
     HOSTFS_ERR_IO,

--- a/src/libs/hostfs-api/src/long_msg.rs
+++ b/src/libs/hostfs-api/src/long_msg.rs
@@ -26,6 +26,7 @@
 //! - **Readlink**: `[op_id:4][path_len:2][path:N]`
 //! - **Lstat**: `[op_id:4][path_len:2][path:N]`
 //! - **ChownAt**: `[op_id:4][owner:4][group:4][flags:4][path_len:2][path:N]`
+//! - **Update times**: `[op_id:4][flags:4][times:32][path_len:2][path:N]`
 //!
 //! # Long Response Format
 //!
@@ -82,6 +83,9 @@ pub const LSTAT_HEADER_SIZE: usize = 6;
 
 /// Header size for long chownat: op_id(4) + owner(4) + group(4) + flags(4) + path_len(2) = 18.
 pub const CHOWNAT_HEADER_SIZE: usize = 18;
+
+/// Header size for long timestamp update: op_id(4) + flags(4) + times(32) + path_len(2) = 42.
+pub const UPDATE_TIMES_HEADER_SIZE: usize = 4 + 4 + 2 * ::sysapi::time::timespec::WIRE_SIZE + 2;
 
 /// Header size for the long Readlink *response* body:
 /// `op_id(4) + status(4) + target_len(2) = 10`.
@@ -610,6 +614,47 @@ pub fn deserialize_long_chownat(bytes: &[u8]) -> Option<LongChownAtRequest> {
     })
 }
 
+/// Result of deserializing a long path-based timestamp update request.
+#[cfg(feature = "std")]
+pub struct LongUpdateTimesRequest {
+    pub op_id: OperationId,
+    pub flags: i32,
+    pub times: [::sysapi::time::timespec; 2],
+    pub path: std::string::String,
+}
+
+/// Deserializes a long path-based timestamp update request.
+#[cfg(feature = "std")]
+pub fn deserialize_long_update_times(bytes: &[u8]) -> Option<LongUpdateTimesRequest> {
+    use ::sysapi::time::timespec;
+
+    if bytes.len() < UPDATE_TIMES_HEADER_SIZE {
+        return None;
+    }
+    let op_id = OperationId::new(u32::from_le_bytes(bytes[0..4].try_into().ok()?));
+    let flags = i32::from_le_bytes(bytes[4..8].try_into().ok()?);
+    let times_start: usize = 8;
+    let times = [
+        timespec::try_from_bytes(&bytes[times_start..times_start + timespec::WIRE_SIZE]).ok()?,
+        timespec::try_from_bytes(
+            &bytes[times_start + timespec::WIRE_SIZE..times_start + 2 * timespec::WIRE_SIZE],
+        )
+        .ok()?,
+    ];
+    let path_len_start: usize = times_start + 2 * timespec::WIRE_SIZE;
+    let path_len =
+        u16::from_le_bytes(bytes[path_len_start..path_len_start + 2].try_into().ok()?) as usize;
+    let path_start: usize = UPDATE_TIMES_HEADER_SIZE;
+    let path_end: usize = path_start.checked_add(path_len)?;
+    let path = std::string::String::from_utf8(bytes.get(path_start..path_end)?.to_vec()).ok()?;
+    Some(LongUpdateTimesRequest {
+        op_id,
+        flags,
+        times,
+        path,
+    })
+}
+
 //==================================================================================================
 // Serialization (vfsd, no_std + alloc)
 //==================================================================================================
@@ -756,6 +801,24 @@ pub fn serialize_long_chownat_request(
     buf.extend_from_slice(&owner.to_le_bytes());
     buf.extend_from_slice(&group.to_le_bytes());
     buf.extend_from_slice(&flags.to_le_bytes());
+    buf.extend_from_slice(&path_len.to_le_bytes());
+    buf.extend_from_slice(path);
+    Some(buf)
+}
+
+/// Serializes a long path-based timestamp update request.
+pub fn serialize_long_update_times_request(
+    op_id: OperationId,
+    flags: i32,
+    times: &[::sysapi::time::timespec; 2],
+    path: &[u8],
+) -> Option<Vec<u8>> {
+    let path_len: u16 = u16::try_from(path.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(UPDATE_TIMES_HEADER_SIZE + path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&flags.to_le_bytes());
+    buf.extend_from_slice(&times[0].to_bytes());
+    buf.extend_from_slice(&times[1].to_bytes());
     buf.extend_from_slice(&path_len.to_le_bytes());
     buf.extend_from_slice(path);
     Some(buf)

--- a/src/libs/hostfs-api/src/update_times.rs
+++ b/src/libs/hostfs-api/src/update_times.rs
@@ -1,0 +1,58 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! File timestamp request wire format.
+
+use crate::{
+    set_kind,
+    set_op_id,
+    OperationId,
+    HOSTFS_DATA_START,
+};
+use ::sys::ipc::Message;
+use ::sysapi::time::timespec;
+
+const _: () = assert!(HOSTFS_DATA_START + 4 + 2 * timespec::WIRE_SIZE <= Message::PAYLOAD_SIZE);
+
+/// Descriptor-based timestamp update request.
+#[derive(Debug, Clone, Copy)]
+pub struct UpdateTimesRequest {
+    /// Remote file descriptor.
+    pub fd: i32,
+    /// Access and modification times.
+    pub times: [timespec; 2],
+}
+
+impl UpdateTimesRequest {
+    /// Serializes this request into a complete message payload.
+    pub fn serialize(&self, kind_value: u16, op_id: OperationId) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0u8; Message::PAYLOAD_SIZE];
+        set_kind(&mut payload, kind_value);
+        set_op_id(&mut payload, op_id);
+        let data_start: usize = HOSTFS_DATA_START;
+        payload[data_start..data_start + 4].copy_from_slice(&self.fd.to_le_bytes());
+        payload[data_start + 4..data_start + 4 + timespec::WIRE_SIZE]
+            .copy_from_slice(&self.times[0].to_bytes());
+        payload[data_start + 4 + timespec::WIRE_SIZE..data_start + 4 + 2 * timespec::WIRE_SIZE]
+            .copy_from_slice(&self.times[1].to_bytes());
+        payload
+    }
+
+    /// Decodes a descriptor-based timestamp update request.
+    pub fn decode(payload: &[u8; Message::PAYLOAD_SIZE]) -> Option<Self> {
+        let data_start: usize = HOSTFS_DATA_START;
+        let fd: i32 = i32::from_le_bytes(payload[data_start..data_start + 4].try_into().ok()?);
+        let times: [timespec; 2] = [
+            timespec::try_from_bytes(
+                &payload[data_start + 4..data_start + 4 + timespec::WIRE_SIZE],
+            )
+            .ok()?,
+            timespec::try_from_bytes(
+                &payload[data_start + 4 + timespec::WIRE_SIZE
+                    ..data_start + 4 + 2 * timespec::WIRE_SIZE],
+            )
+            .ok()?,
+        ];
+        Some(Self { fd, times })
+    }
+}

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -365,6 +365,12 @@ pub enum SystemCallMessageKind {
     HostFsChownAtRequestPart,
     /// Hostfs ownership response.
     HostFsChownResponse,
+    /// Descriptor-based hostfs timestamp update.
+    HostFsUpdateTimesRequest,
+    HostFsUpdateTimesResponse,
+    /// Path-based hostfs timestamp update.
+    HostFsUpdateTimesAtRequestPart,
+    HostFsUpdateTimesAtResponse,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageKind.
 impl TryFrom<u16> for SystemCallMessageKind {
@@ -558,6 +564,10 @@ impl TryFrom<u16> for SystemCallMessageKind {
             x if x == HostFsChownRequest as u16 => Ok(HostFsChownRequest),
             x if x == HostFsChownAtRequestPart as u16 => Ok(HostFsChownAtRequestPart),
             x if x == HostFsChownResponse as u16 => Ok(HostFsChownResponse),
+            x if x == HostFsUpdateTimesRequest as u16 => Ok(HostFsUpdateTimesRequest),
+            x if x == HostFsUpdateTimesResponse as u16 => Ok(HostFsUpdateTimesResponse),
+            x if x == HostFsUpdateTimesAtRequestPart as u16 => Ok(HostFsUpdateTimesAtRequestPart),
+            x if x == HostFsUpdateTimesAtResponse as u16 => Ok(HostFsUpdateTimesAtResponse),
             _ => Err(()),
         }
     }
@@ -570,6 +580,10 @@ impl SystemCallMessageKind {
             self,
             Self::HostFsOpenRequest
                 | Self::HostFsOpenResponse
+                | Self::HostFsUpdateTimesRequest
+                | Self::HostFsUpdateTimesResponse
+                | Self::HostFsUpdateTimesAtRequestPart
+                | Self::HostFsUpdateTimesAtResponse
                 | Self::HostFsCloseRequest
                 | Self::HostFsCloseResponse
                 | Self::HostFsReadRequest
@@ -659,6 +673,8 @@ impl SystemCallMessageKind {
             Self::HostFsChownRequest | Self::HostFsChownAtRequestPart => {
                 Some(Self::HostFsChownResponse)
             },
+            Self::HostFsUpdateTimesRequest => Some(Self::HostFsUpdateTimesResponse),
+            Self::HostFsUpdateTimesAtRequestPart => Some(Self::HostFsUpdateTimesAtResponse),
             _ => None,
         }
     }
@@ -692,6 +708,8 @@ impl SystemCallMessageKind {
                 | Self::HostFsPathStatResponse
                 | Self::HostFsStatTimesResponse
                 | Self::HostFsChownResponse
+                | Self::HostFsUpdateTimesResponse
+                | Self::HostFsUpdateTimesAtResponse
         )
     }
 

--- a/src/tests/integration/test-c-file/futimens.c
+++ b/src/tests/integration/test-c-file/futimens.c
@@ -59,6 +59,26 @@ void test_futimens(void)
     assert(st.st_atime == times[0].tv_sec);
     assert(st.st_mtime == times[1].tv_sec);
 
+    // Update one timestamp while preserving the other.
+    const struct timespec old_atime = st.st_atim;
+    times[0].tv_nsec = UTIME_OMIT;
+    times[1].tv_sec = st.st_mtime + 10;
+    times[1].tv_nsec = 123456789;
+    assert(futimens(fd, times) == 0);
+    assert(fstat(fd, &st) == 0);
+    assert(st.st_atim.tv_sec == old_atime.tv_sec);
+    assert(st.st_atim.tv_nsec == old_atime.tv_nsec);
+    assert(st.st_mtim.tv_sec == times[1].tv_sec);
+    assert(st.st_mtim.tv_nsec == times[1].tv_nsec);
+
+    // Reject an invalid nanosecond value.
+    times[0].tv_sec = 0;
+    times[0].tv_nsec = -1;
+    times[1].tv_nsec = UTIME_OMIT;
+    errno = 0;
+    assert(futimens(fd, times) == -1);
+    assert(errno == EINVAL);
+
     // Clean up.
     assert(close(fd) == 0);
     assert(unlink(filename) == 0);

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -171,6 +172,17 @@ int main(int argc, const char *argv[])
     test_utimensat();
     test_utimensat_now();
     test_utime_preserve_imported_timestamps();
+if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
+    char cwd[PATH_MAX];
+    assert(getcwd(cwd, sizeof(cwd)) != NULL);
+    assert(chdir("/mnt") == 0);
+    test_utimensat();
+    test_utimensat_now();
+    test_utimes();
+    test_utime();
+    test_futimens();
+    assert(chdir(cwd) == 0);
+}
 #ifndef __NANVIX_STANDALONE__
     // FAT32 timestamps, permissions, and ownership are no-ops that fail assertions.
     test_utimensat();

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -172,17 +172,17 @@ int main(int argc, const char *argv[])
     test_utimensat();
     test_utimensat_now();
     test_utime_preserve_imported_timestamps();
-if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
-    char cwd[PATH_MAX];
-    assert(getcwd(cwd, sizeof(cwd)) != NULL);
-    assert(chdir("/mnt") == 0);
-    test_utimensat();
-    test_utimensat_now();
-    test_utimes();
-    test_utime();
-    test_futimens();
-    assert(chdir(cwd) == 0);
-}
+    if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
+        char cwd[PATH_MAX];
+        assert(getcwd(cwd, sizeof(cwd)) != NULL);
+        assert(chdir("/mnt") == 0);
+        test_utimensat();
+        test_utimensat_now();
+        test_utimes();
+        test_utime();
+        test_futimens();
+        assert(chdir(cwd) == 0);
+    }
 #ifndef __NANVIX_STANDALONE__
     // FAT32 timestamps, permissions, and ownership are no-ops that fail assertions.
     test_utimensat();

--- a/src/tests/integration/test-c-file/utimensat.c
+++ b/src/tests/integration/test-c-file/utimensat.c
@@ -99,6 +99,11 @@ void test_utimensat(void)
     assert(utimensat(AT_FDCWD, childpath, times, 1 << 30) == -1);
     assert(errno == EINVAL);
 
+    // Omitting both timestamps does not require resolving the path or directory descriptor.
+    times[0].tv_nsec = UTIME_OMIT;
+    times[1].tv_nsec = UTIME_OMIT;
+    assert(utimensat(123456, "missing.tmp", times, 0) == 0);
+
     assert(close(dirfd) == 0);
     assert(unlink(childpath) == 0);
     assert(rmdir(dirname) == 0);


### PR DESCRIPTION
Closes #3134.

Implement hostfs timestamp mutation for path- and descriptor-based operations. The hostfs protocol now supports `utimensat()` and `futimens()` while preserving nanosecond precision, `UTIME_NOW`, `UTIME_OMIT`, and `AT_SYMLINK_NOFOLLOW`.

Enable the existing timestamp tests for hostfs and add coverage for timestamp preservation, validation, descriptor errors, multipart paths, symbolic-link handling, and all-omitted timestamps.

Verified with:

- hostfs unit and handler tests
- workspace checks
- POSIX test image build
- focused `posix/test-c-file` execution
- formatting, linting, and spellcheck

Before marking ready:

- test the native host path on Windows
- resolve the reviewed Windows read-only ACL fallback concern
