### PR TITLE
[vfs] F: Add Null Device

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -117,7 +117,7 @@ $(POSIX_TESTS_OBJDIR)/%.o: $(POSIX_TESTS_STRESS_SRCDIR)/%.c
 POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c poll.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
-	fdatasync.c stat.c ftruncate.c truncate.c link.c linkat.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
+	fdatasync.c stat.c device_namespace.c ftruncate.c truncate.c link.c linkat.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
 	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c \
 	utimensat.c utimes.c utime.c futimens.c chown.c fchown.c fchownat.c lchown.c \
 	chmod.c fchmodat.c fchmod.c lchmod.c faccessat.c access.c

--- a/src/libs/syscall/src/safe/file/file_control_request.rs
+++ b/src/libs/syscall/src/safe/file/file_control_request.rs
@@ -16,16 +16,19 @@ use ::sys::error::{
     ErrorCode,
 };
 use ::sysapi::{
-    fcntl::file_control_request::{
-        F_DUPFD,
-        F_DUPFD_CLOEXEC,
-        F_DUPFD_CLOFORK,
-        F_GETFD,
-        F_GETFL,
-        F_GETOWN,
-        F_SETFD,
-        F_SETFL,
-        F_SETOWN,
+    fcntl::{
+        file_access_mode,
+        file_control_request::{
+            F_DUPFD,
+            F_DUPFD_CLOEXEC,
+            F_DUPFD_CLOFORK,
+            F_GETFD,
+            F_GETFL,
+            F_GETOWN,
+            F_SETFD,
+            F_SETFL,
+            F_SETOWN,
+        },
     },
     ffi::c_int,
 };
@@ -127,7 +130,8 @@ impl TryFrom<(c_int, Option<c_int>)> for FileControlRequest {
             },
             (F_GETFL, None) => Ok(FileControlRequest::GetFileStatusFlags),
             (F_SETFL, Some(flags)) => {
-                let fd_flags: FileStatusFlags = FileStatusFlags::try_from(flags)?;
+                let fd_flags: FileStatusFlags =
+                    FileStatusFlags::try_from(flags & !file_access_mode::O_ACCMODE)?;
                 Ok(FileControlRequest::SetFileStatusFlags(fd_flags))
             },
             (F_GETOWN, None) => Ok(FileControlRequest::GetSocketOwner),
@@ -173,7 +177,8 @@ impl<'a> TryFrom<(c_int, VaList<'a>)> for FileControlRequest {
             F_SETFL => {
                 let flags: c_int = unsafe { arg.next_arg() };
                 ::syslog::debug!("F_SETFL: flags={flags:?}");
-                let status_flags: FileStatusFlags = FileStatusFlags::try_from(flags)?;
+                let status_flags: FileStatusFlags =
+                    FileStatusFlags::try_from(flags & !file_access_mode::O_ACCMODE)?;
                 Ok(FileControlRequest::SetFileStatusFlags(status_flags))
             },
             F_GETOWN => Ok(FileControlRequest::GetSocketOwner),

--- a/src/libs/vfs/src/descriptor.rs
+++ b/src/libs/vfs/src/descriptor.rs
@@ -7,12 +7,14 @@
 // Modules
 //==================================================================================================
 
+mod access_mode;
 mod console_handle;
 mod console_stream;
 mod direct_read_handle;
 mod directory_handle;
 mod fd_flags;
 mod host_fs_handle;
+mod null_handle;
 mod pipe_closure;
 mod process_exit_reclaim;
 mod socket_handle;
@@ -25,12 +27,14 @@ mod vfs_route;
 //==================================================================================================
 
 pub use self::{
+    access_mode::AccessMode,
     console_handle::ConsoleHandle,
     console_stream::ConsoleStream,
     direct_read_handle::DirectReadHandle,
     directory_handle::DirectoryHandle,
     fd_flags::FdFlags,
     host_fs_handle::HostFsHandle,
+    null_handle::NullHandle,
     pipe_closure::PipeClosure,
     process_exit_reclaim::ProcessExitReclaim,
     socket_handle::SocketHandle,

--- a/src/libs/vfs/src/descriptor/access_mode.rs
+++ b/src/libs/vfs/src/descriptor/access_mode.rs
@@ -1,0 +1,35 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Descriptor access mode.
+
+//==================================================================================================
+// Enumerations
+//==================================================================================================
+
+/// Access permitted by an open file description.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AccessMode {
+    /// Reads are permitted.
+    ReadOnly,
+    /// Writes are permitted.
+    WriteOnly,
+    /// Reads and writes are permitted.
+    ReadWrite,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl AccessMode {
+    /// Returns whether reads are permitted.
+    pub fn readable(self) -> bool {
+        matches!(self, Self::ReadOnly | Self::ReadWrite)
+    }
+
+    /// Returns whether writes are permitted.
+    pub fn writable(self) -> bool {
+        matches!(self, Self::WriteOnly | Self::ReadWrite)
+    }
+}

--- a/src/libs/vfs/src/descriptor/null_handle.rs
+++ b/src/libs/vfs/src/descriptor/null_handle.rs
@@ -1,0 +1,78 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Null-device descriptor handle.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::AccessMode;
+use ::fat32::Fat32Error;
+use ::sysapi::{
+    ffi::{
+        c_int,
+        c_short,
+    },
+    poll::poll_flags::{
+        POLLIN,
+        POLLOUT,
+        POLLRDNORM,
+        POLLWRNORM,
+    },
+    sys_types::off_t,
+    unistd::file_seek,
+};
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// An open description of `/dev/null`.
+pub struct NullHandle {
+    /// Access permitted by this open description.
+    access_mode: AccessMode,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl NullHandle {
+    /// Creates a null-device handle with the requested access mode.
+    pub fn new(access_mode: AccessMode) -> Self {
+        Self { access_mode }
+    }
+
+    /// Reads EOF from the null device.
+    pub fn read(&self) -> Result<usize, Fat32Error> {
+        if !self.access_mode.readable() {
+            return Err(Fat32Error::InvalidFd);
+        }
+        Ok(0)
+    }
+
+    /// Discards a buffer and returns its full length.
+    pub fn write(&self, buf: &[u8]) -> Result<usize, Fat32Error> {
+        if !self.access_mode.writable() {
+            return Err(Fat32Error::InvalidFd);
+        }
+        Ok(buf.len())
+    }
+
+    /// Seeks the null device, which remains at offset zero.
+    pub fn seek(&self, whence: c_int) -> Result<off_t, Fat32Error> {
+        match whence {
+            file_seek::SEEK_SET | file_seek::SEEK_CUR | file_seek::SEEK_END => Ok(0),
+            _ => Err(Fat32Error::InvalidArgument),
+        }
+    }
+
+    /// Returns events that can complete immediately.
+    pub fn poll(&self, events: c_short) -> c_short {
+        const READ_EVENTS: c_short = POLLIN | POLLRDNORM;
+        const WRITE_EVENTS: c_short = POLLOUT | POLLWRNORM;
+
+        events & (READ_EVENTS | WRITE_EVENTS)
+    }
+}

--- a/src/libs/vfs/src/descriptor/vfs_file_handle.rs
+++ b/src/libs/vfs/src/descriptor/vfs_file_handle.rs
@@ -12,6 +12,7 @@ use super::{
     DirectReadHandle,
     DirectoryHandle,
     HostFsHandle,
+    NullHandle,
     SocketHandle,
 };
 use crate::{
@@ -44,6 +45,8 @@ pub enum VfsFileHandle {
     /// Remote file opened through the host filesystem daemon (hostfsd).
     /// Operations on this handle must be forwarded via IKC by the caller (vfsd).
     HostFs(HostFsHandle),
+    /// The null device.
+    Null(NullHandle),
     /// One end of a POSIX unnamed pipe.
     Pipe(PipeEnd),
     /// Routing token for a console stream (stdin/stdout/stderr).
@@ -64,6 +67,7 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(handle) => state::with_storage_lock(|| Ok(handle.read(buf))),
             VfsFileHandle::Directory(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+            VfsFileHandle::Null(handle) => handle.read(),
             VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::Console(_) | VfsFileHandle::Socket(_) => Err(Fat32Error::NotSupported),
         }
@@ -76,6 +80,7 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
             VfsFileHandle::Directory(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+            VfsFileHandle::Null(handle) => handle.write(buf),
             VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::Console(_) | VfsFileHandle::Socket(_) => Err(Fat32Error::NotSupported),
         }
@@ -91,6 +96,7 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(handle) => handle.seek(offset, whence),
             VfsFileHandle::Directory(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
+            VfsFileHandle::Null(handle) => handle.seek(whence),
             VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::Console(_) | VfsFileHandle::Socket(_) => Err(Fat32Error::NotSupported),
         }
@@ -103,6 +109,7 @@ impl VfsFileHandle {
             VfsFileHandle::DirectRead(handle) => Ok(handle.size() as u64),
             VfsFileHandle::Directory(_) => Ok(0),
             VfsFileHandle::HostFs(_) => Ok(0),
+            VfsFileHandle::Null(_) => Ok(0),
             VfsFileHandle::Pipe(_) => Ok(0),
             VfsFileHandle::Console(_) | VfsFileHandle::Socket(_) => Ok(0),
         }

--- a/src/libs/vfs/src/devfs.rs
+++ b/src/libs/vfs/src/devfs.rs
@@ -69,6 +69,17 @@ const STAT_BLOCK_SIZE: i64 = ::arch::mem::PAGE_SIZE as i64;
 /// Stable timestamp used until VFS defines backend-neutral synthetic timestamps.
 const STAT_TIMESTAMP_SECS: i64 = FAT_EPOCH_SECS;
 
+/// Name of the null device.
+const NULL_NAME: &str = "null";
+/// Absolute path of the null device.
+const NULL_PATH: &str = "/dev/null";
+
+/// Stable inode identifier for `/dev/null`.
+const NULL_INODE: u64 = 2;
+
+/// Character-device identifier reported for `/dev/null`.
+const NULL_SPECIAL_DEVICE_ID: u64 = 1;
+
 //==================================================================================================
 // Structures
 //==================================================================================================
@@ -80,6 +91,8 @@ struct DeviceMetadata {
     device: u64,
     /// Stable inode identifier.
     inode: u64,
+    /// Device identifier for a character-special entry.
+    special_device: u64,
     /// Whether this entry is a directory.
     is_directory: bool,
 }
@@ -93,6 +106,8 @@ struct DeviceMetadata {
 pub(crate) enum DevicePath {
     /// The synthetic `/dev` directory.
     Directory,
+    /// The null device.
+    Null,
     /// An unknown entry below `/dev`.
     Missing,
 }
@@ -108,7 +123,14 @@ impl DevicePath {
             DevicePath::Directory => Some(DeviceMetadata {
                 device: DEVICE_NAMESPACE_ID,
                 inode: DIRECTORY_INODE,
+                special_device: 0,
                 is_directory: true,
+            }),
+            DevicePath::Null => Some(DeviceMetadata {
+                device: DEVICE_NAMESPACE_ID,
+                inode: NULL_INODE,
+                special_device: NULL_SPECIAL_DEVICE_ID,
+                is_directory: false,
             }),
             DevicePath::Missing => None,
         }
@@ -145,7 +167,11 @@ fn metadata(cwd: &str, path: &str) -> Result<Option<DeviceMetadata>, Fat32Error>
     let Some(device_path) = resolve_normalized(&normalized) else {
         return Ok(None);
     };
-    Ok(Some(device_path.metadata().ok_or(Fat32Error::NotFound)?))
+    let metadata: DeviceMetadata = device_path.metadata().ok_or(Fat32Error::NotFound)?;
+    if path.ends_with('/') && !metadata.is_directory {
+        return Err(Fat32Error::NotADirectory);
+    }
+    Ok(Some(metadata))
 }
 
 /// Synthesizes backend-neutral metadata for an existing devfs path.
@@ -164,28 +190,39 @@ pub(crate) fn stat(cwd: &str, path: &str) -> Result<Option<Stat>, Fat32Error> {
 
 /// Synthesizes POSIX metadata for an existing devfs path.
 pub(crate) fn posix_stat(cwd: &str, path: &str) -> Result<Option<PosixStat>, Fat32Error> {
-    let Some(metadata) = metadata(cwd, path)? else {
-        return Ok(None);
-    };
+    Ok(metadata(cwd, path)?.map(build_posix_stat))
+}
+
+/// Synthesizes POSIX metadata for `/dev/null`.
+pub(crate) fn null_posix_stat() -> PosixStat {
+    build_posix_stat(DevicePath::Null.metadata().expect("null device has metadata"))
+}
+
+/// Builds POSIX metadata for a devfs entry.
+fn build_posix_stat(metadata: DeviceMetadata) -> PosixStat {
     let timestamp: timespec = timespec {
         tv_sec: STAT_TIMESTAMP_SECS,
         tv_nsec: 0,
     };
-    Ok(Some(PosixStat {
+    PosixStat {
         st_dev: metadata.device,
         st_ino: metadata.inode,
-        st_mode: file_type::S_IFDIR | file_mode::S_IRWXU,
+        st_mode: if metadata.is_directory {
+            file_type::S_IFDIR | file_mode::S_IRWXU
+        } else {
+            file_type::S_IFCHR | file_mode::S_IRUSR | file_mode::S_IWUSR
+        },
         st_nlink: if metadata.is_directory { 2 } else { 1 },
         st_uid: UserIdentifier::ROOT.as_usize() as uid_t,
         st_gid: GroupIdentifier::ROOT.as_usize() as gid_t,
-        st_rdev: 0,
+        st_rdev: metadata.special_device,
         st_size: 0,
         st_blksize: STAT_BLOCK_SIZE,
         st_blocks: 0,
         st_atim: timestamp,
         st_mtim: timestamp,
         st_ctim: timestamp,
-    }))
+    }
 }
 
 /// Returns the `/dev` entry injected into the VFS root directory.
@@ -196,7 +233,11 @@ pub(crate) fn directory_entry() -> DirEntry {
 /// Reads a directory owned by devfs.
 pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Option<Vec<DirEntry>>, Fat32Error> {
     match resolve(cwd, path)? {
-        Some(DevicePath::Directory) => Ok(Some(Vec::new())),
+        Some(DevicePath::Directory) => Ok(Some(alloc::vec![DirEntry::new_character_device(
+            String::from(NULL_NAME),
+            NULL_INODE,
+        )])),
+        Some(DevicePath::Null) => Err(Fat32Error::NotADirectory),
         Some(DevicePath::Missing) => Err(Fat32Error::NotFound),
         None => Ok(None),
     }
@@ -207,7 +248,10 @@ fn validate_components(path: &str) -> Result<(), Fat32Error> {
     let mut components: Vec<&str> = Vec::new();
     for component in path.split('/').filter(|component| !component.is_empty()) {
         if components.len() >= 2 && components[0] == DIRECTORY_NAME {
-            return Err(Fat32Error::NotFound);
+            return match components[1] {
+                NULL_NAME => Err(Fat32Error::NotADirectory),
+                _ => Err(Fat32Error::NotFound),
+            };
         }
         match component {
             "." => {},
@@ -224,6 +268,7 @@ fn validate_components(path: &str) -> Result<(), Fat32Error> {
 fn resolve_normalized(path: &str) -> Option<DevicePath> {
     match path {
         DIRECTORY_PATH => Some(DevicePath::Directory),
+        NULL_PATH => Some(DevicePath::Null),
         path if path.starts_with(DIRECTORY_PREFIX) => Some(DevicePath::Missing),
         _ => None,
     }
@@ -240,8 +285,10 @@ mod tests {
     #[test]
     fn resolves_namespace_paths() {
         assert_eq!(resolve("/", "/dev"), Ok(Some(DevicePath::Directory)));
+        assert_eq!(resolve("/", "/dev/null"), Ok(Some(DevicePath::Null)));
         assert_eq!(resolve("/", "/dev/unknown"), Ok(Some(DevicePath::Missing)));
         assert_eq!(resolve("/", "/dev/unknown/child"), Err(Fat32Error::NotFound));
+        assert_eq!(resolve("/", "/dev/null/child"), Err(Fat32Error::NotADirectory));
     }
 
     #[test]

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -172,6 +172,7 @@ pub use crate::{
         DirectoryHandle,
         FdFlags,
         HostFsHandle,
+        NullHandle,
         PipeClosure,
         ProcessExitReclaim,
         SocketHandle,
@@ -223,6 +224,11 @@ const MAX_OPEN_FDS: c_int = 2048;
 /// while the `networkd` descriptor that backs it lives in `networkd`'s own space and is invisible
 /// here.
 fn alloc_fd(handle: VfsFileHandle) -> Result<c_int, Fat32Error> {
+    alloc_fd_with_status(handle, 0)
+}
+
+/// Allocates a descriptor with initial open-file status flags.
+fn alloc_fd_with_status(handle: VfsFileHandle, status_flags: c_int) -> Result<c_int, Fat32Error> {
     let mut procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
         PROCESSES.lock();
     let state: &mut ProcessState = procs.entry(current_pid()).or_insert_with(ProcessState::new);
@@ -233,7 +239,7 @@ fn alloc_fd(handle: VfsFileHandle) -> Result<c_int, Fat32Error> {
     let file: OpenFile = Arc::new(Mutex::new(VfsEntry {
         handle,
         virtual_pos: 0,
-        status_flags: 0,
+        status_flags,
     }));
     state.slots.insert(fd, Slot::new(file));
     // Allocating a descriptor graduates a lazily-inserted placeholder into an active state: a
@@ -954,6 +960,7 @@ pub fn vfs_resolve(fd: c_int) -> Option<(VfsRoute, c_int)> {
         | VfsFileHandle::DirectRead(_)
         | VfsFileHandle::Directory(_)
         | VfsFileHandle::HostFs(_)
+        | VfsFileHandle::Null(_)
         | VfsFileHandle::Pipe(_) => (VfsRoute::Vfs, fd),
     };
     Some(resolution)
@@ -972,6 +979,7 @@ pub fn vfs_poll(fd: c_int, events: c_short) -> Result<c_short, Fat32Error> {
             VfsFileHandle::Fat32(_) | VfsFileHandle::DirectRead(_) | VfsFileHandle::HostFs(_) => {
                 return Ok(events & (READ_EVENTS | WRITE_EVENTS))
             },
+            VfsFileHandle::Null(handle) => return Ok(handle.poll(events)),
             VfsFileHandle::Directory(_) => return Ok(events & READ_EVENTS),
             VfsFileHandle::Pipe(end) => return Ok(end.poll(events)),
             VfsFileHandle::Socket(_) => return Err(Fat32Error::NotSupported),
@@ -1013,10 +1021,13 @@ pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
         }
         let normalized: String = crate::filesystem::normalize(&cwd, path)?;
         let handle: VfsFileHandle = VfsFileHandle::Directory(DirectoryHandle::new(normalized));
-        return alloc_fd(handle);
+        let status_flags: c_int =
+            flags & (file_access_mode::O_ACCMODE | file_status_flags::O_NONBLOCK);
+        return alloc_fd_with_status(handle, status_flags);
     }
     let handle: VfsFileHandle = open_adapter::open(&cwd, path, flags)?;
-    alloc_fd(handle)
+    let status_flags: c_int = flags & (file_access_mode::O_ACCMODE | file_status_flags::O_NONBLOCK);
+    alloc_fd_with_status(handle, status_flags)
 }
 
 /// Opens a file relative to a directory file descriptor through the VFS.
@@ -1051,6 +1062,10 @@ pub fn vfs_read(fd: c_int, buf: &mut [u8]) -> Result<c_size_t, Fat32Error> {
     let mut guard = file.lock();
     let entry: &mut VfsEntry = &mut guard;
 
+    if let VfsFileHandle::Null(handle) = &entry.handle {
+        return handle.read().map(|count| count as c_size_t);
+    }
+
     if entry.handle.is_dir() {
         return Err(Fat32Error::NotAFile);
     }
@@ -1075,6 +1090,10 @@ pub fn vfs_write(fd: c_int, buf: &[u8]) -> Result<c_size_t, Fat32Error> {
     let file: OpenFile = entry_arc(fd)?;
     let mut guard = file.lock();
     let entry: &mut VfsEntry = &mut guard;
+
+    if let VfsFileHandle::Null(handle) = &entry.handle {
+        return handle.write(buf).map(|count| count as c_size_t);
+    }
 
     let size: u64 = entry.handle.size()?;
     if (entry.virtual_pos as u64) > size {
@@ -1110,6 +1129,10 @@ pub fn vfs_lseek(fd: c_int, offset: off_t, whence: c_int) -> Result<off_t, Fat32
     let file: OpenFile = entry_arc(fd)?;
     let mut guard = file.lock();
     let entry: &mut VfsEntry = &mut guard;
+
+    if let VfsFileHandle::Null(handle) = &entry.handle {
+        return handle.seek(whence);
+    }
 
     let size: i64 = entry.handle.size()? as i64;
     let new_pos: i64 = match whence {
@@ -1273,6 +1296,9 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
                 FAT_EPOCH_SECS,
             );
             buf.update_from_vfs(&info);
+        },
+        VfsFileHandle::Null(_) => {
+            *buf = devfs::null_posix_stat();
         },
         VfsFileHandle::Pipe(end) => {
             populate_pipe_stat_fields(buf, end.pipe_id(), end.created());
@@ -1619,6 +1645,7 @@ pub fn vfs_ftruncate(fd: c_int, length: off_t) -> Result<(), Fat32Error> {
             }
         },
         VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
+        VfsFileHandle::Null(_) => Err(Fat32Error::InvalidArgument),
         VfsFileHandle::Directory(_)
         | VfsFileHandle::HostFs(_)
         | VfsFileHandle::Pipe(_)
@@ -1667,6 +1694,7 @@ pub fn vfs_fallocate(fd: c_int, offset: off_t, len: off_t) -> Result<(), Fat32Er
         VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
         VfsFileHandle::Directory(_)
         | VfsFileHandle::HostFs(_)
+        | VfsFileHandle::Null(_)
         | VfsFileHandle::Pipe(_)
         | VfsFileHandle::Console(_)
         | VfsFileHandle::Socket(_) => Err(Fat32Error::NotSupported),
@@ -1682,6 +1710,7 @@ pub fn vfs_fsync(fd: c_int) -> Result<(), Fat32Error> {
     let entry: &mut VfsEntry = &mut guard;
     match &mut entry.handle {
         VfsFileHandle::Fat32(file) => file.flush(),
+        VfsFileHandle::Null(_) => Err(Fat32Error::InvalidArgument),
         VfsFileHandle::DirectRead(_)
         | VfsFileHandle::Directory(_)
         | VfsFileHandle::HostFs(_)
@@ -1826,9 +1855,16 @@ pub fn vfs_console_peek(fd: c_int, buf: &mut [u8]) -> Result<ConsoleReadOutcome,
 ///
 /// POSIX semantics: reading past EOF returns 0 bytes (not an error).
 pub fn vfs_pread(fd: c_int, buf: &mut [u8], offset: off_t) -> Result<c_size_t, Fat32Error> {
+    if offset < 0 {
+        return Err(Fat32Error::InvalidArgument);
+    }
     let file: OpenFile = entry_arc(fd)?;
     let mut guard = file.lock();
     let entry: &mut VfsEntry = &mut guard;
+
+    if let VfsFileHandle::Null(handle) = &entry.handle {
+        return handle.read().map(|count| count as c_size_t);
+    }
 
     // If the offset is at or past EOF, return 0 (POSIX EOF semantics).
     let size: u64 = entry.handle.size()?;
@@ -1850,9 +1886,16 @@ pub fn vfs_pread(fd: c_int, buf: &mut [u8], offset: off_t) -> Result<c_size_t, F
 ///
 /// POSIX semantics: writing past EOF extends the file with zeros up to the offset.
 pub fn vfs_pwrite(fd: c_int, buf: &[u8], offset: off_t) -> Result<c_size_t, Fat32Error> {
+    if offset < 0 {
+        return Err(Fat32Error::InvalidArgument);
+    }
     let file: OpenFile = entry_arc(fd)?;
     let mut guard = file.lock();
     let entry: &mut VfsEntry = &mut guard;
+
+    if let VfsFileHandle::Null(handle) = &entry.handle {
+        return handle.write(buf).map(|count| count as c_size_t);
+    }
 
     // Save current handle position.
     let saved: off_t = entry.handle.seek(0, file_seek::SEEK_CUR)?;
@@ -1944,7 +1987,10 @@ pub fn vfs_fcntl(fd: c_int, cmd: c_int, arg: c_int) -> Result<c_int, Fat32Error>
         file_control_request::F_SETFL => {
             // Persist only the mutable status-flag subset (currently `O_NONBLOCK`). The remaining
             // bits (access mode, creation flags) are not changeable via `F_SETFL` per POSIX.
-            entry_arc(fd)?.lock().status_flags = arg & file_status_flags::O_NONBLOCK;
+            let file: OpenFile = entry_arc(fd)?;
+            let mut entry = file.lock();
+            entry.status_flags = (entry.status_flags & file_access_mode::O_ACCMODE)
+                | (arg & file_status_flags::O_NONBLOCK);
             Ok(0)
         },
         _ => Err(Fat32Error::NotSupported), // Other commands not supported.
@@ -1984,6 +2030,8 @@ pub fn vfs_getdents(
             d_reclen: core::mem::size_of::<posix_dent>() as u16,
             d_type: if de.is_dir() {
                 dirent_file_type::DT_DIR
+            } else if de.is_character_device() {
+                dirent_file_type::DT_CHR
             } else {
                 dirent_file_type::DT_REG
             },
@@ -2322,15 +2370,160 @@ mod tests {
         let dev: Vec<filesystem::DirEntry> = vfs_readdir("/dev").expect("read /dev");
         assert_eq!(root.iter().map(|entry| entry.name()).collect::<Vec<_>>(), ["dev"]);
         assert_eq!(root[0].inode(), directory.st_ino);
-        assert!(dev.is_empty());
+        assert_eq!(dev.iter().map(|entry| entry.name()).collect::<Vec<_>>(), ["null"]);
+        assert!(dev[0].is_character_device());
 
         let fd: c_int = vfs_open("/dev", file_access_mode::O_RDONLY).expect("open /dev");
         let mut opened: ::sysapi::sys_stat::stat = ::sysapi::sys_stat::stat::default();
         vfs_fstat(fd, &mut opened).expect("fstat /dev");
         assert_eq!(opened.st_dev, directory.st_dev);
         assert_eq!(opened.st_ino, directory.st_ino);
-        assert!(vfs_getdents(fd, 1).expect("getdents /dev").is_empty());
+        let dents: Vec<::sysapi::dirent::posix_dent> = vfs_getdents(fd, 1).expect("getdents /dev");
+        assert_eq!(dents.len(), 1);
+        assert_eq!(dents[0].d_type, ::sysapi::dirent::dirent_file_type::DT_CHR);
+        assert_eq!(dents[0].d_ino, dev[0].inode());
         vfs_close(fd).expect("close /dev");
+        forget_processes(&[pid]);
+    }
+
+    /// Tests null-device reads, writes, positioned I/O, and seeks.
+    #[test]
+    fn null_device_io() {
+        let _guard = FORK_TEST_GUARD.lock();
+        if !crate::state::is_initialized() {
+            crate::state::init().expect("initialize VFS");
+        }
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7403);
+        set_current_process(pid);
+
+        let fd: c_int = vfs_open("/dev/null", file_access_mode::O_RDWR).expect("open null");
+        assert_eq!(vfs_fcntl(fd, file_control_request::F_GETFL, 0), Ok(file_access_mode::O_RDWR));
+        assert_eq!(vfs_write(fd, b"discarded"), Ok(9));
+        assert_eq!(vfs_write(fd, b"again"), Ok(5));
+        assert_eq!(vfs_pwrite(fd, b"positionless", 42), Ok(12));
+        let mut data: [u8; 8] = [0; 8];
+        assert_eq!(vfs_read(fd, &mut data), Ok(0));
+        assert_eq!(vfs_pread(fd, &mut data, 42), Ok(0));
+        assert_eq!(vfs_pread(fd, &mut data, -1), Err(Fat32Error::InvalidArgument));
+        assert_eq!(vfs_pwrite(fd, b"rejected", -1), Err(Fat32Error::InvalidArgument));
+        for whence in [
+            file_seek::SEEK_SET,
+            file_seek::SEEK_CUR,
+            file_seek::SEEK_END,
+        ] {
+            assert_eq!(vfs_lseek(fd, 17, whence), Ok(0));
+        }
+        assert_eq!(vfs_lseek(fd, 0, -1), Err(Fat32Error::InvalidArgument));
+
+        vfs_close(fd).expect("close null");
+        forget_processes(&[pid]);
+    }
+
+    /// Tests null-device descriptor metadata against pathname metadata.
+    #[test]
+    fn null_device_fstat() {
+        let _guard = FORK_TEST_GUARD.lock();
+        if !crate::state::is_initialized() {
+            crate::state::init().expect("initialize VFS");
+        }
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7404);
+        set_current_process(pid);
+
+        let fd: c_int = vfs_open("/dev/null", file_access_mode::O_RDONLY).expect("open null");
+        let mut by_path: ::sysapi::sys_stat::stat = ::sysapi::sys_stat::stat::default();
+        let mut by_fd: ::sysapi::sys_stat::stat = ::sysapi::sys_stat::stat::default();
+        vfs_stat("/dev/null", &mut by_path).expect("stat null");
+        vfs_fstat(fd, &mut by_fd).expect("fstat null");
+
+        assert_eq!(by_fd.st_mode & file_type::S_IFMT, file_type::S_IFCHR);
+        assert_eq!(by_fd.st_dev, by_path.st_dev);
+        assert_eq!(by_fd.st_ino, by_path.st_ino);
+        assert_eq!(by_fd.st_rdev, by_path.st_rdev);
+        assert_eq!(by_fd.st_size, 0);
+        assert_eq!(by_fd.st_blocks, 0);
+
+        vfs_close(fd).expect("close null");
+        forget_processes(&[pid]);
+    }
+
+    /// Tests null-device creation flags and access modes.
+    #[test]
+    fn null_device_open_modes() {
+        let _guard = FORK_TEST_GUARD.lock();
+        if !crate::state::is_initialized() {
+            crate::state::init().expect("initialize VFS");
+        }
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7405);
+        set_current_process(pid);
+        let mut data: [u8; 8] = [0; 8];
+
+        let flags: c_int = file_access_mode::O_WRONLY
+            | file_creation_flags::O_CREAT
+            | file_creation_flags::O_TRUNC;
+        let write_fd: c_int = vfs_open("/dev/null", flags).expect("open null for writing");
+        assert_eq!(
+            vfs_fcntl(write_fd, file_control_request::F_GETFL, 0),
+            Ok(file_access_mode::O_WRONLY)
+        );
+        assert_eq!(vfs_write(write_fd, b"discarded"), Ok(9));
+        assert_eq!(vfs_read(write_fd, &mut data), Err(Fat32Error::InvalidFd));
+        vfs_close(write_fd).expect("close write-only null");
+
+        let read_fd: c_int = vfs_open("/dev/null", file_access_mode::O_RDONLY).expect("open null");
+        assert_eq!(
+            vfs_fcntl(read_fd, file_control_request::F_GETFL, 0),
+            Ok(file_access_mode::O_RDONLY)
+        );
+        assert_eq!(vfs_write(read_fd, b"rejected"), Err(Fat32Error::InvalidFd));
+        vfs_close(read_fd).expect("close read-only null");
+
+        let exclusive_flags: c_int =
+            file_access_mode::O_WRONLY | file_creation_flags::O_CREAT | file_creation_flags::O_EXCL;
+        assert_eq!(vfs_open("/dev/null", exclusive_flags), Err(Fat32Error::AlreadyExists));
+        assert_eq!(
+            vfs_open("/dev/null", file_access_mode::O_EXEC),
+            Err(Fat32Error::PermissionDenied)
+        );
+        forget_processes(&[pid]);
+    }
+
+    /// Tests null-device polling and synchronization.
+    #[test]
+    fn null_device_poll_and_sync() {
+        let _guard = FORK_TEST_GUARD.lock();
+        if !crate::state::is_initialized() {
+            crate::state::init().expect("initialize VFS");
+        }
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7406);
+        set_current_process(pid);
+
+        for mode in [file_access_mode::O_RDONLY, file_access_mode::O_WRONLY] {
+            let fd: c_int = vfs_open("/dev/null", mode).expect("open null");
+            let events: c_short = POLLIN | POLLOUT | POLLRDNORM | POLLWRNORM;
+            assert_eq!(vfs_poll(fd, events), Ok(events));
+            assert_eq!(vfs_fsync(fd), Err(Fat32Error::InvalidArgument));
+            assert_eq!(vfs_ftruncate(fd, 0), Err(Fat32Error::InvalidArgument));
+            vfs_close(fd).expect("close null");
+        }
+        forget_processes(&[pid]);
+    }
+
+    /// Tests directory requirements when opening the null device.
+    #[test]
+    fn null_device_path_errors() {
+        let _guard = FORK_TEST_GUARD.lock();
+        if !crate::state::is_initialized() {
+            crate::state::init().expect("initialize VFS");
+        }
+        let pid: ProcessIdentifier = ProcessIdentifier::from(0x7407);
+        set_current_process(pid);
+
+        let directory_flags: c_int = file_access_mode::O_RDONLY | file_creation_flags::O_DIRECTORY;
+        assert_eq!(vfs_open("/dev/null", directory_flags), Err(Fat32Error::NotADirectory));
+        assert_eq!(
+            vfs_open("/dev/null/", file_access_mode::O_RDONLY),
+            Err(Fat32Error::NotADirectory)
+        );
         forget_processes(&[pid]);
     }
 

--- a/src/libs/vfs/src/fd/open.rs
+++ b/src/libs/vfs/src/fd/open.rs
@@ -13,9 +13,15 @@
 
 use crate::{
     descriptor::{
+        AccessMode,
         DirectReadHandle,
         DirectoryHandle,
+        NullHandle,
         VfsFileHandle,
+    },
+    devfs::{
+        self,
+        DevicePath,
     },
     filesystem,
 };
@@ -112,6 +118,33 @@ pub fn open(cwd: &str, path: &str, flags: c_int) -> Result<VfsFileHandle, Fat32E
 
     let access_mode: c_int = flags & file_access_mode::O_ACCMODE;
     let is_read_only: bool = access_mode == file_access_mode::O_RDONLY;
+
+    match devfs::resolve(cwd, path)? {
+        Some(DevicePath::Null) => {
+            if flags & file_access_mode::O_EXEC != 0 {
+                return Err(Fat32Error::PermissionDenied);
+            }
+            if flags & file_creation_flags::O_CREAT != 0 && flags & file_creation_flags::O_EXCL != 0
+            {
+                return Err(Fat32Error::AlreadyExists);
+            }
+            let access_mode: AccessMode = match access_mode {
+                file_access_mode::O_RDONLY => AccessMode::ReadOnly,
+                file_access_mode::O_WRONLY => AccessMode::WriteOnly,
+                file_access_mode::O_RDWR => AccessMode::ReadWrite,
+                _ => return Err(Fat32Error::InvalidArgument),
+            };
+            return Ok(VfsFileHandle::Null(NullHandle::new(access_mode)));
+        },
+        Some(DevicePath::Missing) => {
+            if flags & file_creation_flags::O_CREAT != 0 {
+                return Err(Fat32Error::PermissionDenied);
+            }
+            return Err(Fat32Error::NotFound);
+        },
+        Some(DevicePath::Directory) => return Err(Fat32Error::NotAFile),
+        None => {},
+    }
 
     // Try zero-copy direct read for read-only opens of contiguous files.
     let creation_flags: c_int =

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -200,7 +200,9 @@ pub(crate) fn set_times(
 /// - [POSIX mkdir()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkdir.html)
 pub(crate) fn mkdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
     match devfs::resolve(cwd, path)? {
-        Some(DevicePath::Directory) => return Err(Fat32Error::AlreadyExists),
+        Some(DevicePath::Directory | DevicePath::Null) => {
+            return Err(Fat32Error::AlreadyExists);
+        },
         Some(DevicePath::Missing) => return Err(Fat32Error::PermissionDenied),
         None => {},
     }
@@ -475,7 +477,7 @@ pub(crate) fn normalize(cwd: &str, path: &str) -> Result<String, Fat32Error> {
 /// Rejects mutation of an existing synthetic device-namespace entry.
 fn reject_device_mutation(cwd: &str, path: &str) -> Result<(), Fat32Error> {
     match devfs::resolve(cwd, path)? {
-        Some(DevicePath::Directory) => Err(Fat32Error::PermissionDenied),
+        Some(DevicePath::Directory | DevicePath::Null) => Err(Fat32Error::PermissionDenied),
         Some(DevicePath::Missing) => Err(Fat32Error::NotFound),
         None => Ok(()),
     }
@@ -484,7 +486,9 @@ fn reject_device_mutation(cwd: &str, path: &str) -> Result<(), Fat32Error> {
 /// Rejects a valid rename destination in the synthetic device namespace.
 fn reject_device_destination(cwd: &str, path: &str) -> Result<(), Fat32Error> {
     match devfs::resolve(cwd, path)? {
-        Some(DevicePath::Directory | DevicePath::Missing) => Err(Fat32Error::PermissionDenied),
+        Some(DevicePath::Directory | DevicePath::Null | DevicePath::Missing) => {
+            Err(Fat32Error::PermissionDenied)
+        },
         None => Ok(()),
     }
 }
@@ -551,7 +555,7 @@ pub(crate) fn open_with_options(
     }
 
     match devfs::resolve(cwd, path)? {
-        Some(DevicePath::Directory) => return Err(Fat32Error::NotAFile),
+        Some(DevicePath::Directory | DevicePath::Null) => return Err(Fat32Error::NotAFile),
         Some(DevicePath::Missing) if create || create_new => {
             return Err(Fat32Error::PermissionDenied);
         },

--- a/src/libs/vfs/src/filesystem/dir_entry.rs
+++ b/src/libs/vfs/src/filesystem/dir_entry.rs
@@ -22,6 +22,8 @@ pub struct DirEntry {
     inode: u64,
     /// Whether this entry is a directory.
     is_dir: bool,
+    /// Whether this entry is a character device.
+    is_character_device: bool,
     /// Size in bytes (0 for directories).
     size: u64,
 }
@@ -44,7 +46,19 @@ impl DirEntry {
             name,
             inode,
             is_dir,
+            is_character_device: false,
             size,
+        }
+    }
+
+    /// Creates a character-device directory entry.
+    pub fn new_character_device(name: String, inode: u64) -> Self {
+        Self {
+            name,
+            inode,
+            is_dir: false,
+            is_character_device: true,
+            size: 0,
         }
     }
 
@@ -64,6 +78,12 @@ impl DirEntry {
     #[must_use]
     pub fn is_dir(&self) -> bool {
         self.is_dir
+    }
+
+    /// Returns whether this entry is a character device.
+    #[must_use]
+    pub fn is_character_device(&self) -> bool {
+        self.is_character_device
     }
 
     /// Returns the size in bytes (0 for directories).

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -21,6 +21,9 @@ extern void test_open_close(void);
 // Tests whether we can create and unlink a file.
 extern void test_create_unlink(void);
 
+// Tests the synthetic device namespace.
+extern void test_device_namespace(void);
+
 // Tests whether we can get the current working directory.
 extern void test_getcwd(void);
 

--- a/src/tests/integration/test-c-file/device_namespace.c
+++ b/src/tests/integration/test-c-file/device_namespace.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+// Tests the synthetic namespace and null device.
+void test_device_namespace(void)
+{
+    struct stat directory = {0};
+    struct stat null = {0};
+    assert(stat("/dev", &directory) == 0);
+    assert(S_ISDIR(directory.st_mode));
+    assert(stat("/dev/null", &null) == 0);
+    assert(S_ISCHR(null.st_mode));
+    assert(null.st_dev == directory.st_dev);
+    assert(null.st_ino != directory.st_ino);
+    assert(null.st_rdev != 0);
+    assert(null.st_size == 0);
+    assert(null.st_blocks == 0);
+
+    struct stat missing = {0};
+    errno = 0;
+    assert(stat("/dev/missing", &missing) == -1);
+    assert(errno == ENOENT);
+
+    DIR *root = opendir("/");
+    assert(root != NULL);
+    bool found_dev = false;
+    struct dirent *entry;
+    while ((entry = readdir(root)) != NULL) {
+        if (strcmp(entry->d_name, "dev") == 0) {
+            found_dev = true;
+            assert(entry->d_ino == directory.st_ino);
+        }
+    }
+    assert(found_dev);
+    assert(closedir(root) == 0);
+
+    DIR *dev = opendir("/dev");
+    assert(dev != NULL);
+    entry = readdir(dev);
+    assert(entry != NULL);
+    assert(strcmp(entry->d_name, "null") == 0);
+    assert(entry->d_ino == null.st_ino);
+    assert(readdir(dev) == NULL);
+    assert(closedir(dev) == 0);
+
+    int nullfd = open("/dev/null", O_RDWR);
+    assert(nullfd >= 0);
+    int status_flags = fcntl(nullfd, F_GETFL);
+    assert((status_flags & O_ACCMODE) == O_RDWR);
+    assert(fcntl(nullfd, F_SETFL, status_flags | O_NONBLOCK) == 0);
+    status_flags = fcntl(nullfd, F_GETFL);
+    assert((status_flags & O_ACCMODE) == O_RDWR);
+    assert(status_flags & O_NONBLOCK);
+    assert(write(nullfd, "discarded", 9) == 9);
+    assert(write(nullfd, "again", 5) == 5);
+    assert(lseek(nullfd, 17, SEEK_SET) == 0);
+    char buffer[8] = {0};
+    assert(read(nullfd, buffer, sizeof(buffer)) == 0);
+    struct stat opened = {0};
+    assert(fstat(nullfd, &opened) == 0);
+    assert(opened.st_dev == null.st_dev);
+    assert(opened.st_ino == null.st_ino);
+    assert(opened.st_rdev == null.st_rdev);
+    assert(close(nullfd) == 0);
+
+    nullfd = open("/dev/null", O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    assert(nullfd >= 0);
+    assert(write(nullfd, "discarded", 9) == 9);
+    errno = 0;
+    assert(read(nullfd, buffer, sizeof(buffer)) == -1);
+    assert(errno == EBADF);
+    assert(close(nullfd) == 0);
+
+    errno = 0;
+    assert(open("/dev/null", O_WRONLY | O_CREAT | O_EXCL, 0600) == -1);
+    assert(errno == EEXIST);
+
+    nullfd = open("/dev/null", O_RDONLY);
+    assert(nullfd >= 0);
+    errno = 0;
+    assert(write(nullfd, "rejected", 8) == -1);
+    assert(errno == EBADF);
+    struct pollfd pollfd = {
+        .fd = nullfd,
+        .events = POLLIN | POLLOUT,
+        .revents = 0,
+    };
+    assert(poll(&pollfd, 1, 0) == 1);
+    assert((pollfd.revents & (POLLIN | POLLOUT)) == (POLLIN | POLLOUT));
+    assert(close(nullfd) == 0);
+
+    errno = 0;
+    assert(unlink("/dev/null") == -1);
+    assert(errno == EACCES);
+    errno = 0;
+    assert(rename("/dev/null", "device-out.tmp") == -1);
+    assert(errno == EACCES);
+    errno = 0;
+    assert(rmdir("/dev") == -1);
+    assert(errno == EACCES);
+
+    int source = open("device-rename.tmp", O_CREAT | O_WRONLY, 0600);
+    assert(source >= 0);
+    assert(close(source) == 0);
+    errno = 0;
+    assert(rename("device-rename.tmp", "/dev/replacement") == -1);
+    assert(errno == EACCES);
+    assert(unlink("device-rename.tmp") == 0);
+}

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -132,6 +132,7 @@ int main(int argc, const char *argv[])
     test_pwrite();          // requires open(), close(), read(), lseek() and unlink().
     test_fdatasync();       // requires open(), close(), read(), write(), and unlink().
     test_stat();
+    test_device_namespace();
     test_ftruncate(); // requires open(), close(), fstat() and unlink().
     test_truncate();  // requires open(), close(), stat() and unlinkat().
 #ifndef __NANVIX_STANDALONE__


### PR DESCRIPTION
## Summary

Add `/dev/null` to the synthetic device namespace.

The device returns EOF from reads, accepts and discards complete writes, remains at offset zero when sought, and reports immediate poll readiness. Opens preserve their requested read-only, write-only, or read-write access mode, including through descriptor duplication and status-flag operations.

The access state is represented by an explicit `AccessMode` enum rather than independent read and write booleans, so unsupported combinations cannot be constructed.

This PR is stacked on #3148.

## Testing

- Passed formatting, linting, and spellchecking.
- Passed compilation checks and the full debug build.
- Built all POSIX test programs and images.
- Passed `test-c-file`, including metadata, enumeration, access-mode, I/O, poll, seek, and namespace-mutation coverage.

## Follow-up

`AccessMode` is currently shared by the synthetic null and terminal handles. It would be useful as a common representation for other VFS handles as their access semantics are consolidated. That broader conversion is outside this change; FAT32 does not currently enforce a POSIX permission model.

**This will break busybox.** A draft PR has been opened to counteract.
https://github.com/nanvix/busybox/pull/74

## Tracking

Partial implementation of #3122.
