### PR TITLE
[build] Quote Recursive Make Path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ endif
 export MAKE_NO_PRINT ?= yes
 
 # Make command for recursive invocations (adds --no-print-directory if MAKE_NO_PRINT=yes)
-export MAKE_QUIET := $(MAKE) $(if $(filter yes,$(MAKE_NO_PRINT)),--no-print-directory)
+export MAKE_QUIET := "$(MAKE)" $(if $(filter yes,$(MAKE_NO_PRINT)),--no-print-directory)
 
 #===================================================================================================
 # Directories


### PR DESCRIPTION
## Summary

Quote the recursive Make executable so native Windows builds support installation paths containing spaces.

## Testing

- Verified the full Windows lifecycle, including build and tests.
- Passed pre-commit checks.