### PR TITLE
[hostfsd] F: Forward Permission Changes

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -119,7 +119,8 @@ POSIX_TEST_FILES_test-c-file := \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c ftruncate.c truncate.c link.c linkat.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
 	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c \
-	utimensat.c utimes.c utime.c futimens.c chown.c fchown.c fchownat.c lchown.c
+	utimensat.c utimes.c utime.c futimens.c chown.c fchown.c fchownat.c lchown.c \
+	chmod.c fchmodat.c fchmod.c lchmod.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's

--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -250,7 +250,8 @@ impl HostFsHandler {
             | SystemCallMessageKind::HostFsLstatRequestPart
             | SystemCallMessageKind::HostFsPathStatRequestPart
             | SystemCallMessageKind::HostFsChownAtRequestPart
-            | SystemCallMessageKind::HostFsUpdateTimesAtRequestPart => self.handle_long_part(
+            | SystemCallMessageKind::HostFsUpdateTimesAtRequestPart
+            | SystemCallMessageKind::HostFsChmodRequestPart => self.handle_long_part(
                 syscall_msg.kind(),
                 OperationId::from_le_bytes(syscall_msg.request_id().raw().to_le_bytes()),
                 &syscall_msg.payload,
@@ -281,6 +282,7 @@ impl HostFsHandler {
             SystemCallMessageKind::HostFsLstatRequest => run(self, Self::handle_lstat),
             SystemCallMessageKind::HostFsPathStatRequest => run(self, Self::handle_pathstat),
             SystemCallMessageKind::HostFsChownRequest => run(self, Self::handle_chown),
+            SystemCallMessageKind::HostFsFchmodRequest => run(self, Self::handle_fchmod),
             other => {
                 log::error!("hostfsd: unexpected message header: {:?}", other);
                 let mut response = [0u8; Message::PAYLOAD_SIZE];
@@ -493,6 +495,14 @@ impl HostFsHandler {
                         &mut response,
                         SystemCallMessageKind::HostFsUpdateTimesAtResponse as u16,
                     );
+                    set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
+                }
+            },
+            SystemCallMessageKind::HostFsChmodRequestPart => {
+                if let Some(req) = long_msg::deserialize_long_mode_path(&assembled) {
+                    self.handle_long_chmod(req, &mut response);
+                } else {
+                    set_kind(&mut response, SystemCallMessageKind::HostFsChmodResponse as u16);
                     set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
                 }
             },
@@ -977,6 +987,104 @@ impl HostFsHandler {
             fs::set_times(host_path, times)
         };
         let status: i32 = result.map(|()| 0).unwrap_or_else(|e| io_error_to_code(&e));
+        set_payload_data(response, &status.to_le_bytes());
+    }
+
+    /// Handles a fully assembled long CHMOD request.
+    fn handle_long_chmod(
+        &mut self,
+        req: long_msg::LongModePathRequest,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        use ::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW;
+
+        set_kind(response, SystemCallMessageKind::HostFsChmodResponse as u16);
+        let flags: i32 = req.flags();
+        if flags != 0 && flags != AT_SYMLINK_NOFOLLOW {
+            set_payload_data(response, &HOSTFS_ERR_INVALID.to_le_bytes());
+            return;
+        }
+
+        let no_follow: bool = flags == AT_SYMLINK_NOFOLLOW;
+        let host_path: PathBuf = match if no_follow {
+            self.sandbox.resolve_nofollow(req.path())
+        } else {
+            self.sandbox.resolve(req.path())
+        } {
+            Some(path) => path,
+            None => {
+                set_payload_data(response, &HOSTFS_ERR_PERMISSION.to_le_bytes());
+                return;
+            },
+        };
+
+        if no_follow {
+            match fs::symlink_metadata(&host_path) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    set_payload_data(response, &HOSTFS_ERR_NOT_SUPPORTED.to_le_bytes());
+                    return;
+                },
+                Ok(_) => {},
+                Err(error) => {
+                    set_payload_data(response, &io_error_to_code(&error).to_le_bytes());
+                    return;
+                },
+            }
+        }
+
+        #[cfg(unix)]
+        let permissions = fs::Permissions::from_mode(req.mode() as u32);
+        #[cfg(not(unix))]
+        let permissions = {
+            let mut permissions = match fs::metadata(&host_path) {
+                Ok(metadata) => metadata.permissions(),
+                Err(error) => {
+                    set_payload_data(response, &io_error_to_code(&error).to_le_bytes());
+                    return;
+                },
+            };
+            permissions
+                .set_readonly(req.mode() as u32 & ::sysapi::sys_stat::file_mode::S_IWUSR == 0);
+            permissions
+        };
+        let status: i32 = match fs::set_permissions(&host_path, permissions) {
+            Ok(()) => 0,
+            Err(error) => io_error_to_code(&error),
+        };
+        set_payload_data(response, &status.to_le_bytes());
+    }
+
+    /// Handles an inline single-message FCHMOD request.
+    fn handle_fchmod(
+        &mut self,
+        payload: &[u8; Message::PAYLOAD_SIZE],
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        set_kind(response, SystemCallMessageKind::HostFsFchmodResponse as u16);
+        let request: ChmodRequest = ChmodRequest::decode(payload);
+        let Some(entry) = self.fd_table.get(request.fd()) else {
+            set_payload_data(response, &HOSTFS_ERR_BAD_FD.to_le_bytes());
+            return;
+        };
+
+        #[cfg(unix)]
+        let permissions = fs::Permissions::from_mode(request.mode());
+        #[cfg(not(unix))]
+        let permissions = {
+            let mut permissions = match entry.file.metadata() {
+                Ok(metadata) => metadata.permissions(),
+                Err(error) => {
+                    set_payload_data(response, &io_error_to_code(&error).to_le_bytes());
+                    return;
+                },
+            };
+            permissions.set_readonly(request.mode() & ::sysapi::sys_stat::file_mode::S_IWUSR == 0);
+            permissions
+        };
+        let status: i32 = match entry.file.set_permissions(permissions) {
+            Ok(()) => 0,
+            Err(error) => io_error_to_code(&error),
+        };
         set_payload_data(response, &status.to_le_bytes());
     }
 

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -1138,6 +1138,59 @@ fn make_part_payload(
     buf
 }
 
