### PR TITLE
[hostfsd] Forward Access Checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,7 @@ version = "0.24.14"
 dependencies = [
  "anyhow",
  "hostfs-api",
+ "libc",
  "log",
  "sys",
  "sysapi",

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -120,7 +120,7 @@ POSIX_TEST_FILES_test-c-file := \
 	fdatasync.c stat.c ftruncate.c truncate.c link.c linkat.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
 	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c \
 	utimensat.c utimes.c utime.c futimens.c chown.c fchown.c fchownat.c lchown.c \
-	chmod.c fchmodat.c fchmod.c lchmod.c
+	chmod.c fchmodat.c fchmod.c lchmod.c faccessat.c access.c
 
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's

--- a/src/daemons/hostfsd/Cargo.toml
+++ b/src/daemons/hostfsd/Cargo.toml
@@ -23,6 +23,9 @@ sysapi = { workspace = true, features = ["std"] }
 syscall = { workspace = true, default-features = false }
 syslog = { workspace = true, features = ["std"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 hostfs-api = { workspace = true, features = ["test-support"] }
 sysapi = { workspace = true, features = ["std"] }

--- a/src/daemons/hostfsd/src/handler.rs
+++ b/src/daemons/hostfsd/src/handler.rs
@@ -68,10 +68,18 @@ use std::{
 };
 
 #[cfg(unix)]
-use std::os::unix::fs::{
-    MetadataExt,
-    PermissionsExt,
+use std::{
+    ffi::CString,
+    os::unix::{
+        ffi::OsStrExt,
+        fs::{
+            MetadataExt,
+            PermissionsExt,
+        },
+        io::FromRawFd,
+    },
 };
+
 fn timestamp_to_system_time(seconds: i64, nanoseconds: i64) -> io::Result<SystemTime> {
     if !(0..1_000_000_000).contains(&nanoseconds) {
         return Err(io::Error::from(io::ErrorKind::InvalidInput));
@@ -110,29 +118,78 @@ fn file_times(times: &[::sysapi::time::timespec; 2]) -> io::Result<FileTimes> {
     Ok(result)
 }
 
-fn open_regular_file(
-    options: &OpenOptions,
-    host_path: &PathBuf,
-    create: bool,
-    exclusive: bool,
-) -> io::Result<(File, bool)> {
+fn open_regular_file(host_path: &PathBuf, mode: u32, flags: i32) -> io::Result<(File, bool)> {
+    let read_only: bool = (flags & O_ACCMODE) == O_RDONLY;
+    let write_only: bool = (flags & O_ACCMODE) == O_WRONLY;
+    let read_write: bool = (flags & O_ACCMODE) == O_RDWR;
+    let create: bool = (flags & O_CREAT) != 0;
+    let exclusive: bool = (flags & O_EXCL) != 0;
+    let truncate: bool = (flags & O_TRUNC) != 0;
+    let append: bool = (flags & O_APPEND) != 0;
+
+    let mut options: OpenOptions = OpenOptions::new();
+    options.read(read_only || read_write);
+    #[cfg(windows)]
+    if read_only {
+        use std::os::windows::fs::OpenOptionsExt;
+        const GENERIC_READ: u32 = 0x8000_0000;
+        const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
+        options.access_mode(GENERIC_READ | FILE_WRITE_ATTRIBUTES);
+    }
+    options.write(write_only || read_write);
+    options.create(create);
+    options.truncate(truncate);
+    // `append(true)` also grants write access.
+    options.append(append && (write_only || read_write));
+
     if !create {
         return options.open(host_path).map(|file| (file, false));
     }
 
-    let mut create_options: OpenOptions = options.clone();
-    create_options.create_new(true);
-
-    let mut existing_options: OpenOptions = options.clone();
-    existing_options.create(false);
-
     loop {
-        match create_options.open(host_path) {
+        let create_result: io::Result<File> = if read_only {
+            #[cfg(unix)]
+            {
+                let path: CString = CString::new(host_path.as_os_str().as_bytes())
+                    .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+                // SAFETY: `path` is NUL-terminated, and a successful call returns a new owned fd.
+                let fd: i32 = unsafe {
+                    libc::open(
+                        path.as_ptr(),
+                        libc::O_RDONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC,
+                        mode as libc::mode_t,
+                    )
+                };
+                if fd < 0 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    // SAFETY: `fd` was freshly returned by `open()` and ownership moves to `File`.
+                    Ok(unsafe { File::from_raw_fd(fd) })
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = mode;
+                let mut create_options: OpenOptions = options.clone();
+                create_options.create_new(true);
+                create_options.open(host_path)
+            }
+        } else {
+            let mut create_options: OpenOptions = options.clone();
+            create_options.create_new(true);
+            create_options.open(host_path)
+        };
+
+        match create_result {
             Ok(file) => return Ok((file, true)),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists && !exclusive => {
+                let mut existing_options: OpenOptions = options.clone();
+                existing_options.create(false);
                 match existing_options.open(host_path) {
                     Ok(file) => return Ok((file, false)),
-                    Err(error) if error.kind() == io::ErrorKind::NotFound => {},
+                    Err(error)
+                        if error.kind() == io::ErrorKind::NotFound
+                            && fs::symlink_metadata(host_path).is_err() => {},
                     Err(error) => return Err(error),
                 }
             },
@@ -251,7 +308,8 @@ impl HostFsHandler {
             | SystemCallMessageKind::HostFsPathStatRequestPart
             | SystemCallMessageKind::HostFsChownAtRequestPart
             | SystemCallMessageKind::HostFsUpdateTimesAtRequestPart
-            | SystemCallMessageKind::HostFsChmodRequestPart => self.handle_long_part(
+            | SystemCallMessageKind::HostFsChmodRequestPart
+            | SystemCallMessageKind::HostFsAccessRequestPart => self.handle_long_part(
                 syscall_msg.kind(),
                 OperationId::from_le_bytes(syscall_msg.request_id().raw().to_le_bytes()),
                 &syscall_msg.payload,
@@ -506,6 +564,14 @@ impl HostFsHandler {
                     set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
                 }
             },
+            SystemCallMessageKind::HostFsAccessRequestPart => {
+                if let Some(req) = long_msg::deserialize_long_mode_path(&assembled) {
+                    self.handle_long_access(req, &mut response);
+                } else {
+                    set_kind(&mut response, SystemCallMessageKind::HostFsAccessResponse as u16);
+                    set_payload_data(&mut response, &HOSTFS_ERR_INVALID.to_le_bytes());
+                }
+            },
             _ => {
                 log::error!("hostfsd: unexpected assembled header: {:?}", dispatch_header);
                 if let Some(resp_header) = dispatch_header.hostfs_response_kind() {
@@ -535,38 +601,8 @@ impl HostFsHandler {
         };
 
         let flags: i32 = req.flags;
-        let mut opts: OpenOptions = OpenOptions::new();
-
-        let rdonly: bool = (flags & O_ACCMODE) == O_RDONLY;
         let wronly: bool = (flags & O_ACCMODE) == O_WRONLY;
         let rdwr: bool = (flags & O_ACCMODE) == O_RDWR;
-        let o_creat: bool = (flags & O_CREAT) != 0;
-        let o_excl: bool = (flags & O_EXCL) != 0;
-        let o_trunc: bool = (flags & O_TRUNC) != 0;
-        let o_append: bool = (flags & O_APPEND) != 0;
-
-        if rdonly || rdwr {
-            opts.read(true);
-        }
-        #[cfg(windows)]
-        if rdonly {
-            use std::os::windows::fs::OpenOptionsExt;
-            const GENERIC_READ: u32 = 0x8000_0000;
-            const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
-            opts.access_mode(GENERIC_READ | FILE_WRITE_ATTRIBUTES);
-        }
-        if wronly || rdwr {
-            opts.write(true);
-        }
-        if o_creat {
-            opts.create(true);
-        }
-        if o_trunc {
-            opts.truncate(true);
-        }
-        if o_append && (wronly || rdwr) {
-            opts.append(true);
-        }
 
         let o_directory: bool = (flags & O_DIRECTORY) != 0;
 
@@ -599,7 +635,7 @@ impl HostFsHandler {
                 },
             }
         } else {
-            match open_regular_file(&opts, &host_path, o_creat, o_excl) {
+            match open_regular_file(&host_path, req.mode, flags) {
                 Ok(result) => result,
                 Err(e) => {
                     set_kind(response, SystemCallMessageKind::HostFsOpenResponse as u16);
@@ -1088,6 +1124,80 @@ impl HostFsHandler {
         set_payload_data(response, &status.to_le_bytes());
     }
 
+    /// Handles a fully assembled long ACCESS request.
+    fn handle_long_access(
+        &mut self,
+        req: long_msg::LongModePathRequest,
+        response: &mut [u8; Message::PAYLOAD_SIZE],
+    ) {
+        use ::sysapi::{
+            fcntl::atflags::{
+                AT_EACCESS,
+                AT_SYMLINK_NOFOLLOW,
+            },
+            sys_stat::file_mode::{
+                S_IRUSR,
+                S_IWUSR,
+                S_IXUSR,
+            },
+            unistd::access_mode::{
+                R_OK,
+                W_OK,
+                X_OK,
+            },
+        };
+
+        set_kind(response, SystemCallMessageKind::HostFsAccessResponse as u16);
+        let valid_modes: i32 = R_OK | W_OK | X_OK;
+        let valid_flags: i32 = AT_EACCESS | AT_SYMLINK_NOFOLLOW;
+        let mode: i32 = req.mode();
+        let flags: i32 = req.flags();
+        if mode & !valid_modes != 0 || flags & !valid_flags != 0 {
+            set_payload_data(response, &HOSTFS_ERR_INVALID.to_le_bytes());
+            return;
+        }
+
+        let no_follow: bool = flags & AT_SYMLINK_NOFOLLOW != 0;
+        let host_path: PathBuf = match if no_follow {
+            self.sandbox.resolve_nofollow(req.path())
+        } else {
+            self.sandbox.resolve(req.path())
+        } {
+            Some(path) => path,
+            None => {
+                set_payload_data(response, &HOSTFS_ERR_PERMISSION.to_le_bytes());
+                return;
+            },
+        };
+        let metadata = match if no_follow {
+            fs::symlink_metadata(&host_path)
+        } else {
+            fs::metadata(&host_path)
+        } {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                set_payload_data(response, &io_error_to_code(&error).to_le_bytes());
+                return;
+            },
+        };
+
+        #[cfg(unix)]
+        let owner_mode: u32 = metadata.permissions().mode();
+        #[cfg(not(unix))]
+        let owner_mode: u32 = S_IRUSR
+            | if metadata.permissions().readonly() {
+                0
+            } else {
+                S_IWUSR
+            }
+            | if metadata.is_dir() { S_IXUSR } else { 0 };
+        let denied: bool = (mode & R_OK != 0 && owner_mode & S_IRUSR == 0)
+            || (mode & W_OK != 0 && owner_mode & S_IWUSR == 0)
+            || (mode & X_OK != 0 && owner_mode & S_IXUSR == 0);
+        let status: i32 = if denied { HOSTFS_ERR_PERMISSION } else { 0 };
+        set_payload_data(response, &status.to_le_bytes());
+    }
+
     /// Handles an inline single-message READLINK request.
     fn handle_readlink(
         &mut self,
@@ -1516,43 +1626,9 @@ impl HostFsHandler {
             },
         };
 
-        // Translate POSIX flags to Rust OpenOptions.
         let flags: i32 = req.flags;
-        let mut opts: OpenOptions = OpenOptions::new();
-
-        let rdonly: bool = (flags & O_ACCMODE) == O_RDONLY;
         let wronly: bool = (flags & O_ACCMODE) == O_WRONLY;
         let rdwr: bool = (flags & O_ACCMODE) == O_RDWR;
-        let o_creat: bool = (flags & O_CREAT) != 0;
-        let o_excl: bool = (flags & O_EXCL) != 0;
-        let o_trunc: bool = (flags & O_TRUNC) != 0;
-        let o_append: bool = (flags & O_APPEND) != 0;
-
-        if rdonly || rdwr {
-            opts.read(true);
-        }
-        #[cfg(windows)]
-        if rdonly {
-            use std::os::windows::fs::OpenOptionsExt;
-            const GENERIC_READ: u32 = 0x8000_0000;
-            const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
-            opts.access_mode(GENERIC_READ | FILE_WRITE_ATTRIBUTES);
-        }
-        if wronly || rdwr {
-            opts.write(true);
-        }
-        if o_creat {
-            opts.create(true);
-        }
-        if o_trunc {
-            opts.truncate(true);
-        }
-        // Only set append when the access mode includes write. Rust's
-        // `OpenOptions::append(true)` implicitly enables write access, so setting it
-        // on a read-only open would incorrectly grant write permissions.
-        if o_append && (wronly || rdwr) {
-            opts.append(true);
-        }
 
         // Check if this is a directory open.
         let o_directory: bool = (flags & O_DIRECTORY) != 0;
@@ -1598,7 +1674,7 @@ impl HostFsHandler {
                 },
             }
         } else {
-            match open_regular_file(&opts, &host_path, o_creat, o_excl) {
+            match open_regular_file(&host_path, req.mode, flags) {
                 Ok(result) => result,
                 Err(e) => {
                     log::debug!(

--- a/src/daemons/hostfsd/tests/handler_test.rs
+++ b/src/daemons/hostfsd/tests/handler_test.rs
@@ -248,6 +248,52 @@ fn test_open_nonexistent_file_fails() {
 }
 
 #[test]
+fn test_open_create_read_only_retains_read_only_handle() {
+    let (mut handler, _tmp) = setup();
+    let payload: [u8; Message::PAYLOAD_SIZE] =
+        make_open_request("read-only-create.txt", O_RDONLY | O_CREAT, 0);
+    let response: [u8; Message::PAYLOAD_SIZE] = handler
+        .handle_request(&payload)
+        .expect("open should return a response");
+    let fd: i32 = OpenResponse::decode(&response).fd;
+    assert!(fd > 0, "O_CREAT | O_RDONLY should create the file");
+
+    let write_response: [u8; Message::PAYLOAD_SIZE] = handler
+        .handle_request(&make_write_request(fd, b"x", -1))
+        .expect("write should return a response");
+    assert!(
+        WriteResponse::decode(&write_response).bytes_written < 0,
+        "created read-only descriptor must not be writable"
+    );
+
+    let read_response: [u8; Message::PAYLOAD_SIZE] = handler
+        .handle_request(&make_read_request(fd, 1, -1))
+        .expect("read should return a response");
+    assert_eq!(ReadResponse::decode(&read_response).bytes_read, 0);
+
+    #[cfg(unix)]
+    assert_eq!(
+        fs::metadata(_tmp.path().join("read-only-create.txt"))
+            .expect("created file should have metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_open_create_read_only_dangling_symlink_fails() {
+    let (mut handler, tmp) = setup();
+    std::os::unix::fs::symlink("missing.txt", tmp.path().join("dangling.txt"))
+        .expect("symlink creation should succeed");
+
+    let fd: i32 = open_file(&mut handler, "dangling.txt", O_RDONLY | O_CREAT);
+    assert!(fd < 0, "opening a dangling symlink should fail");
+}
+
+#[test]
 fn test_open_create_flag() {
     let (mut handler, tmp) = setup();
 
@@ -1281,6 +1327,59 @@ fn test_chmod_and_fchmod() {
         HOSTFS_ERR_NOT_SUPPORTED
     );
     assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o640);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_access_uses_owner_permission_bits() {
+    use sysapi::unistd::access_mode::{
+        R_OK,
+        W_OK,
+    };
+
+    let (mut handler, tmp) = setup();
+    let path: PathBuf = tmp.path().join("mode.txt");
+    fs::write(&path, b"data").expect("test file creation should succeed");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400))
+        .expect("setting test permissions should succeed");
+
+    let read_access = make_long_mode_path_parts(
+        SystemCallMessageKind::HostFsAccessRequestPart,
+        "mode.txt",
+        R_OK,
+        0,
+        OperationId::from_raw(102),
+    );
+    assert_eq!(response_status(&run_long_request(&mut handler, &read_access)), 0);
+    let write_access = make_long_mode_path_parts(
+        SystemCallMessageKind::HostFsAccessRequestPart,
+        "mode.txt",
+        W_OK,
+        0,
+        OperationId::from_raw(103),
+    );
+    assert_eq!(
+        response_status(&run_long_request(&mut handler, &write_access)),
+        HOSTFS_ERR_PERMISSION
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_access_rejects_unknown_mode_and_flags() {
+    let (mut handler, tmp) = setup();
+    fs::write(tmp.path().join("access.txt"), b"data").unwrap();
+
+    for (op_id, mode, flags) in [(107, 8, 0), (108, 0, 4)] {
+        let request = make_long_mode_path_parts(
+            SystemCallMessageKind::HostFsAccessRequestPart,
+            "access.txt",
+            mode,
+            flags,
+            OperationId::from_raw(op_id),
+        );
+        assert_eq!(response_status(&run_long_request(&mut handler, &request)), HOSTFS_ERR_INVALID);
+    }
 }
 
 #[test]

--- a/src/daemons/vfsd/src/assembler.rs
+++ b/src/daemons/vfsd/src/assembler.rs
@@ -337,7 +337,8 @@ fn dispatch_assembled_request(
         },
         SystemCallMessageKind::FileAccessAtRequestPart => {
             match FileAccessAtRequest::from_parts(parts) {
-                Ok(req) => handler::handle_faccessat(source, req),
+                Ok(req) => handler::handle_faccessat_with_hostfs(response_context, req, pending)
+                    .unwrap_or_default(),
                 Err(e) => {
                     ::syslog::error!("dispatch: faccessat from_parts failed (error={:?})", e);
                     vec![build_error(source, ErrorCode::InvalidMessage)]

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -1212,6 +1212,56 @@ pub(crate) fn handle_fchmodat_with_hostfs(
     Some(super::long::handle_fchmodat(source, request))
 }
 
+pub(crate) fn handle_faccessat_with_hostfs(
+    response_context: ResponseContext,
+    request: ::syscall::unistd::message::FileAccessAtRequest,
+    pending: &mut PendingQueue,
+) -> Option<Vec<Message>> {
+    let source_pid: ProcessIdentifier = response_context.source_pid();
+    let source: ThreadIdentifier = response_context.source_tid();
+    let resolved = match vfs_resolve_path(request.dirfd, &request.path) {
+        Ok(path) => path,
+        Err(error) => return Some(vec![build_error(source, fat32_to_error_code(&error))]),
+    };
+
+    if hostfs::is_hostfs_path(resolved.as_str()) {
+        const VALID_MODES: i32 = ::sysapi::unistd::access_mode::R_OK
+            | ::sysapi::unistd::access_mode::W_OK
+            | ::sysapi::unistd::access_mode::X_OK;
+        const VALID_FLAGS: i32 =
+            ::sysapi::fcntl::atflags::AT_EACCESS | ::sysapi::fcntl::atflags::AT_SYMLINK_NOFOLLOW;
+        if request.mode & !VALID_MODES != 0 || request.flag & !VALID_FLAGS != 0 {
+            return Some(vec![build_error(source, ErrorCode::InvalidArgument)]);
+        }
+        if !pending.has_capacity() {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        let op_id: ::hostfs_api::OperationId = pending.alloc_op_id();
+        if let Err(error) =
+            hostfs::send_access_request(&resolved, request.mode, request.flag, op_id)
+        {
+            return Some(vec![build_error(source, error)]);
+        }
+        if pending
+            .insert(
+                op_id,
+                PendingOp {
+                    response_context,
+                    source_tid: source,
+                    source_pid,
+                    kind: PendingOpKind::Access,
+                },
+            )
+            .is_err()
+        {
+            return Some(vec![build_error(source, ErrorCode::ResourceBusy)]);
+        }
+        return None;
+    }
+
+    Some(super::long::handle_faccessat(source, request))
+}
+
 pub(crate) fn handle_symlinkat_with_hostfs(
     response_context: ResponseContext,
     request: SymbolicLinkAtRequest,

--- a/src/daemons/vfsd/src/hostfs.rs
+++ b/src/daemons/vfsd/src/hostfs.rs
@@ -422,6 +422,21 @@ pub fn send_chmod_request(
     send_long_request(&buf, SystemCallMessageKind::HostFsChmodRequestPart, op_id)
 }
 
+/// Sends an ACCESS request to hostfsd.
+pub fn send_access_request(
+    path: &ResolvedPath,
+    mode: i32,
+    flags: i32,
+    op_id: OperationId,
+) -> Result<(), ::sys::error::ErrorCode> {
+    let relative: &str = strip_mount_prefix(path.as_str());
+    let buf: alloc::vec::Vec<u8> =
+        long_msg::serialize_long_mode_path_request(op_id, mode, flags, relative.as_bytes())
+            .ok_or(::sys::error::ErrorCode::InvalidArgument)?;
+
+    send_long_request(&buf, SystemCallMessageKind::HostFsAccessRequestPart, op_id)
+}
+
 /// Sends a STAT request to hostfsd (by remote FD).
 pub fn send_stat_request(
     remote_fd: i32,

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -98,6 +98,8 @@ pub(crate) enum PendingOpKind {
     Chmod,
     /// fchmod — response is a status code.
     Fchmod,
+    /// access — response is a status code.
+    Access,
     /// mkdir — response is a status code.
     Mkdir,
     /// rmdir — response is a status code.
@@ -561,6 +563,9 @@ pub(crate) fn complete_pending_op(
         PendingOpKind::Fchmod => {
             complete_status(response_context, response_payload, OpGroup::Fchmod)
         },
+        PendingOpKind::Access => {
+            complete_status(response_context, response_payload, OpGroup::Access)
+        },
         PendingOpKind::Mkdir => complete_status(response_context, response_payload, OpGroup::Mkdir),
         PendingOpKind::Rmdir => complete_status(response_context, response_payload, OpGroup::Rmdir),
         PendingOpKind::Unlink => {
@@ -1007,6 +1012,7 @@ fn validate_response_header(kind: &PendingOpKind, payload: &[u8; Message::PAYLOA
             | (PendingOpKind::UpdateTimesAt, SystemCallMessageKind::HostFsUpdateTimesAtResponse,)
             | (PendingOpKind::Chmod, SystemCallMessageKind::HostFsChmodResponse)
             | (PendingOpKind::Fchmod, SystemCallMessageKind::HostFsFchmodResponse)
+            | (PendingOpKind::Access, SystemCallMessageKind::HostFsAccessResponse)
             | (PendingOpKind::Mkdir, SystemCallMessageKind::HostFsMkdirResponse)
             | (PendingOpKind::Rmdir, SystemCallMessageKind::HostFsRmdirResponse)
             | (PendingOpKind::Unlink, SystemCallMessageKind::HostFsUnlinkResponse)
@@ -1165,6 +1171,7 @@ enum OpGroup {
     UpdateTimesAt,
     Chmod,
     Fchmod,
+    Access,
     Mkdir,
     Rmdir,
     Unlink,
@@ -1221,6 +1228,10 @@ fn complete_status(
         OpGroup::Fchmod => {
             use ::syscall::sys::stat::message::FileChmodResponse;
             FileChmodResponse::build(source_tid, ProcessIdentifier::VFSD, MessageType::Ipc)
+        },
+        OpGroup::Access => {
+            use ::syscall::unistd::message::FileAccessAtResponse;
+            FileAccessAtResponse::build(source_tid, ProcessIdentifier::VFSD, MessageType::Ipc)
         },
         OpGroup::Mkdir => {
             use ::syscall::sys::stat::message::MakeDirectoryAtResponse;

--- a/src/libs/hostfs-api/src/long_msg.rs
+++ b/src/libs/hostfs-api/src/long_msg.rs
@@ -28,7 +28,7 @@
 //! - **Lstat**: `[op_id:4][path_len:2][path:N]`
 //! - **ChownAt**: `[op_id:4][owner:4][group:4][flags:4][path_len:2][path:N]`
 //! - **Update times**: `[op_id:4][flags:4][times:32][path_len:2][path:N]`
-//! - **Chmod**: `[op_id:4][mode:4][flags:4][path_len:2][path:N]`
+//! - **Mode/path**: `[op_id:4][mode:4][flags:4][path_len:2][path:N]`
 //!
 //! # Long Response Format
 //!
@@ -782,7 +782,7 @@ impl LongModePathRequest {
     }
 }
 
-/// Deserializes a long chmod request.
+/// Deserializes a long mode/path request.
 #[cfg(feature = "std")]
 pub fn deserialize_long_mode_path(bytes: &[u8]) -> Option<LongModePathRequest> {
     if bytes.len() < MODE_PATH_HEADER_SIZE {
@@ -1013,7 +1013,7 @@ pub fn serialize_long_update_times_request(
     Some(buf)
 }
 
-/// Serializes a long chmod request.
+/// Serializes a long mode/path request.
 pub fn serialize_long_mode_path_request(
     op_id: OperationId,
     mode: i32,

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -379,6 +379,8 @@ pub enum SystemCallMessageKind {
     HostFsChmodResponse,
     HostFsFchmodRequest,
     HostFsFchmodResponse,
+    HostFsAccessRequestPart,
+    HostFsAccessResponse,
 }
 // Manual TryFrom<u16> implementation for SystemCallMessageKind.
 impl TryFrom<u16> for SystemCallMessageKind {
@@ -582,6 +584,8 @@ impl TryFrom<u16> for SystemCallMessageKind {
             x if x == HostFsChmodResponse as u16 => Ok(HostFsChmodResponse),
             x if x == HostFsFchmodRequest as u16 => Ok(HostFsFchmodRequest),
             x if x == HostFsFchmodResponse as u16 => Ok(HostFsFchmodResponse),
+            x if x == HostFsAccessRequestPart as u16 => Ok(HostFsAccessRequestPart),
+            x if x == HostFsAccessResponse as u16 => Ok(HostFsAccessResponse),
             _ => Err(()),
         }
     }
@@ -650,6 +654,8 @@ impl SystemCallMessageKind {
                 | Self::HostFsChmodResponse
                 | Self::HostFsFchmodRequest
                 | Self::HostFsFchmodResponse
+                | Self::HostFsAccessRequestPart
+                | Self::HostFsAccessResponse
         )
     }
 
@@ -698,6 +704,7 @@ impl SystemCallMessageKind {
             Self::HostFsLinkRequestPart => Some(Self::HostFsLinkResponse),
             Self::HostFsChmodRequestPart => Some(Self::HostFsChmodResponse),
             Self::HostFsFchmodRequest => Some(Self::HostFsFchmodResponse),
+            Self::HostFsAccessRequestPart => Some(Self::HostFsAccessResponse),
             _ => None,
         }
     }
@@ -736,6 +743,7 @@ impl SystemCallMessageKind {
                 | Self::HostFsLinkResponse
                 | Self::HostFsChmodResponse
                 | Self::HostFsFchmodResponse
+                | Self::HostFsAccessResponse
         )
     }
 

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -10,6 +10,7 @@
 #include "common.h"
 #include <assert.h>
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -166,8 +167,11 @@ int main(int argc, const char *argv[])
         test_fchmodat(); // requires open(), close(), stat() and unlinkat().
         test_fchmod();   // requires open(), close(), fstat() and unlink().
         test_lchmod();   // requires open(), close(), stat(), link() and unlinkat().
+        test_faccessat(); // requires open(), close() and unlinkat().
+        test_access();    // requires open(), close() and unlink().
         assert(fchdir(cwd) == 0);
         assert(close(cwd) == 0);
+        errno = 0;
     }
 
     test_poll_hostfs(); // requires test_umask() to mount hostfs.


### PR DESCRIPTION
Closes #3132.

### Summary

- Forward `access()` and `faccessat()` operations to hostfsd.
- Evaluate requested access using guest-visible owner permission bits.
- Preserve and validate `AT_EACCESS` and `AT_SYMLINK_NOFOLLOW`.
- Support `O_CREAT | O_RDONLY` on Unix while retaining a read-only descriptor.
- Re-enable the existing hostfs access tests.

### Dependencies

Stacked on the permission-mutation PR because the existing access tests use `chmod()` and `fchmodat()` to prepare their permission states.

### Verification

- Workspace checks, formatting, linting, and spellcheck pass.
- Unit tests pass.
- The focused `test-c-file` POSIX test passes.
