### PR TITLE
[scripts] B: Normalize Verus Toolchain

### DIFF
--- a/scripts/setup/verus.py
+++ b/scripts/setup/verus.py
@@ -441,6 +441,18 @@ def ensure_verus_toolchain(install_dir: Path) -> None:
     if not isinstance(required_toolchain, str) or not required_toolchain:
         return
 
+    toolchain_parts = required_toolchain.split(maxsplit=1)
+    if not toolchain_parts:
+        return
+
+    normalized_toolchain = toolchain_parts[0]
+    if normalized_toolchain != required_toolchain:
+        print_warning(
+            "Verus Rust toolchain metadata contains an annotation; "
+            f"using '{normalized_toolchain}'."
+        )
+    required_toolchain = normalized_toolchain
+
     probe = subprocess.run(
         [rustup, "run", required_toolchain, "rustc", "--version"],
         stdout=subprocess.DEVNULL,

--- a/tests/test_verus.py
+++ b/tests/test_verus.py
@@ -6,11 +6,12 @@
 from __future__ import annotations
 
 import io
+import subprocess
 import tempfile
 import unittest
 import zipfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from scripts.setup import verus as verusmod
 
@@ -72,6 +73,67 @@ class TestDownloadVerusArchive(unittest.TestCase):
 
             self.assertEqual(destination.read_bytes(), archive_contents)
             self.assertEqual(cached_archive.read_bytes(), archive_contents)
+
+
+class TestEnsureVerusToolchain(unittest.TestCase):
+    """Tests for installing the Rust toolchain required by Verus."""
+
+    def test_strips_rustup_annotation_before_install(self) -> None:
+        """Rustup annotations in Verus metadata are not part of the toolchain name."""
+        toolchain = "1.98.0-x86_64-unknown-linux-gnu"
+        annotated_toolchain = (
+            f"{toolchain} (overridden by environment variable RUSTUP_TOOLCHAIN)"
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            install_dir = Path(temp_dir)
+            (install_dir / "version.json").write_text(
+                f'{{"verus": {{"toolchain": "{annotated_toolchain}"}}}}',
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(verusmod.shutil, "which", return_value="rustup"),
+                patch.object(
+                    verusmod.subprocess,
+                    "run",
+                    side_effect=[
+                        subprocess.CompletedProcess(args=[], returncode=1),
+                        subprocess.CompletedProcess(args=[], returncode=0),
+                    ],
+                ) as run_command,
+                patch.object(verusmod, "print_warning") as print_warning,
+            ):
+                verusmod.ensure_verus_toolchain(install_dir)
+
+        print_warning.assert_called_once_with(
+            "Verus Rust toolchain metadata contains an annotation; "
+            f"using '{toolchain}'."
+        )
+        self.assertEqual(
+            run_command.call_args_list,
+            [
+                call(
+                    ["rustup", "run", toolchain, "rustc", "--version"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                ),
+                call(
+                    [
+                        "rustup",
+                        "toolchain",
+                        "install",
+                        toolchain,
+                        "--profile",
+                        "minimal",
+                        "--component",
+                        "rust-src",
+                    ],
+                    check=True,
+                ),
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- normalize annotated Verus toolchain metadata before invoking rustup
- warn when human-readable rustup status text is discarded
- cover the failed installation path with a regression test

## Rationale

Verus `0.2026.09.06.8dea4a2` records the toolchain as
`1.98.0-x86_64-unknown-linux-gnu (overridden by environment variable RUSTUP_TOOLCHAIN)`.
Passing that value verbatim causes rustup to reject the toolchain name and blocks the scheduled
[Verus Update workflow](https://github.com/nanvix/nanvix/actions/runs/34116231979/job/101723592561).

## Testing

- `python -m unittest tests.test_verus`
- `python -m black --check scripts/setup/verus.py tests/test_verus.py`
- `python -m flake8 scripts/setup/verus.py tests/test_verus.py`

The full Python discovery suite was also attempted; it has five unrelated Windows-host failures in
`test_update_verus` and `test_z` involving Bash path conversion and path separators.