+/// Serializes a long mode/path request into multi-part IKC payloads.
+#[cfg(unix)]
+fn make_long_mode_path_parts(
+    header: SystemCallMessageKind,
+    path: &str,
+    mode: i32,
+    flags: i32,
+    op_id: OperationId,
+) -> Vec<[u8; Message::PAYLOAD_SIZE]> {
+    let data: Vec<u8> =
+        long_msg::serialize_long_mode_path_request(op_id, mode, flags, path.as_bytes())
+            .expect("mode/path request should serialize");
+    let chunk_size: usize = SystemCallMessagePart::PAYLOAD_SIZE;
+    let num_parts: u16 = data.len().div_ceil(chunk_size) as u16;
+
+    data.chunks(chunk_size)
+        .enumerate()
+        .map(|(index, chunk)| {
+            let mut part: [u8; Message::PAYLOAD_SIZE] =
+                make_part_payload(header, num_parts, index as u16, chunk.len() as u8, chunk);
+            set_op_id(&mut part, op_id);
+            part
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+fn run_long_request(
+    handler: &mut HostFsHandler,
+    parts: &[[u8; Message::PAYLOAD_SIZE]],
+) -> [u8; Message::PAYLOAD_SIZE] {
+    for part in &parts[..parts.len() - 1] {
+        assert!(handler.handle_request(part).is_none());
+    }
+    handler
+        .handle_request(parts.last().expect("request has at least one part"))
+        .expect("final request part should return a response")
+}
+
+#[cfg(unix)]
+const OFFSET_OF_RESPONSE_STATUS: usize = HOSTFS_DATA_START;
+#[cfg(unix)]
+const SIZE_OF_RESPONSE_STATUS: usize = ::core::mem::size_of::<i32>();
+
+#[cfg(unix)]
+fn response_status(response: &[u8; Message::PAYLOAD_SIZE]) -> i32 {
+    i32::from_le_bytes(
+        response[OFFSET_OF_RESPONSE_STATUS..OFFSET_OF_RESPONSE_STATUS + SIZE_OF_RESPONSE_STATUS]
+            .try_into()
+            .expect("response contains status"),
+    )
+}
+
 /// Serializes a long OPEN request into multi-part IKC payloads.
 fn make_long_open_parts(
     path: &str,
@@ -1168,6 +1221,66 @@ fn make_long_open_parts(
         parts.push(part);
     }
     parts
+}
+
+#[cfg(unix)]
+#[test]
+fn test_chmod_and_fchmod() {
+    use sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW;
+
+    let (mut handler, tmp) = setup();
+    let path: PathBuf = tmp.path().join("mode.txt");
+    fs::write(&path, b"data").unwrap();
+
+    let chmod = make_long_mode_path_parts(
+        SystemCallMessageKind::HostFsChmodRequestPart,
+        "mode.txt",
+        0o400,
+        0,
+        OperationId::from_raw(101),
+    );
+    assert_eq!(response_status(&run_long_request(&mut handler, &chmod)), 0);
+    assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o400);
+
+    let fd: i32 = open_file(&mut handler, "mode.txt", O_RDONLY);
+    let fchmod: [u8; Message::PAYLOAD_SIZE] = ChmodRequest::new(fd, 0o600)
+        .serialize(SystemCallMessageKind::HostFsFchmodRequest as u16, OperationId::from_raw(104));
+    let response = handler.handle_request(&fchmod).expect("fchmod response");
+    assert_eq!(response_status(&response), 0);
+    assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+
+    let invalid_fchmod: [u8; Message::PAYLOAD_SIZE] = ChmodRequest::new(-1, 0o600)
+        .serialize(SystemCallMessageKind::HostFsFchmodRequest as u16, OperationId::from_raw(105));
+    let response = handler
+        .handle_request(&invalid_fchmod)
+        .expect("fchmod response");
+    assert_eq!(response_status(&response), HOSTFS_ERR_BAD_FD);
+
+    let hard_link: PathBuf = tmp.path().join("hard-link.txt");
+    fs::hard_link(&path, &hard_link).unwrap();
+    let hard_link_chmod = make_long_mode_path_parts(
+        SystemCallMessageKind::HostFsChmodRequestPart,
+        "hard-link.txt",
+        0o640,
+        AT_SYMLINK_NOFOLLOW,
+        OperationId::from_raw(106),
+    );
+    assert_eq!(response_status(&run_long_request(&mut handler, &hard_link_chmod)), 0);
+
+    let symlink: PathBuf = tmp.path().join("symlink.txt");
+    std::os::unix::fs::symlink(&path, &symlink).unwrap();
+    let symlink_chmod = make_long_mode_path_parts(
+        SystemCallMessageKind::HostFsChmodRequestPart,
+        "symlink.txt",
+        0o777,
+        AT_SYMLINK_NOFOLLOW,
+        OperationId::from_raw(107),
+    );
+    assert_eq!(
+        response_status(&run_long_request(&mut handler, &symlink_chmod)),
+        HOSTFS_ERR_NOT_SUPPORTED
+    );
+    assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o640);
 }
 
 #[test]

--- a/src/daemons/vfsd/src/assembler.rs
+++ b/src/daemons/vfsd/src/assembler.rs
@@ -397,7 +397,8 @@ fn dispatch_assembled_request(
         },
         SystemCallMessageKind::FileChmodAtRequestPart => {
             match FileChmodAtRequest::from_parts(parts) {
-                Ok(req) => handler::handle_fchmodat(source, req),
+                Ok(req) => handler::handle_fchmodat_with_hostfs(response_context, req, pending)
+                    .unwrap_or_default(),
                 Err(e) => {
                     ::syslog::error!("dispatch: fchmodat from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -365,6 +365,48 @@ pub(crate) fn handle_futimens_with_hostfs(
     Some(super::short::handle_futimens(source, msg))
 }
 
+pub(crate) fn handle_fchmod_with_hostfs(
+    response_context: ResponseContext,
+    msg: SystemCallMessage,
+    pending: &mut PendingQueue,
+) -> Option<Message> {
+    let source_pid: ProcessIdentifier = response_context.source_pid();
+    let source: ThreadIdentifier = response_context.source_tid();
+    let req: ::syscall::sys::stat::message::FileChmodRequest =
+        ::syscall::sys::stat::message::FileChmodRequest::from_bytes(msg.payload);
+
+    if ::vfs::fd::vfs_resolve(req.fd).is_none() {
+        return Some(build_error(source, ErrorCode::BadFile));
+    }
+
+    if let Some(remote_fd) = ::vfs::fd::vfs_hostfs_remote_fd(req.fd) {
+        if !pending.has_capacity() {
+            return Some(build_error(source, ErrorCode::ResourceBusy));
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        if hostfs::send_fchmod_request(remote_fd, req.mode, op_id).is_err() {
+            return Some(build_error(source, ErrorCode::IoErr));
+        }
+        if pending
+            .insert(
+                op_id,
+                PendingOp {
+                    response_context,
+                    source_tid: source,
+                    source_pid,
+                    kind: PendingOpKind::Fchmod,
+                },
+            )
+            .is_err()
+        {
+            return Some(build_error(source, ErrorCode::ResourceBusy));
+        }
+        return None;
+    }
+
+    Some(super::short::handle_fchmod(source, msg))
+}
+
 pub(crate) fn handle_ftruncate_with_hostfs(
     response_context: ResponseContext,
     msg: SystemCallMessage,
@@ -1124,6 +1166,50 @@ pub(crate) fn handle_mkdirat_with_hostfs(
     }
 
     Some(super::long::handle_mkdirat(source, resolved))
+}
+
+pub(crate) fn handle_fchmodat_with_hostfs(
+    response_context: ResponseContext,
+    request: ::syscall::sys::stat::message::FileChmodAtRequest,
+    pending: &mut PendingQueue,
+) -> Option<Vec<Message>> {
+    let source_pid: ProcessIdentifier = response_context.source_pid();
+    let source: ThreadIdentifier = response_context.source_tid();
+    let resolved = match vfs_resolve_path(request.dirfd, &request.path) {
+        Ok(path) => path,
+        Err(error) => return Some(vec![build_error(source, fat32_to_error_code(&error))]),
+    };
+
+    if hostfs::is_hostfs_path(resolved.as_str()) {
+        if request.flag != 0 && request.flag != ::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW {
+            return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+        }
+        if !pending.has_capacity() {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        if let Err(error) = hostfs::send_chmod_request(&resolved, request.mode, request.flag, op_id)
+        {
+            return Some(vec![build_error(source, error)]);
+        }
+        if pending
+            .insert(
+                op_id,
+                PendingOp {
+                    response_context,
+                    source_tid: source,
+                    source_pid,
+                    kind: PendingOpKind::Chmod,
+                },
+            )
+            .is_err()
+        {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        return None;
+    }
+
+    Some(super::long::handle_fchmodat(source, request))
 }
 
 pub(crate) fn handle_symlinkat_with_hostfs(

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -391,6 +391,37 @@ pub fn send_unlink_request(
     send_long_request(&buf, SystemCallMessageKind::HostFsUnlinkRequestPart, op_id)
 }
 
+/// Sends an FCHMOD request to hostfsd.
+pub fn send_fchmod_request(
+    remote_fd: i32,
+    mode: u32,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let payload: [u8; Message::PAYLOAD_SIZE] = ChmodRequest::new(remote_fd, mode)
+        .serialize(SystemCallMessageKind::HostFsFchmodRequest as u16, op_id);
+
+    if send_request(&payload) {
+        Ok(())
+    } else {
+        Err(::sys::error::ErrorCode::IoErr)
+    }
+}
+
+/// Sends a CHMOD request to hostfsd.
+pub fn send_chmod_request(
+    path: &ResolvedPath,
+    mode: u32,
+    flags: i32,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path.as_str());
+    let buf: alloc::vec::Vec<u8> =
+        long_msg::serialize_long_mode_path_request(op_id, mode as i32, flags, relative.as_bytes())
+            .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
+
+    send_long_request(&buf, SystemCallMessageKind::HostFsChmodRequestPart, op_id)
+}
+
 /// Sends a STAT request to hostfsd (by remote FD).
 pub fn send_stat_request(
     remote_fd: i32,

--- a/src/daemons/vfsd/src/ipc.rs
+++ b/src/daemons/vfsd/src/ipc.rs
@@ -489,8 +489,11 @@ pub(crate) fn handle_ipc_message(
             response_context.send(&response);
         },
         SystemCallMessageKind::FileChmodRequest => {
-            let response: Message = handler::handle_fchmod(source_tid, syscall_msg);
-            response_context.send(&response);
+            if let Some(response) =
+                handler::handle_fchmod_with_hostfs(response_context, syscall_msg, pending)
+            {
+                response_context.send(&response);
+            }
         },
         SystemCallMessageKind::FileCreationMaskRequest => {
             let response: Message = handler::handle_umask(source_tid, syscall_msg);

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -94,6 +94,10 @@ pub(crate) enum PendingOpKind {
     UpdateTimes,
     /// utimensat — response is a status code.
     UpdateTimesAt,
+    /// chmod — response is a status code.
+    Chmod,
+    /// fchmod — response is a status code.
+    Fchmod,
     /// mkdir — response is a status code.
     Mkdir,
     /// rmdir — response is a status code.
@@ -553,6 +557,10 @@ pub(crate) fn complete_pending_op(
         PendingOpKind::UpdateTimesAt => {
             complete_status(response_context, response_payload, OpGroup::UpdateTimesAt)
         },
+        PendingOpKind::Chmod => complete_status(response_context, response_payload, OpGroup::Chmod),
+        PendingOpKind::Fchmod => {
+            complete_status(response_context, response_payload, OpGroup::Fchmod)
+        },
         PendingOpKind::Mkdir => complete_status(response_context, response_payload, OpGroup::Mkdir),
         PendingOpKind::Rmdir => complete_status(response_context, response_payload, OpGroup::Rmdir),
         PendingOpKind::Unlink => {
@@ -997,6 +1005,8 @@ fn validate_response_header(kind: &PendingOpKind, payload: &[u8; Message::PAYLOA
             | (PendingOpKind::Truncate, SystemCallMessageKind::HostFsTruncateResponse)
             | (PendingOpKind::UpdateTimes, SystemCallMessageKind::HostFsUpdateTimesResponse)
             | (PendingOpKind::UpdateTimesAt, SystemCallMessageKind::HostFsUpdateTimesAtResponse,)
+            | (PendingOpKind::Chmod, SystemCallMessageKind::HostFsChmodResponse)
+            | (PendingOpKind::Fchmod, SystemCallMessageKind::HostFsFchmodResponse)
             | (PendingOpKind::Mkdir, SystemCallMessageKind::HostFsMkdirResponse)
             | (PendingOpKind::Rmdir, SystemCallMessageKind::HostFsRmdirResponse)
             | (PendingOpKind::Unlink, SystemCallMessageKind::HostFsUnlinkResponse)
@@ -1153,6 +1163,8 @@ enum OpGroup {
     Truncate,
     UpdateTimes,
     UpdateTimesAt,
+    Chmod,
+    Fchmod,
     Mkdir,
     Rmdir,
     Unlink,
@@ -1201,6 +1213,14 @@ fn complete_status(
                 ProcessIdentifier::VFSD,
                 MessageType::Ipc,
             )
+        },
+        OpGroup::Chmod => {
+            use ::syscall::sys::stat::message::FileChmodAtResponse;
+            FileChmodAtResponse::build(source_tid, ProcessIdentifier::VFSD, MessageType::Ipc)
+        },
+        OpGroup::Fchmod => {
+            use ::syscall::sys::stat::message::FileChmodResponse;
+            FileChmodResponse::build(source_tid, ProcessIdentifier::VFSD, MessageType::Ipc)
         },
         OpGroup::Mkdir => {
             use ::syscall::sys::stat::message::MakeDirectoryAtResponse;
@@ -1660,6 +1680,11 @@ mod tests {
         }
         .encode(&mut payload);
         payload
+    }
+
+    #[test]
+    fn bad_fd_protocol_error_maps_to_bad_file() {
+        assert_eq!(hostfs_error_to_code(::hostfs_api::HOSTFS_ERR_BAD_FD), ErrorCode::BadFile);
     }
 
     #[test]

--- a/src/libs/hostfs-api/src/chmod.rs
+++ b/src/libs/hostfs-api/src/chmod.rs
@@ -1,0 +1,95 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Wire format for hostfs descriptor-based permission changes.
+
+use crate::{
+    set_kind,
+    set_op_id,
+    OperationId,
+    HOSTFS_DATA_START,
+};
+use ::core::mem;
+use ::sys::ipc::Message;
+
+/// Descriptor-based permission-change request.
+#[derive(Debug, Clone, Copy)]
+pub struct ChmodRequest {
+    /// Remote file descriptor.
+    fd: i32,
+    /// New file mode.
+    mode: u32,
+}
+
+impl ChmodRequest {
+    /// Size of the file descriptor field.
+    const SIZE_OF_FD: usize = mem::size_of::<i32>();
+    /// Size of the mode field.
+    const SIZE_OF_MODE: usize = mem::size_of::<u32>();
+    /// Offset of the file descriptor field.
+    const OFFSET_OF_FD: usize = 0;
+    /// Offset of the mode field.
+    const OFFSET_OF_MODE: usize = Self::OFFSET_OF_FD + Self::SIZE_OF_FD;
+
+    /// Creates a descriptor-based permission-change request.
+    pub const fn new(fd: i32, mode: u32) -> Self {
+        Self { fd, mode }
+    }
+
+    /// Returns the remote file descriptor.
+    pub const fn fd(&self) -> i32 {
+        self.fd
+    }
+
+    /// Returns the requested file mode.
+    pub const fn mode(&self) -> u32 {
+        self.mode
+    }
+
+    /// Serializes this request into a hostfs message payload.
+    pub fn serialize(&self, kind_value: u16, op_id: OperationId) -> [u8; Message::PAYLOAD_SIZE] {
+        let mut payload: [u8; Message::PAYLOAD_SIZE] = [0; Message::PAYLOAD_SIZE];
+        set_kind(&mut payload, kind_value);
+        set_op_id(&mut payload, op_id);
+        let fd_offset: usize = HOSTFS_DATA_START + Self::OFFSET_OF_FD;
+        let mode_offset: usize = HOSTFS_DATA_START + Self::OFFSET_OF_MODE;
+        payload[fd_offset..fd_offset + Self::SIZE_OF_FD]
+            .copy_from_slice(&self.fd.to_le_bytes());
+        payload[mode_offset..mode_offset + Self::SIZE_OF_MODE]
+            .copy_from_slice(&self.mode.to_le_bytes());
+        payload
+    }
+
+    /// Decodes this request from a hostfs message payload.
+    pub fn decode(payload: &[u8; Message::PAYLOAD_SIZE]) -> Self {
+        let fd_offset: usize = HOSTFS_DATA_START + Self::OFFSET_OF_FD;
+        let mode_offset: usize = HOSTFS_DATA_START + Self::OFFSET_OF_MODE;
+        Self {
+            fd: i32::from_le_bytes(
+                payload[fd_offset..fd_offset + Self::SIZE_OF_FD]
+                    .try_into()
+                    .expect("file descriptor field size must match i32"),
+            ),
+            mode: u32::from_le_bytes(
+                payload[mode_offset..mode_offset + Self::SIZE_OF_MODE]
+                    .try_into()
+                    .expect("mode field size must match u32"),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_round_trip() {
+        let request: ChmodRequest = ChmodRequest::new(17, 0o754);
+        let payload: [u8; Message::PAYLOAD_SIZE] = request.serialize(123, OperationId::new(42));
+
+        assert_eq!(ChmodRequest::decode(&payload).fd(), request.fd());
+        assert_eq!(ChmodRequest::decode(&payload).mode(), request.mode());
+        assert_eq!(crate::get_op_id(&payload), OperationId::new(42));
+    }
+}

--- a/src/libs/hostfs-api/src/lib.rs
+++ b/src/libs/hostfs-api/src/lib.rs
@@ -34,6 +34,7 @@ use ::sys::ipc::Message;
 //==================================================================================================
 
 mod chown;
+mod chmod;
 mod close;
 mod error;
 mod flush;
@@ -56,6 +57,7 @@ mod write;
 
 pub use self::{
     chown::ChownRequest,
+    chmod::ChmodRequest,
     close::CloseRequest,
     flush::FlushRequest,
     lseek::{

--- a/src/libs/hostfs-api/src/long_msg.rs
+++ b/src/libs/hostfs-api/src/long_msg.rs
@@ -28,6 +28,7 @@
 //! - **Lstat**: `[op_id:4][path_len:2][path:N]`
 //! - **ChownAt**: `[op_id:4][owner:4][group:4][flags:4][path_len:2][path:N]`
 //! - **Update times**: `[op_id:4][flags:4][times:32][path_len:2][path:N]`
+//! - **Chmod**: `[op_id:4][mode:4][flags:4][path_len:2][path:N]`
 //!
 //! # Long Response Format
 //!
@@ -116,6 +117,18 @@ pub const CHOWNAT_HEADER_SIZE: usize = 18;
 
 /// Header size for long timestamp update: op_id(4) + flags(4) + times(32) + path_len(2) = 42.
 pub const UPDATE_TIMES_HEADER_SIZE: usize = 4 + 4 + 2 * ::sysapi::time::timespec::WIRE_SIZE + 2;
+/// Size of a file mode.
+const SIZE_OF_MODE: usize = mem::size_of::<i32>();
+/// Offset of the mode/path operation identifier.
+const MODE_PATH_OFFSET_OF_OPERATION_ID: usize = 0;
+/// Offset of the file mode.
+const MODE_PATH_OFFSET_OF_MODE: usize = MODE_PATH_OFFSET_OF_OPERATION_ID + SIZE_OF_OPERATION_ID;
+/// Offset of the mode/path flags.
+const MODE_PATH_OFFSET_OF_FLAGS: usize = MODE_PATH_OFFSET_OF_MODE + SIZE_OF_MODE;
+/// Offset of the mode/path length.
+const MODE_PATH_OFFSET_OF_PATH_LEN: usize = MODE_PATH_OFFSET_OF_FLAGS + SIZE_OF_FLAGS;
+/// Header size for a long mode/path request.
+pub const MODE_PATH_HEADER_SIZE: usize = MODE_PATH_OFFSET_OF_PATH_LEN + SIZE_OF_PATH_LEN;
 
 /// Header size for the long Readlink *response* body:
 /// `op_id(4) + status(4) + target_len(2) = 10`.
@@ -737,6 +750,78 @@ pub fn deserialize_long_update_times(bytes: &[u8]) -> Option<LongUpdateTimesRequ
     })
 }
 
+/// Result of deserializing a path request carrying a mode and flags.
+#[cfg(feature = "std")]
+pub struct LongModePathRequest {
+    op_id: OperationId,
+    mode: i32,
+    flags: i32,
+    path: std::string::String,
+}
+
+#[cfg(feature = "std")]
+impl LongModePathRequest {
+    /// Returns the operation identifier.
+    pub const fn op_id(&self) -> OperationId {
+        self.op_id
+    }
+
+    /// Returns the requested file mode.
+    pub const fn mode(&self) -> i32 {
+        self.mode
+    }
+
+    /// Returns the request flags.
+    pub const fn flags(&self) -> i32 {
+        self.flags
+    }
+
+    /// Returns the requested path.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+/// Deserializes a long chmod request.
+#[cfg(feature = "std")]
+pub fn deserialize_long_mode_path(bytes: &[u8]) -> Option<LongModePathRequest> {
+    if bytes.len() < MODE_PATH_HEADER_SIZE {
+        return None;
+    }
+    let op_id = OperationId::new(u32::from_le_bytes(
+        bytes[MODE_PATH_OFFSET_OF_OPERATION_ID..MODE_PATH_OFFSET_OF_MODE]
+            .try_into()
+            .ok()?,
+    ));
+    let mode = i32::from_le_bytes(
+        bytes[MODE_PATH_OFFSET_OF_MODE..MODE_PATH_OFFSET_OF_FLAGS]
+            .try_into()
+            .ok()?,
+    );
+    let flags = i32::from_le_bytes(
+        bytes[MODE_PATH_OFFSET_OF_FLAGS..MODE_PATH_OFFSET_OF_PATH_LEN]
+            .try_into()
+            .ok()?,
+    );
+    let path_len = u16::from_le_bytes(
+        bytes[MODE_PATH_OFFSET_OF_PATH_LEN..MODE_PATH_HEADER_SIZE]
+            .try_into()
+            .ok()?,
+    ) as usize;
+    let path_end = MODE_PATH_HEADER_SIZE.checked_add(path_len)?;
+    if bytes.len() < path_end {
+        return None;
+    }
+    let path =
+        std::string::String::from_utf8(bytes[MODE_PATH_HEADER_SIZE..path_end].to_vec()).ok()?;
+    Some(LongModePathRequest {
+        op_id,
+        mode,
+        flags,
+        path,
+    })
+}
+
 //==================================================================================================
 // Serialization (vfsd, no_std + alloc)
 //==================================================================================================
@@ -928,6 +1013,23 @@ pub fn serialize_long_update_times_request(
     Some(buf)
 }
 
+/// Serializes a long chmod request.
+pub fn serialize_long_mode_path_request(
+    op_id: OperationId,
+    mode: i32,
+    flags: i32,
+    path: &[u8],
+) -> Option<Vec<u8>> {
+    let path_len: u16 = u16::try_from(path.len()).ok()?;
+    let mut buf: Vec<u8> = Vec::with_capacity(MODE_PATH_HEADER_SIZE + path.len());
+    buf.extend_from_slice(&op_id.to_le_bytes());
+    buf.extend_from_slice(&mode.to_le_bytes());
+    buf.extend_from_slice(&flags.to_le_bytes());
+    buf.extend_from_slice(&path_len.to_le_bytes());
+    buf.extend_from_slice(path);
+    Some(buf)
+}
+
 //==================================================================================================
 // Tests
 //==================================================================================================
@@ -956,6 +1058,20 @@ mod tests {
         assert_eq!(request.flags, 0x400);
         assert_eq!(request.old_path, "old/path");
         assert_eq!(request.new_path, "new/path");
+    }
+
+    #[test]
+    fn mode_path_request_round_trip() {
+        let bytes = serialize_long_mode_path_request(OperationId::new(9), 0o754, 2, b"dir/file")
+            .expect("mode/path request should serialize");
+        #[cfg(feature = "std")]
+        {
+            let request = deserialize_long_mode_path(&bytes).expect("request should deserialize");
+            assert_eq!(request.op_id(), OperationId::new(9));
+            assert_eq!(request.mode(), 0o754);
+            assert_eq!(request.flags(), 2);
+            assert_eq!(request.path(), "dir/file");
+        }
     }
 
     #[test]

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -375,6 +375,10 @@ pub enum SystemCallMessageKind {
     HostFsLinkRequestPart,
     /// Hard-link response from hostfs.
     HostFsLinkResponse,
+    HostFsChmodRequestPart,
+    HostFsChmodResponse,
+    HostFsFchmodRequest,
+    HostFsFchmodResponse,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageKind.
 impl TryFrom<u16> for SystemCallMessageKind {
@@ -574,6 +578,10 @@ impl TryFrom<u16> for SystemCallMessageKind {
             x if x == HostFsUpdateTimesAtResponse as u16 => Ok(HostFsUpdateTimesAtResponse),
             x if x == HostFsLinkRequestPart as u16 => Ok(HostFsLinkRequestPart),
             x if x == HostFsLinkResponse as u16 => Ok(HostFsLinkResponse),
+            x if x == HostFsChmodRequestPart as u16 => Ok(HostFsChmodRequestPart),
+            x if x == HostFsChmodResponse as u16 => Ok(HostFsChmodResponse),
+            x if x == HostFsFchmodRequest as u16 => Ok(HostFsFchmodRequest),
+            x if x == HostFsFchmodResponse as u16 => Ok(HostFsFchmodResponse),
             _ => Err(()),
         }
     }
@@ -638,6 +646,10 @@ impl SystemCallMessageKind {
                 | Self::HostFsChownResponse
                 | Self::HostFsLinkRequestPart
                 | Self::HostFsLinkResponse
+                | Self::HostFsChmodRequestPart
+                | Self::HostFsChmodResponse
+                | Self::HostFsFchmodRequest
+                | Self::HostFsFchmodResponse
         )
     }
 
@@ -684,6 +696,8 @@ impl SystemCallMessageKind {
             Self::HostFsUpdateTimesRequest => Some(Self::HostFsUpdateTimesResponse),
             Self::HostFsUpdateTimesAtRequestPart => Some(Self::HostFsUpdateTimesAtResponse),
             Self::HostFsLinkRequestPart => Some(Self::HostFsLinkResponse),
+            Self::HostFsChmodRequestPart => Some(Self::HostFsChmodResponse),
+            Self::HostFsFchmodRequest => Some(Self::HostFsFchmodResponse),
             _ => None,
         }
     }
@@ -720,6 +734,8 @@ impl SystemCallMessageKind {
                 | Self::HostFsUpdateTimesResponse
                 | Self::HostFsUpdateTimesAtResponse
                 | Self::HostFsLinkResponse
+                | Self::HostFsChmodResponse
+                | Self::HostFsFchmodResponse
         )
     }
 

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -162,6 +162,10 @@ int main(int argc, const char *argv[])
         test_chown();
         test_fchown();
         test_lchown();
+        test_chmod();    // requires open(), close(), stat() and unlinkat().
+        test_fchmodat(); // requires open(), close(), stat() and unlinkat().
+        test_fchmod();   // requires open(), close(), fstat() and unlink().
+        test_lchmod();   // requires open(), close(), stat(), link() and unlinkat().
         assert(fchdir(cwd) == 0);
         assert(close(cwd) == 0);
     }


### PR DESCRIPTION
Part of #3132.

### Summary

- Forward `chmod()`, `fchmodat()`, `lchmod()`, and `fchmod()` operations to hostfsd.
- Preserve path flags, including no-follow behavior for `lchmod()`.
- Return `EBADF` for invalid descriptors.
- Re-enable the existing hostfs permission-mutation tests without changing their behavior.

### Dependencies

Stacked on #3138 because the existing `lchmod()` test uses a hard link.

### Verification

- Workspace checks, formatting, linting, and spellcheck pass.
- Unit tests pass.
- The focused `test-c-file` POSIX test passes as part of the complete stack.
