### PR TITLE
[vfs] F: Add devfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4473,6 +4473,7 @@ dependencies = [
 name = "vfs"
 version = "0.24.15"
 dependencies = [
+ "arch",
  "config",
  "error",
  "fat32",

--- a/src/libs/vfs/Cargo.toml
+++ b/src/libs/vfs/Cargo.toml
@@ -14,6 +14,7 @@ homepage.workspace = true
 crate-type = ["lib"]
 
 [dependencies]
+arch = { workspace = true }
 config = { workspace = true }
 error = { workspace = true }
 fat32 = { workspace = true }

--- a/src/libs/vfs/src/devfs.rs
+++ b/src/libs/vfs/src/devfs.rs
@@ -7,25 +7,67 @@
 // Imports
 //==================================================================================================
 
-use crate::mount::{
-    anchor_path,
-    normalize_anchored,
+use crate::{
+    filesystem::{
+        DirEntry,
+        Stat,
+    },
+    mount::{
+        anchor_path,
+        normalize_anchored,
+    },
 };
 use ::alloc::{
     string::String,
     vec::Vec,
 };
-use ::fat32::Fat32Error;
+use ::fat32::{
+    Fat32Error,
+    FAT_EPOCH_SECS,
+};
+use ::sys::pm::{
+    GroupIdentifier,
+    UserIdentifier,
+};
+use ::sysapi::{
+    sys_stat::{
+        file_mode,
+        file_type,
+        stat as PosixStat,
+    },
+    sys_types::{
+        gid_t,
+        uid_t,
+    },
+    time::timespec,
+};
 
 //==================================================================================================
 // Constants
 //==================================================================================================
 
-/// Synthetic device identifier for the device namespace.
+/// Synthetic device identifier for devfs.
+///
+/// IDs 1 through 3 identify the VFS file namespace, pipefs, and console.
 const DEVICE_NAMESPACE_ID: u64 = 4;
 
+/// Name of the devfs root directory.
+const DIRECTORY_NAME: &str = "dev";
+/// Absolute path of the devfs root directory.
+const DIRECTORY_PATH: &str = "/dev";
+/// Absolute prefix for devfs entries.
+const DIRECTORY_PREFIX: &str = "/dev/";
+
 /// Stable inode identifier for `/dev`.
-pub(crate) const DIRECTORY_INODE: u64 = 1;
+///
+/// Inode zero is reserved, so `/dev` uses the first available identifier.
+const DIRECTORY_INODE: u64 = 1;
+
+/// Preferred I/O block size reported for devfs entries.
+const STAT_BLOCK_SIZE: i64 = ::arch::mem::PAGE_SIZE as i64;
+
+/// Stable timestamp used until VFS defines backend-neutral synthetic timestamps.
+const STAT_TIMESTAMP_SECS: i64 = FAT_EPOCH_SECS;
 
 //==================================================================================================
 // Structures
@@ -33,7 +75,7 @@ pub(crate) const DIRECTORY_INODE: u64 = 1;
 
 /// Metadata for a synthetic device-namespace entry.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct DeviceMetadata {
+struct DeviceMetadata {
     /// Synthetic device identifier.
     device: u64,
     /// Stable inode identifier.
@@ -59,26 +101,9 @@ pub(crate) enum DevicePath {
 // Implementations
 //==================================================================================================
 
-impl DeviceMetadata {
-    /// Returns the synthetic device identifier.
-    pub(crate) fn device(&self) -> u64 {
-        self.device
-    }
-
-    /// Returns the stable inode identifier.
-    pub(crate) fn inode(&self) -> u64 {
-        self.inode
-    }
-
-    /// Returns whether this entry is a directory.
-    pub(crate) fn is_directory(&self) -> bool {
-        self.is_directory
-    }
-}
-
 impl DevicePath {
     /// Returns metadata for an existing namespace entry.
-    pub(crate) fn metadata(self) -> Option<DeviceMetadata> {
+    fn metadata(self) -> Option<DeviceMetadata> {
         match self {
             DevicePath::Directory => Some(DeviceMetadata {
                 device: DEVICE_NAMESPACE_ID,
@@ -95,7 +120,7 @@ impl DevicePath {
 //==================================================================================================
 
 /// Resolves a path in the synthetic device namespace.
-pub(crate) fn resolve(path: &str, cwd: &str) -> Result<Option<DevicePath>, Fat32Error> {
+pub(crate) fn resolve(cwd: &str, path: &str) -> Result<Option<DevicePath>, Fat32Error> {
     let anchored: String = anchor_path(path, cwd)?;
     validate_components(&anchored)?;
     let normalized: String = normalize_anchored(&anchored);
@@ -103,7 +128,7 @@ pub(crate) fn resolve(path: &str, cwd: &str) -> Result<Option<DevicePath>, Fat32
 }
 
 /// Returns whether routing for a path belongs to the synthetic device namespace.
-pub(crate) fn owns(path: &str, cwd: &str) -> Result<bool, Fat32Error> {
+pub(crate) fn owns(cwd: &str, path: &str) -> Result<bool, Fat32Error> {
     let anchored: String = anchor_path(path, cwd)?;
     if validate_components(&anchored).is_err() {
         return Ok(true);
@@ -113,7 +138,7 @@ pub(crate) fn owns(path: &str, cwd: &str) -> Result<bool, Fat32Error> {
 }
 
 /// Resolves metadata for an existing device-namespace path.
-pub(crate) fn metadata(path: &str, cwd: &str) -> Result<Option<DeviceMetadata>, Fat32Error> {
+fn metadata(cwd: &str, path: &str) -> Result<Option<DeviceMetadata>, Fat32Error> {
     let anchored: String = anchor_path(path, cwd)?;
     validate_components(&anchored)?;
     let normalized: String = normalize_anchored(&anchored);
@@ -123,11 +148,65 @@ pub(crate) fn metadata(path: &str, cwd: &str) -> Result<Option<DeviceMetadata>, 
     Ok(Some(device_path.metadata().ok_or(Fat32Error::NotFound)?))
 }
 
+/// Synthesizes backend-neutral metadata for an existing devfs path.
+pub(crate) fn stat(cwd: &str, path: &str) -> Result<Option<Stat>, Fat32Error> {
+    let Some(metadata) = metadata(cwd, path)? else {
+        return Ok(None);
+    };
+    Ok(Some(Stat::new(
+        0,
+        metadata.is_directory,
+        STAT_TIMESTAMP_SECS,
+        STAT_TIMESTAMP_SECS,
+        STAT_TIMESTAMP_SECS,
+    )))
+}
+
+/// Synthesizes POSIX metadata for an existing devfs path.
+pub(crate) fn posix_stat(cwd: &str, path: &str) -> Result<Option<PosixStat>, Fat32Error> {
+    let Some(metadata) = metadata(cwd, path)? else {
+        return Ok(None);
+    };
+    let timestamp: timespec = timespec {
+        tv_sec: STAT_TIMESTAMP_SECS,
+        tv_nsec: 0,
+    };
+    Ok(Some(PosixStat {
+        st_dev: metadata.device,
+        st_ino: metadata.inode,
+        st_mode: file_type::S_IFDIR | file_mode::S_IRWXU,
+        st_nlink: if metadata.is_directory { 2 } else { 1 },
+        st_uid: UserIdentifier::ROOT.as_usize() as uid_t,
+        st_gid: GroupIdentifier::ROOT.as_usize() as gid_t,
+        st_rdev: 0,
+        st_size: 0,
+        st_blksize: STAT_BLOCK_SIZE,
+        st_blocks: 0,
+        st_atim: timestamp,
+        st_mtim: timestamp,
+        st_ctim: timestamp,
+    }))
+}
+
+/// Returns the `/dev` entry injected into the VFS root directory.
+pub(crate) fn directory_entry() -> DirEntry {
+    DirEntry::new(String::from(DIRECTORY_NAME), DIRECTORY_INODE, true, 0)
+}
+
+/// Reads a directory owned by devfs.
+pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Option<Vec<DirEntry>>, Fat32Error> {
+    match resolve(cwd, path)? {
+        Some(DevicePath::Directory) => Ok(Some(Vec::new())),
+        Some(DevicePath::Missing) => Err(Fat32Error::NotFound),
+        None => Ok(None),
+    }
+}
+
 /// Rejects traversal through an unknown namespace entry.
 fn validate_components(path: &str) -> Result<(), Fat32Error> {
     let mut components: Vec<&str> = Vec::new();
     for component in path.split('/').filter(|component| !component.is_empty()) {
-        if components.len() >= 2 && components[0] == "dev" {
+        if components.len() >= 2 && components[0] == DIRECTORY_NAME {
             return Err(Fat32Error::NotFound);
         }
         match component {
@@ -144,8 +223,8 @@ fn validate_components(path: &str) -> Result<(), Fat32Error> {
 /// Classifies a normalized, absolute path.
 fn resolve_normalized(path: &str) -> Option<DevicePath> {
     match path {
-        "/dev" => Some(DevicePath::Directory),
-        path if path.starts_with("/dev/") => Some(DevicePath::Missing),
+        DIRECTORY_PATH => Some(DevicePath::Directory),
+        path if path.starts_with(DIRECTORY_PREFIX) => Some(DevicePath::Missing),
         _ => None,
     }
 }
@@ -160,28 +239,49 @@ mod tests {
 
     #[test]
     fn resolves_namespace_paths() {
-        assert_eq!(resolve("/dev", "/"), Ok(Some(DevicePath::Directory)));
-        assert_eq!(resolve("/dev/unknown", "/"), Ok(Some(DevicePath::Missing)));
-        assert_eq!(resolve("/dev/unknown/child", "/"), Err(Fat32Error::NotFound));
+        assert_eq!(resolve("/", "/dev"), Ok(Some(DevicePath::Directory)));
+        assert_eq!(resolve("/", "/dev/unknown"), Ok(Some(DevicePath::Missing)));
+        assert_eq!(resolve("/", "/dev/unknown/child"), Err(Fat32Error::NotFound));
+    }
+
+    #[test]
+    fn synthesizes_stat() {
+        let stat: Stat = stat("/", "/dev").expect("valid path").expect("existing path");
+        assert_eq!(
+            stat,
+            Stat::new(
+                0,
+                true,
+                STAT_TIMESTAMP_SECS,
+                STAT_TIMESTAMP_SECS,
+                STAT_TIMESTAMP_SECS,
+            )
+        );
+
+        let stat: PosixStat =
+            posix_stat("/", "/dev").expect("valid path").expect("existing path");
+        assert_eq!(stat.st_dev, DEVICE_NAMESPACE_ID);
+        assert_eq!(stat.st_ino, DIRECTORY_INODE);
+        assert_eq!(stat.st_blksize, ::arch::mem::PAGE_SIZE as i64);
     }
 
     #[test]
     fn routing_ownership_is_distinct_from_validity() {
-        assert!(owns("/dev/unknown/child", "/").expect("valid path"));
-        assert!(!owns("/dev/../tmp", "/").expect("valid path"));
+        assert!(owns("/", "/dev/unknown/child").expect("valid path"));
+        assert!(!owns("/", "/dev/../tmp").expect("valid path"));
     }
 
     #[test]
     fn normalizes_paths_before_resolving() {
-        assert_eq!(resolve("/dev/", "/"), Ok(Some(DevicePath::Directory)));
-        assert_eq!(resolve("dev", "/"), Ok(Some(DevicePath::Directory)));
-        assert_eq!(resolve("/dev/../tmp", "/"), Ok(None));
+        assert_eq!(resolve("/", "/dev/"), Ok(Some(DevicePath::Directory)));
+        assert_eq!(resolve("/", "dev"), Ok(Some(DevicePath::Directory)));
+        assert_eq!(resolve("/", "/dev/../tmp"), Ok(None));
     }
 
     #[test]
     fn ignores_similar_prefixes() {
         assert_eq!(resolve("/", "/"), Ok(None));
-        assert_eq!(resolve("/device", "/"), Ok(None));
-        assert_eq!(resolve("/devil/null", "/"), Ok(None));
+        assert_eq!(resolve("/", "/device"), Ok(None));
+        assert_eq!(resolve("/", "/devil/null"), Ok(None));
     }
 }

--- a/src/libs/vfs/src/devfs.rs
+++ b/src/libs/vfs/src/devfs.rs
@@ -1,0 +1,187 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Synthetic `/dev` namespace.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::mount::{
+    anchor_path,
+    normalize_anchored,
+};
+use ::alloc::{
+    string::String,
+    vec::Vec,
+};
+use ::fat32::Fat32Error;
+
+//==================================================================================================
+// Constants
+//==================================================================================================
+
+/// Synthetic device identifier for the device namespace.
+const DEVICE_NAMESPACE_ID: u64 = 4;
+
+/// Stable inode identifier for `/dev`.
+pub(crate) const DIRECTORY_INODE: u64 = 1;
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// Metadata for a synthetic device-namespace entry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DeviceMetadata {
+    /// Synthetic device identifier.
+    device: u64,
+    /// Stable inode identifier.
+    inode: u64,
+    /// Whether this entry is a directory.
+    is_directory: bool,
+}
+
+//==================================================================================================
+// Enumerations
+//==================================================================================================
+
+/// A path resolved within the synthetic device namespace.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DevicePath {
+    /// The synthetic `/dev` directory.
+    Directory,
+    /// An unknown entry below `/dev`.
+    Missing,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl DeviceMetadata {
+    /// Returns the synthetic device identifier.
+    pub(crate) fn device(&self) -> u64 {
+        self.device
+    }
+
+    /// Returns the stable inode identifier.
+    pub(crate) fn inode(&self) -> u64 {
+        self.inode
+    }
+
+    /// Returns whether this entry is a directory.
+    pub(crate) fn is_directory(&self) -> bool {
+        self.is_directory
+    }
+}
+
+impl DevicePath {
+    /// Returns metadata for an existing namespace entry.
+    pub(crate) fn metadata(self) -> Option<DeviceMetadata> {
+        match self {
+            DevicePath::Directory => Some(DeviceMetadata {
+                device: DEVICE_NAMESPACE_ID,
+                inode: DIRECTORY_INODE,
+                is_directory: true,
+            }),
+            DevicePath::Missing => None,
+        }
+    }
+}
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+/// Resolves a path in the synthetic device namespace.
+pub(crate) fn resolve(path: &str, cwd: &str) -> Result<Option<DevicePath>, Fat32Error> {
+    let anchored: String = anchor_path(path, cwd)?;
+    validate_components(&anchored)?;
+    let normalized: String = normalize_anchored(&anchored);
+    Ok(resolve_normalized(&normalized))
+}
+
+/// Returns whether routing for a path belongs to the synthetic device namespace.
+pub(crate) fn owns(path: &str, cwd: &str) -> Result<bool, Fat32Error> {
+    let anchored: String = anchor_path(path, cwd)?;
+    if validate_components(&anchored).is_err() {
+        return Ok(true);
+    }
+    let normalized: String = normalize_anchored(&anchored);
+    Ok(resolve_normalized(&normalized).is_some())
+}
+
+/// Resolves metadata for an existing device-namespace path.
+pub(crate) fn metadata(path: &str, cwd: &str) -> Result<Option<DeviceMetadata>, Fat32Error> {
+    let anchored: String = anchor_path(path, cwd)?;
+    validate_components(&anchored)?;
+    let normalized: String = normalize_anchored(&anchored);
+    let Some(device_path) = resolve_normalized(&normalized) else {
+        return Ok(None);
+    };
+    Ok(Some(device_path.metadata().ok_or(Fat32Error::NotFound)?))
+}
+
+/// Rejects traversal through an unknown namespace entry.
+fn validate_components(path: &str) -> Result<(), Fat32Error> {
+    let mut components: Vec<&str> = Vec::new();
+    for component in path.split('/').filter(|component| !component.is_empty()) {
+        if components.len() >= 2 && components[0] == "dev" {
+            return Err(Fat32Error::NotFound);
+        }
+        match component {
+            "." => {},
+            ".." => {
+                components.pop();
+            },
+            component => components.push(component),
+        }
+    }
+    Ok(())
+}
+
+/// Classifies a normalized, absolute path.
+fn resolve_normalized(path: &str) -> Option<DevicePath> {
+    match path {
+        "/dev" => Some(DevicePath::Directory),
+        path if path.starts_with("/dev/") => Some(DevicePath::Missing),
+        _ => None,
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_namespace_paths() {
+        assert_eq!(resolve("/dev", "/"), Ok(Some(DevicePath::Directory)));
+        assert_eq!(resolve("/dev/unknown", "/"), Ok(Some(DevicePath::Missing)));
+        assert_eq!(resolve("/dev/unknown/child", "/"), Err(Fat32Error::NotFound));
+    }
+
+    #[test]
+    fn routing_ownership_is_distinct_from_validity() {
+        assert!(owns("/dev/unknown/child", "/").expect("valid path"));
+        assert!(!owns("/dev/../tmp", "/").expect("valid path"));
+    }
+
+    #[test]
+    fn normalizes_paths_before_resolving() {
+        assert_eq!(resolve("/dev/", "/"), Ok(Some(DevicePath::Directory)));
+        assert_eq!(resolve("dev", "/"), Ok(Some(DevicePath::Directory)));
+        assert_eq!(resolve("/dev/../tmp", "/"), Ok(None));
+    }
+
+    #[test]
+    fn ignores_similar_prefixes() {
+        assert_eq!(resolve("/", "/"), Ok(None));
+        assert_eq!(resolve("/device", "/"), Ok(None));
+        assert_eq!(resolve("/devil/null", "/"), Ok(None));
+    }
+}

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -28,6 +28,11 @@ mod open;
 
 use self::open as open_adapter;
 use crate::{
+    devfs::{
+        self,
+        DeviceMetadata,
+        DevicePath,
+    },
     filesystem,
     line_discipline::{
         ConsoleReadOutcome,
@@ -76,6 +81,7 @@ use ::sys::pm::{
 use ::sysapi::{
     fcntl::{
         atflags::AT_SYMLINK_NOFOLLOW,
+        file_access_mode,
         file_control_request,
         file_creation_flags,
         file_status_flags,
@@ -913,7 +919,8 @@ pub fn vfs_current_generation() -> u64 {
 
 /// Returns `true` if the given path is handled by the VFS.
 pub fn is_vfs_path(path: &str) -> bool {
-    open_adapter::exists(&current_cwd(), path)
+    let cwd: String = current_cwd();
+    matches!(devfs::owns(path, &cwd), Ok(true)) || open_adapter::exists(&cwd, path)
 }
 
 /// Resolves a flat descriptor to its backend route and the descriptor that backend expects.
@@ -990,6 +997,15 @@ pub fn vfs_poll(fd: c_int, events: c_short) -> Result<c_short, Fat32Error> {
 /// Opens a file through the VFS and allocates a system-wide FD.
 pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
     let cwd: String = current_cwd();
+    if matches!(devfs::resolve(path, &cwd)?, Some(DevicePath::Directory)) {
+        if flags & file_creation_flags::O_CREAT != 0 && flags & file_creation_flags::O_EXCL != 0 {
+            return Err(Fat32Error::AlreadyExists);
+        }
+        let access_mode: c_int = flags & file_access_mode::O_ACCMODE;
+        if access_mode != file_access_mode::O_RDONLY || flags & file_creation_flags::O_TRUNC != 0 {
+            return Err(Fat32Error::NotAFile);
+        }
+    }
     // If O_DIRECTORY is set, verify the path is a directory before opening.
     if flags & file_creation_flags::O_DIRECTORY != 0 {
         let info: filesystem::Stat = filesystem::stat(&cwd, path)?;
@@ -1221,6 +1237,29 @@ fn populate_console_stat_fields(
     };
 }
 
+/// Populates stat fields for a synthetic device-namespace entry.
+fn populate_device_stat_fields(buf: &mut ::sysapi::sys_stat::stat, metadata: DeviceMetadata) {
+    buf.st_size = 0;
+    buf.st_nlink = if metadata.is_directory() { 2 } else { 1 };
+    buf.st_dev = metadata.device();
+    buf.st_ino = metadata.inode();
+    buf.st_mode = file_type::S_IFDIR | file_mode::S_IRWXU;
+    buf.st_blksize = STAT_BLOCK_SIZE;
+    buf.st_blocks = 0;
+    buf.st_atim = timespec {
+        tv_sec: FAT_EPOCH_SECS,
+        tv_nsec: 0,
+    };
+    buf.st_mtim = timespec {
+        tv_sec: FAT_EPOCH_SECS,
+        tv_nsec: 0,
+    };
+    buf.st_ctim = timespec {
+        tv_sec: FAT_EPOCH_SECS,
+        tv_nsec: 0,
+    };
+}
+
 /// Gets file status for a VFS file descriptor.
 pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fat32Error> {
     let file: OpenFile = entry_arc(fd)?;
@@ -1233,9 +1272,17 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
     }
 
     match &mut entry.handle {
+        VfsFileHandle::Directory(directory) => {
+            if let Some(metadata) = devfs::metadata(directory.path(), "/")? {
+                populate_device_stat_fields(buf, metadata);
+            } else {
+                let info: filesystem::Stat =
+                    filesystem::Stat::new(0, true, FAT_EPOCH_SECS, FAT_EPOCH_SECS, FAT_EPOCH_SECS);
+                buf.update_from_vfs(&info);
+            }
+        },
         handle @ (VfsFileHandle::Fat32(_)
         | VfsFileHandle::DirectRead(_)
-        | VfsFileHandle::Directory(_)
         | VfsFileHandle::HostFs(_)) => {
             // upstream exposes timestamps through directory entries, not open
             // files. Re-querying by path can identify a different file after
@@ -1408,14 +1455,19 @@ pub fn vfs_dup2(oldfd: c_int, newfd: c_int) -> Result<c_int, Fat32Error> {
 
 /// Gets file status for a path through the VFS.
 pub fn vfs_stat(path: &str, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fat32Error> {
-    let info: filesystem::Stat = filesystem::stat(&current_cwd(), path)?;
+    let cwd: String = current_cwd();
 
     // Zero-initialize the stat buffer.
     unsafe {
         ::core::ptr::write_bytes(buf as *mut ::sysapi::sys_stat::stat, 0, 1);
     }
 
-    buf.update_from_vfs(&info);
+    if let Some(metadata) = devfs::metadata(path, &cwd)? {
+        populate_device_stat_fields(buf, metadata);
+    } else {
+        let info: filesystem::Stat = filesystem::stat(&cwd, path)?;
+        buf.update_from_vfs(&info);
+    }
     set_root_ownership(buf);
 
     Ok(())
@@ -1949,11 +2001,10 @@ pub fn vfs_getdents(
 
     let entries: Vec<filesystem::DirEntry> = dir_handle.read_entries(count)?;
 
-    // FAT32 has no real inodes; use synthetic 1-based indices.
     let mut result: Vec<posix_dent> = Vec::new();
-    for (i, de) in entries.iter().enumerate() {
+    for de in &entries {
         let mut dent: posix_dent = posix_dent {
-            d_ino: (i + 1) as u64,
+            d_ino: de.inode(),
             d_reclen: core::mem::size_of::<posix_dent>() as u16,
             d_type: if de.is_dir() {
                 dirent_file_type::DT_DIR
@@ -2215,10 +2266,97 @@ pub fn vfs_utimensat(
 mod tests {
     use super::*;
     use crate::process::CURRENT_PID;
-    use ::sysapi::fcntl::file_descriptor_flags::{
-        FD_CLOEXEC,
-        FD_CLOFORK,
+    use ::sysapi::fcntl::{
+        file_access_mode,
+        file_descriptor_flags::{
+            FD_CLOEXEC,
+            FD_CLOFORK,
+        },
     };
+
+    // -- Device namespace tests -------------------------------------------------
+
+    /// Tests pathname metadata and enumeration for the synthetic `/dev` directory.
+    #[test]
+    fn devfs_directory() {
+        let _guard = FORK_TEST_GUARD.lock();
+        if !crate::state::is_initialized() {
+            crate::state::init().expect("initialize VFS");
+        }
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7402);
+        set_current_process(pid);
+
+        let mut directory: ::sysapi::sys_stat::stat = ::sysapi::sys_stat::stat::default();
+        let mut missing: ::sysapi::sys_stat::stat = ::sysapi::sys_stat::stat::default();
+        vfs_stat("/dev", &mut directory).expect("stat /dev");
+        assert_eq!(directory.st_mode & file_type::S_IFMT, file_type::S_IFDIR);
+        assert_eq!(vfs_stat("/dev/missing", &mut missing), Err(Fat32Error::NotFound));
+        assert_eq!(vfs_rmdir("/dev"), Err(Fat32Error::PermissionDenied));
+        assert_eq!(vfs_unlink("/dev/missing"), Err(Fat32Error::NotFound));
+        assert_eq!(vfs_mkdir("/dev"), Err(Fat32Error::AlreadyExists));
+        assert_eq!(
+            vfs_open(
+                "/dev",
+                file_access_mode::O_RDONLY
+                    | file_creation_flags::O_CREAT
+                    | file_creation_flags::O_EXCL,
+            ),
+            Err(Fat32Error::AlreadyExists)
+        );
+        assert_eq!(vfs_open("/dev", file_access_mode::O_WRONLY), Err(Fat32Error::NotAFile));
+        assert_eq!(
+            vfs_open("/dev", file_access_mode::O_WRONLY | file_creation_flags::O_TRUNC,),
+            Err(Fat32Error::NotAFile)
+        );
+        assert_eq!(vfs_mkdir("/dev/hidden"), Err(Fat32Error::PermissionDenied));
+        assert_eq!(vfs_mkdir("/dev/hidden/child"), Err(Fat32Error::NotFound));
+        assert_eq!(
+            vfs_open("/dev/hidden", file_access_mode::O_WRONLY | file_creation_flags::O_CREAT,),
+            Err(Fat32Error::PermissionDenied)
+        );
+        assert_eq!(
+            vfs_open(
+                "/dev/hidden/child",
+                file_access_mode::O_WRONLY | file_creation_flags::O_CREAT,
+            ),
+            Err(Fat32Error::NotFound)
+        );
+        assert!(filesystem::file_raw_region("/", "/dev/hidden").is_none());
+        assert_eq!(
+            filesystem::set_times("/", "/dev", Some(FAT_EPOCH_SECS), None),
+            Err(Fat32Error::PermissionDenied)
+        );
+        let times: [timespec; 2] = [
+            timespec {
+                tv_sec: FAT_EPOCH_SECS,
+                tv_nsec: 0,
+            },
+            timespec {
+                tv_sec: FAT_EPOCH_SECS,
+                tv_nsec: 0,
+            },
+        ];
+        assert_eq!(
+            vfs_utimensat(::sysapi::fcntl::atflags::AT_FDCWD, "/dev", &times, 0),
+            Err(Fat32Error::PermissionDenied)
+        );
+        assert_eq!(vfs_rename("/dev", "/outside-dev"), Err(Fat32Error::PermissionDenied));
+
+        let root: Vec<filesystem::DirEntry> = vfs_readdir("/").expect("read root");
+        let dev: Vec<filesystem::DirEntry> = vfs_readdir("/dev").expect("read /dev");
+        assert_eq!(root.iter().map(|entry| entry.name()).collect::<Vec<_>>(), ["dev"]);
+        assert_eq!(root[0].inode(), directory.st_ino);
+        assert!(dev.is_empty());
+
+        let fd: c_int = vfs_open("/dev", file_access_mode::O_RDONLY).expect("open /dev");
+        let mut opened: ::sysapi::sys_stat::stat = ::sysapi::sys_stat::stat::default();
+        vfs_fstat(fd, &mut opened).expect("fstat /dev");
+        assert_eq!(opened.st_dev, directory.st_dev);
+        assert_eq!(opened.st_ino, directory.st_ino);
+        assert!(vfs_getdents(fd, 1).expect("getdents /dev").is_empty());
+        vfs_close(fd).expect("close /dev");
+        forget_processes(&[pid]);
+    }
 
     // -- DirectReadHandle tests --------------------------------------------------
 

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -30,7 +30,6 @@ use self::open as open_adapter;
 use crate::{
     devfs::{
         self,
-        DeviceMetadata,
         DevicePath,
     },
     filesystem,
@@ -920,7 +919,7 @@ pub fn vfs_current_generation() -> u64 {
 /// Returns `true` if the given path is handled by the VFS.
 pub fn is_vfs_path(path: &str) -> bool {
     let cwd: String = current_cwd();
-    matches!(devfs::owns(path, &cwd), Ok(true)) || open_adapter::exists(&cwd, path)
+    matches!(devfs::owns(&cwd, path), Ok(true)) || open_adapter::exists(&cwd, path)
 }
 
 /// Resolves a flat descriptor to its backend route and the descriptor that backend expects.
@@ -997,7 +996,7 @@ pub fn vfs_poll(fd: c_int, events: c_short) -> Result<c_short, Fat32Error> {
 /// Opens a file through the VFS and allocates a system-wide FD.
 pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
     let cwd: String = current_cwd();
-    if matches!(devfs::resolve(path, &cwd)?, Some(DevicePath::Directory)) {
+    if matches!(devfs::resolve(&cwd, path)?, Some(DevicePath::Directory)) {
         if flags & file_creation_flags::O_CREAT != 0 && flags & file_creation_flags::O_EXCL != 0 {
             return Err(Fat32Error::AlreadyExists);
         }
@@ -1237,29 +1236,6 @@ fn populate_console_stat_fields(
     };
 }
 
-/// Populates stat fields for a synthetic device-namespace entry.
-fn populate_device_stat_fields(buf: &mut ::sysapi::sys_stat::stat, metadata: DeviceMetadata) {
-    buf.st_size = 0;
-    buf.st_nlink = if metadata.is_directory() { 2 } else { 1 };
-    buf.st_dev = metadata.device();
-    buf.st_ino = metadata.inode();
-    buf.st_mode = file_type::S_IFDIR | file_mode::S_IRWXU;
-    buf.st_blksize = STAT_BLOCK_SIZE;
-    buf.st_blocks = 0;
-    buf.st_atim = timespec {
-        tv_sec: FAT_EPOCH_SECS,
-        tv_nsec: 0,
-    };
-    buf.st_mtim = timespec {
-        tv_sec: FAT_EPOCH_SECS,
-        tv_nsec: 0,
-    };
-    buf.st_ctim = timespec {
-        tv_sec: FAT_EPOCH_SECS,
-        tv_nsec: 0,
-    };
-}
-
 /// Gets file status for a VFS file descriptor.
 pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fat32Error> {
     let file: OpenFile = entry_arc(fd)?;
@@ -1273,8 +1249,8 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
 
     match &mut entry.handle {
         VfsFileHandle::Directory(directory) => {
-            if let Some(metadata) = devfs::metadata(directory.path(), "/")? {
-                populate_device_stat_fields(buf, metadata);
+            if let Some(stat) = devfs::posix_stat("/", directory.path())? {
+                *buf = stat;
             } else {
                 let info: filesystem::Stat =
                     filesystem::Stat::new(0, true, FAT_EPOCH_SECS, FAT_EPOCH_SECS, FAT_EPOCH_SECS);
@@ -1457,17 +1433,17 @@ pub fn vfs_dup2(oldfd: c_int, newfd: c_int) -> Result<c_int, Fat32Error> {
 pub fn vfs_stat(path: &str, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fat32Error> {
     let cwd: String = current_cwd();
 
+    if let Some(stat) = devfs::posix_stat(&cwd, path)? {
+        *buf = stat;
+        return Ok(());
+    }
+
     // Zero-initialize the stat buffer.
     unsafe {
         ::core::ptr::write_bytes(buf as *mut ::sysapi::sys_stat::stat, 0, 1);
     }
-
-    if let Some(metadata) = devfs::metadata(path, &cwd)? {
-        populate_device_stat_fields(buf, metadata);
-    } else {
-        let info: filesystem::Stat = filesystem::stat(&cwd, path)?;
-        buf.update_from_vfs(&info);
-    }
+    let info: filesystem::Stat = filesystem::stat(&cwd, path)?;
+    buf.update_from_vfs(&info);
     set_root_ownership(buf);
 
     Ok(())

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -82,7 +82,7 @@ pub(crate) fn open(cwd: &str, path: &str) -> Result<File, Fat32Error> {
 ///
 /// - `path`: The path to the file.
 pub(crate) fn file_raw_region(cwd: &str, path: &str) -> Option<(*const u8, usize)> {
-    if devfs::owns(path, cwd).ok()? {
+    if devfs::owns(cwd, path).ok()? {
         return None;
     }
     let (mount_idx, relative_path): (usize, String) = resolve_path(cwd, path).ok()?;
@@ -112,14 +112,8 @@ pub(crate) fn file_raw_region(cwd: &str, path: &str) -> Option<(*const u8, usize
 /// - [`Fat32Error::NotFound`] if the path doesn't exist.
 pub(crate) fn stat(cwd: &str, path: &str) -> Result<Stat, Fat32Error> {
     let requires_dir: bool = path.ends_with('/');
-    if let Some(metadata) = devfs::metadata(path, cwd)? {
-        return Ok(Stat::new(
-            0,
-            metadata.is_directory(),
-            FAT_EPOCH_SECS,
-            FAT_EPOCH_SECS,
-            FAT_EPOCH_SECS,
-        ));
+    if let Some(stat) = devfs::stat(cwd, path)? {
+        return Ok(stat);
     }
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;
 
@@ -205,14 +199,10 @@ pub(crate) fn set_times(
 ///
 /// - [POSIX mkdir()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkdir.html)
 pub(crate) fn mkdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
-    match devfs::metadata(path, cwd) {
-        Ok(Some(_)) => return Err(Fat32Error::AlreadyExists),
-        Ok(None) => {},
-        Err(Fat32Error::NotFound) => match devfs::resolve(path, cwd)? {
-            Some(DevicePath::Missing) => return Err(Fat32Error::PermissionDenied),
-            Some(DevicePath::Directory) | None => return Err(Fat32Error::NotFound),
-        },
-        Err(error) => return Err(error),
+    match devfs::resolve(cwd, path)? {
+        Some(DevicePath::Directory) => return Err(Fat32Error::AlreadyExists),
+        Some(DevicePath::Missing) => return Err(Fat32Error::PermissionDenied),
+        None => {},
     }
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;
 
@@ -313,11 +303,8 @@ pub(crate) fn unlink(cwd: &str, path: &str) -> Result<(), Fat32Error> {
 /// - [`Fat32Error::NotFound`] if the path doesn't exist.
 /// - [`Fat32Error::NotADirectory`] if the path is a file.
 pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Vec<DirEntry>, Fat32Error> {
-    if let Some(metadata) = devfs::metadata(path, cwd)? {
-        if !metadata.is_directory() {
-            return Err(Fat32Error::NotADirectory);
-        }
-        return Ok(Vec::new());
+    if let Some(entries) = devfs::read_dir(cwd, path)? {
+        return Ok(entries);
     }
 
     let normalized: String = normalize(cwd, path)?;
@@ -343,13 +330,9 @@ pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Vec<DirEntry>, Fat32Erro
         Err(error) => return Err(error),
     };
     if normalized == "/" {
-        entries.retain(|entry| entry.name() != "dev");
-        entries.push(DirEntry::new(
-            String::from("dev"),
-            devfs::DIRECTORY_INODE,
-            true,
-            0,
-        ));
+        let devfs_entry: DirEntry = devfs::directory_entry();
+        entries.retain(|entry| entry.name() != devfs_entry.name());
+        entries.push(devfs_entry);
     }
     Ok(entries)
 }
@@ -491,21 +474,18 @@ pub(crate) fn normalize(cwd: &str, path: &str) -> Result<String, Fat32Error> {
 
 /// Rejects mutation of an existing synthetic device-namespace entry.
 fn reject_device_mutation(cwd: &str, path: &str) -> Result<(), Fat32Error> {
-    if devfs::metadata(path, cwd)?.is_some() {
-        return Err(Fat32Error::PermissionDenied);
+    match devfs::resolve(cwd, path)? {
+        Some(DevicePath::Directory) => Err(Fat32Error::PermissionDenied),
+        Some(DevicePath::Missing) => Err(Fat32Error::NotFound),
+        None => Ok(()),
     }
-    Ok(())
 }
 
 /// Rejects a valid rename destination in the synthetic device namespace.
 fn reject_device_destination(cwd: &str, path: &str) -> Result<(), Fat32Error> {
-    match devfs::metadata(path, cwd) {
-        Ok(Some(_)) => Err(Fat32Error::PermissionDenied),
-        Ok(None) => Ok(()),
-        Err(Fat32Error::NotFound) if devfs::resolve(path, cwd)?.is_some() => {
-            Err(Fat32Error::PermissionDenied)
-        },
-        Err(error) => Err(error),
+    match devfs::resolve(cwd, path)? {
+        Some(DevicePath::Directory | DevicePath::Missing) => Err(Fat32Error::PermissionDenied),
+        None => Ok(()),
     }
 }
 
@@ -570,18 +550,13 @@ pub(crate) fn open_with_options(
         return Err(Fat32Error::InvalidArgument);
     }
 
-    match devfs::metadata(path, cwd) {
-        Ok(Some(_)) => return Err(Fat32Error::NotAFile),
-        Ok(None) => {},
-        Err(Fat32Error::NotFound) => match devfs::resolve(path, cwd)? {
-            Some(DevicePath::Missing) if create || create_new => {
-                return Err(Fat32Error::PermissionDenied);
-            },
-            Some(DevicePath::Directory | DevicePath::Missing) | None => {
-                return Err(Fat32Error::NotFound);
-            },
+    match devfs::resolve(cwd, path)? {
+        Some(DevicePath::Directory) => return Err(Fat32Error::NotAFile),
+        Some(DevicePath::Missing) if create || create_new => {
+            return Err(Fat32Error::PermissionDenied);
         },
-        Err(error) => return Err(error),
+        Some(DevicePath::Missing) => return Err(Fat32Error::NotFound),
+        None => {},
     }
 
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -29,7 +29,13 @@ pub use self::{
 // Imports
 //==================================================================================================
 
-use crate::state;
+use crate::{
+    devfs::{
+        self,
+        DevicePath,
+    },
+    state,
+};
 use ::alloc::{
     string::String,
     vec::Vec,
@@ -76,6 +82,9 @@ pub(crate) fn open(cwd: &str, path: &str) -> Result<File, Fat32Error> {
 ///
 /// - `path`: The path to the file.
 pub(crate) fn file_raw_region(cwd: &str, path: &str) -> Option<(*const u8, usize)> {
+    if devfs::owns(path, cwd).ok()? {
+        return None;
+    }
     let (mount_idx, relative_path): (usize, String) = resolve_path(cwd, path).ok()?;
     state::with_vfs(|vfs| {
         let mount: &crate::mount::Mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
@@ -103,6 +112,15 @@ pub(crate) fn file_raw_region(cwd: &str, path: &str) -> Option<(*const u8, usize
 /// - [`Fat32Error::NotFound`] if the path doesn't exist.
 pub(crate) fn stat(cwd: &str, path: &str) -> Result<Stat, Fat32Error> {
     let requires_dir: bool = path.ends_with('/');
+    if let Some(metadata) = devfs::metadata(path, cwd)? {
+        return Ok(Stat::new(
+            0,
+            metadata.is_directory(),
+            FAT_EPOCH_SECS,
+            FAT_EPOCH_SECS,
+            FAT_EPOCH_SECS,
+        ));
+    }
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;
 
     // Handle root of mount specially.
@@ -145,6 +163,8 @@ pub(crate) fn set_times(
         return Ok(());
     }
 
+    reject_device_mutation(cwd, path)?;
+
     // Normalization drops trailing slashes, so enforce the directory requirement first.
     if path.ends_with('/') {
         stat(cwd, path)?;
@@ -185,6 +205,15 @@ pub(crate) fn set_times(
 ///
 /// - [POSIX mkdir()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkdir.html)
 pub(crate) fn mkdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
+    match devfs::metadata(path, cwd) {
+        Ok(Some(_)) => return Err(Fat32Error::AlreadyExists),
+        Ok(None) => {},
+        Err(Fat32Error::NotFound) => match devfs::resolve(path, cwd)? {
+            Some(DevicePath::Missing) => return Err(Fat32Error::PermissionDenied),
+            Some(DevicePath::Directory) | None => return Err(Fat32Error::NotFound),
+        },
+        Err(error) => return Err(error),
+    }
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;
 
     // Root of a mount always exists — return AlreadyExists (mirrors stat()).
@@ -220,7 +249,9 @@ pub(crate) fn mkdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
 /// - [`Fat32Error::NotFound`] if directory doesn't exist.
 /// - [`Fat32Error::NotEmpty`] if directory is not empty.
 /// - [`Fat32Error::NotADirectory`] if path is a file.
+/// - [`Fat32Error::PermissionDenied`] if path names an existing synthetic namespace entry.
 pub(crate) fn rmdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
+    reject_device_mutation(cwd, path)?;
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;
 
     // Cannot remove the root of a mount.
@@ -248,7 +279,9 @@ pub(crate) fn rmdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
 /// - [`Fat32Error::ReadOnly`] if the mount is read-only.
 /// - [`Fat32Error::NotFound`] if file doesn't exist.
 /// - [`Fat32Error::NotAFile`] if path is a directory.
+/// - [`Fat32Error::PermissionDenied`] if path names an existing synthetic namespace entry.
 pub(crate) fn unlink(cwd: &str, path: &str) -> Result<(), Fat32Error> {
+    reject_device_mutation(cwd, path)?;
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;
 
     // Root of a mount is a directory, not a file.
@@ -280,26 +313,45 @@ pub(crate) fn unlink(cwd: &str, path: &str) -> Result<(), Fat32Error> {
 /// - [`Fat32Error::NotFound`] if the path doesn't exist.
 /// - [`Fat32Error::NotADirectory`] if the path is a file.
 pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Vec<DirEntry>, Fat32Error> {
-    let (mount_idx, relative_path) = resolve_path(cwd, path)?;
+    if let Some(metadata) = devfs::metadata(path, cwd)? {
+        if !metadata.is_directory() {
+            return Err(Fat32Error::NotADirectory);
+        }
+        return Ok(Vec::new());
+    }
 
-    state::with_vfs(|vfs| {
-        let mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
-
-        let fat_path: &str = if relative_path.is_empty() {
-            "."
-        } else {
-            &relative_path
-        };
-
-        let fat_entries = mount.fat().read_dir(fat_path)?;
-
-        let entries: Vec<DirEntry> = fat_entries
-            .into_iter()
-            .map(|e| DirEntry::new(e.name, e.is_dir, e.size))
-            .collect();
-
-        Ok(entries)
-    })
+    let normalized: String = normalize(cwd, path)?;
+    let resolution: Result<(usize, String), Fat32Error> = resolve_path(cwd, path);
+    let mut entries: Vec<DirEntry> = match resolution {
+        Ok((mount_idx, relative_path)) => state::with_vfs(|vfs| {
+            let mount = vfs.get_mount(mount_idx).ok_or(Fat32Error::NotFound)?;
+            let fat_path: &str = if relative_path.is_empty() {
+                "."
+            } else {
+                &relative_path
+            };
+            let fat_entries = mount.fat().read_dir(fat_path)?;
+            Ok(fat_entries
+                .into_iter()
+                .enumerate()
+                .map(|(index, entry)| {
+                    DirEntry::new(entry.name, index as u64 + 1, entry.is_dir, entry.size)
+                })
+                .collect())
+        })?,
+        Err(Fat32Error::NotFound) if normalized == "/" => Vec::new(),
+        Err(error) => return Err(error),
+    };
+    if normalized == "/" {
+        entries.retain(|entry| entry.name() != "dev");
+        entries.push(DirEntry::new(
+            String::from("dev"),
+            devfs::DIRECTORY_INODE,
+            true,
+            0,
+        ));
+    }
+    Ok(entries)
 }
 
 /// Renames a file or directory.
@@ -322,6 +374,8 @@ pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Vec<DirEntry>, Fat32Erro
 /// - [`Fat32Error::InvalidArgument`] if either path ends in a `.` or `..` component.
 /// - [`Fat32Error::InvalidPath`] if paths are on different mounts, or if path resolution
 ///   fails (e.g. an empty path, or a `cwd` that is not absolute).
+/// - [`Fat32Error::PermissionDenied`] if the source is an existing synthetic entry or the
+///   destination is a valid path in the synthetic device namespace.
 ///
 /// # References
 ///
@@ -332,6 +386,10 @@ pub(crate) fn rename(cwd: &str, old_path: &str, new_path: &str) -> Result<(), Fa
     if ends_with_dot(old_path) || ends_with_dot(new_path) {
         return Err(Fat32Error::InvalidArgument);
     }
+
+    reject_device_mutation(cwd, old_path)?;
+    stat(cwd, old_path)?;
+    reject_device_destination(cwd, new_path)?;
 
     let (old_idx, old_rel) = resolve_path(cwd, old_path)?;
     let (new_idx, new_rel) = resolve_path(cwd, new_path)?;
@@ -431,6 +489,26 @@ pub(crate) fn normalize(cwd: &str, path: &str) -> Result<String, Fat32Error> {
 // Internal Functions
 //==================================================================================================
 
+/// Rejects mutation of an existing synthetic device-namespace entry.
+fn reject_device_mutation(cwd: &str, path: &str) -> Result<(), Fat32Error> {
+    if devfs::metadata(path, cwd)?.is_some() {
+        return Err(Fat32Error::PermissionDenied);
+    }
+    Ok(())
+}
+
+/// Rejects a valid rename destination in the synthetic device namespace.
+fn reject_device_destination(cwd: &str, path: &str) -> Result<(), Fat32Error> {
+    match devfs::metadata(path, cwd) {
+        Ok(Some(_)) => Err(Fat32Error::PermissionDenied),
+        Ok(None) => Ok(()),
+        Err(Fat32Error::NotFound) if devfs::resolve(path, cwd)?.is_some() => {
+            Err(Fat32Error::PermissionDenied)
+        },
+        Err(error) => Err(error),
+    }
+}
+
 /// Returns `true` if the final component of `path` is `.` or `..`.
 ///
 /// POSIX forbids these as rename operands. Trailing slashes are ignored.
@@ -490,6 +568,20 @@ pub(crate) fn open_with_options(
     }
     if create_new && (create || truncate) {
         return Err(Fat32Error::InvalidArgument);
+    }
+
+    match devfs::metadata(path, cwd) {
+        Ok(Some(_)) => return Err(Fat32Error::NotAFile),
+        Ok(None) => {},
+        Err(Fat32Error::NotFound) => match devfs::resolve(path, cwd)? {
+            Some(DevicePath::Missing) if create || create_new => {
+                return Err(Fat32Error::PermissionDenied);
+            },
+            Some(DevicePath::Directory | DevicePath::Missing) | None => {
+                return Err(Fat32Error::NotFound);
+            },
+        },
+        Err(error) => return Err(error),
     }
 
     let (mount_idx, relative_path) = resolve_path(cwd, path)?;

--- a/src/libs/vfs/src/filesystem/dir_entry.rs
+++ b/src/libs/vfs/src/filesystem/dir_entry.rs
@@ -18,6 +18,8 @@ use ::alloc::string::String;
 pub struct DirEntry {
     /// Name of the entry (just the filename, not full path).
     name: String,
+    /// Stable inode identifier.
+    inode: u64,
     /// Whether this entry is a directory.
     is_dir: bool,
     /// Size in bytes (0 for directories).
@@ -34,16 +36,28 @@ impl DirEntry {
     /// # Parameters
     ///
     /// - `name`: Entry name (filename only, not full path).
+    /// - `inode`: Stable inode identifier.
     /// - `is_dir`: Whether this entry is a directory.
     /// - `size`: Size in bytes (0 for directories).
-    pub fn new(name: String, is_dir: bool, size: u64) -> Self {
-        Self { name, is_dir, size }
+    pub fn new(name: String, inode: u64, is_dir: bool, size: u64) -> Self {
+        Self {
+            name,
+            inode,
+            is_dir,
+            size,
+        }
     }
 
     /// Returns the entry name (filename only, not full path).
     #[must_use]
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Returns the stable inode identifier.
+    #[must_use]
+    pub fn inode(&self) -> u64 {
+        self.inode
     }
 
     /// Returns whether this entry is a directory.
@@ -70,11 +84,12 @@ mod tests {
     /// Tests DirEntry equality and debug.
     #[test]
     fn dir_entry_clone_eq_debug() {
-        let entry: DirEntry = DirEntry::new(String::from("test.txt"), false, 100);
+        let entry: DirEntry = DirEntry::new(String::from("test.txt"), 7, false, 100);
         let cloned: DirEntry = entry.clone();
         assert_eq!(entry, cloned, "clone should preserve equality");
 
         assert_eq!(entry.name(), "test.txt", "name accessor should return name");
+        assert_eq!(entry.inode(), 7, "inode accessor should return inode");
         assert!(!entry.is_dir(), "is_dir accessor should return false");
         assert_eq!(entry.size(), 100, "size accessor should return 100");
 

--- a/src/libs/vfs/src/lib.rs
+++ b/src/libs/vfs/src/lib.rs
@@ -62,6 +62,9 @@ extern crate alloc;
 /// Backend-neutral descriptor handle types.
 mod descriptor;
 
+/// Synthetic device namespace.
+mod devfs;
+
 /// Process-independent filesystem operations.
 mod filesystem;
 

--- a/src/libs/vfs/src/mount.rs
+++ b/src/libs/vfs/src/mount.rs
@@ -15,7 +15,11 @@ mod vfs;
 // Re-Exports
 //==================================================================================================
 
-pub(crate) use self::vfs::normalize_absolute;
+pub(crate) use self::vfs::{
+    anchor_path,
+    normalize_absolute,
+    normalize_anchored,
+};
 pub use self::{
     mount_point::Mount,
     vfs::Vfs,

--- a/src/libs/vfs/src/mount/vfs.rs
+++ b/src/libs/vfs/src/mount/vfs.rs
@@ -145,23 +145,7 @@ impl Vfs {
     /// - [POSIX Base Definitions, Chapter 4 — Pathname Resolution](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html)
     /// - [POSIX open() — `ENOENT` for empty path](https://pubs.opengroup.org/onlinepubs/9799919799/functions/open.html)
     pub fn normalize_path(&self, path: &str, cwd: &str) -> Result<String, Fat32Error> {
-        if path.is_empty() {
-            return Err(Fat32Error::NotFound);
-        }
-
-        let abs_path: String = if path.starts_with('/') {
-            String::from(path)
-        } else if !cwd.starts_with('/') {
-            // Relative paths are anchored to `cwd`, which must be absolute per this function's
-            // contract; reject a malformed `cwd` rather than silently produce a bogus result.
-            return Err(Fat32Error::InvalidPath);
-        } else if cwd == "/" {
-            alloc::format!("/{}", path)
-        } else {
-            alloc::format!("{}/{}", cwd, path)
-        };
-
-        Ok(normalize_components(&abs_path))
+        normalize_path(path, cwd)
     }
 
     /// Resolves a path to a mount and relative path within that mount.
@@ -243,13 +227,39 @@ impl Vfs {
     }
 }
 
+/// Anchors a path to an absolute working directory without normalizing its components.
+pub(crate) fn anchor_path(path: &str, cwd: &str) -> Result<String, Fat32Error> {
+    if path.is_empty() {
+        return Err(Fat32Error::NotFound);
+    }
+    if path.starts_with('/') {
+        Ok(String::from(path))
+    } else if !cwd.starts_with('/') {
+        Err(Fat32Error::InvalidPath)
+    } else if cwd == "/" {
+        Ok(alloc::format!("/{}", path))
+    } else {
+        Ok(alloc::format!("{}/{}", cwd, path))
+    }
+}
+
+/// Normalizes a path after anchoring it to an absolute working directory.
+pub(crate) fn normalize_path(path: &str, cwd: &str) -> Result<String, Fat32Error> {
+    Ok(normalize_anchored(&anchor_path(path, cwd)?))
+}
+
 /// Lexically normalizes a resolved path.
 ///
 /// Resolves `.` and `..`, collapses repeated separators, and drops trailing
 /// slashes. Never fails: [`ResolvedPath`] is absolute by construction, and `..`
 /// at the root clamps to the root, as POSIX defines `/..` to be `/`.
 pub(crate) fn normalize_absolute(path: &ResolvedPath) -> String {
-    normalize_components(path.as_str())
+    normalize_anchored(path.as_str())
+}
+
+/// Lexically normalizes an anchored absolute path.
+pub(crate) fn normalize_anchored(path: &str) -> String {
+    normalize_components(path)
 }
 
 /// Lexically normalizes an absolute `path`.


### PR DESCRIPTION
## Summary

Add a synthetic `/dev` namespace owned by the VFS rather than a mounted filesystem backend.

The namespace is resolved before FAT32 or hostfs dispatch. It synthesizes metadata for `/dev`, includes it in root-directory enumeration, and prevents filesystem operations from creating, replacing, renaming, or removing reserved namespace entries.

This is the base of a stacked series. #3149 adds `/dev/null`; subsequent changes add `/dev/console` and `/dev/tty`.

## Testing

- Passed formatting, linting, and spellchecking.
- Passed compilation checks.
- Verified as the base of the stacked device implementation and its integration tests.

## Tracking

Partial implementation of #3122.
