### PR TITLE
[tests] Restore Unix Socket Tests

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -460,6 +460,14 @@ POSIX_TEST_RAMFS_SUITES := test-c-file test-c-stdio test-c-dlfcn test-c-dlfcn-re
 POSIX_TEST_RAMFS_SEED   := $(BINARIES_DIR)/posix-tests-ramfs-seed
 POSIX_TEST_RAMFS_IMG    := $(BINARIES_DIR)/posix-tests-ramfs.img
 
+# Keep this path short enough to fit with a socket name in sockaddr_un.sun_path.
+POSIX_TEST_NETWORK_HOSTFS_DIR := $(BINARIES_DIR)/n
+POSIX_TEST_NETWORK_HOSTFS_MARKER := $(POSIX_TEST_NETWORK_HOSTFS_DIR)/marker.txt
+
+$(POSIX_TEST_NETWORK_HOSTFS_MARKER):
+	@$(MKDIR_CMD) $(POSIX_TEST_NETWORK_HOSTFS_DIR)
+	@echo "posix-tests network hostfs marker" > $@
+
 $(POSIX_TEST_RAMFS_SEED)/marker.txt:
 	@$(MKDIR_CMD) $(POSIX_TEST_RAMFS_SEED)
 	@echo "posix-tests ramfs marker" > $@
@@ -1522,6 +1530,7 @@ $(POSIX_TEST_RAMFS_IMG) $(POSIX_TEST_DLFCN_FIXTURE_IMGS) $(POSIX_TEST_EXECVP_IMG
 .PHONY: all-posix-test-images
 all-posix-test-images: $(POSIX_TEST_INITRDS) \
 		$(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) \
+		$(POSIX_TEST_NETWORK_HOSTFS_MARKER) \
 		$(POSIX_TEST_DLFCN_FIXTURE_IMGS) \
 		$(POSIX_TEST_EXECVP_IMG)
 	@echo "All POSIX C test-suite images built."
@@ -1554,7 +1563,7 @@ ifeq ($(filter $(TARGET),x86 x86_64),)
 run-posix-tests:
 	@echo "Skipping POSIX C test suites (no guest C toolchain for TARGET=$(TARGET))."
 else
-run-posix-tests: $(POSIX_HEADERS_CXX_STAMP) $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_DLFCN_FIXTURE_IMGS) $(POSIX_TEST_EXECVP_IMG)
+run-posix-tests: $(POSIX_HEADERS_CXX_STAMP) $(POSIX_TEST_INITRDS) $(if $(strip $(POSIX_TEST_RAMFS_SUITES)),$(POSIX_TEST_RAMFS_IMG)) $(POSIX_TEST_NETWORK_HOSTFS_MARKER) $(POSIX_TEST_DLFCN_FIXTURE_IMGS) $(POSIX_TEST_EXECVP_IMG)
 	@test -f $(NANVIX_TEST_BIN) || { echo "ERROR: $(NANVIX_TEST_BIN) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(NANVIXD) || { echo "ERROR: $(NANVIXD) missing; run './z build -- all' first."; exit 1; }
 	@test -f $(KERNEL) || { echo "ERROR: $(KERNEL) missing; run './z build -- all' first."; exit 1; }

--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -308,6 +308,11 @@ endef
 
 $(foreach suite,$(ALL_POSIX_TESTS),$(eval $(call POSIX_TEST_RULE,$(suite))))
 
+# The guest compiler targets Nanvix, so pass the host OS explicitly to the Unix socket tests.
+ifeq ($(IS_WINDOWS),yes)
+$(POSIX_TESTS_OBJDIR)/test-c-network/unix.o: POSIX_TEST_EXTRA_CFLAGS += -DNANVIX_HOST_WINDOWS
+endif
+
 #---------------------------------------------------------------------------------------------------
 # Per-suite standalone image rule.
 #---------------------------------------------------------------------------------------------------

--- a/src/tests/integration/test-c-network/common.c
+++ b/src/tests/integration/test-c-network/common.c
@@ -12,7 +12,6 @@
 #include <netinet/in.h>
 #include <string.h>
 #include <sys/socket.h>
-#include <sys/un.h>
 #include <unistd.h>
 
 //==================================================================================================
@@ -80,11 +79,6 @@ void test_bind_socket(int domain,
 
     int ret = close(sockfd);
     assert(ret == 0);
-
-    if (addr->sa_family == AF_UNIX) {
-        ret = unlink(((struct sockaddr_un *)addr)->sun_path);
-        assert(ret == 0);
-    }
 }
 
 // Tests if we succeed to create a listening socket.
@@ -98,11 +92,6 @@ void test_listen_socket(int domain,
 
     int ret = close(sockfd);
     assert(ret == 0);
-
-    if (addr->sa_family == AF_UNIX) {
-        ret = unlink(((struct sockaddr_un *)addr)->sun_path);
-        assert(ret == 0);
-    }
 }
 
 // Tests if we succeed to get the name of a bound socket.
@@ -127,11 +116,6 @@ void test_getsockname_bound_socket(int domain,
 
     ret = close(sockfd);
     assert(ret == 0);
-
-    if (addr->sa_family == AF_UNIX) {
-        ret = unlink(((struct sockaddr_un *)addr)->sun_path);
-        assert(ret == 0);
-    }
 }
 
 // Tests if we succeed to get the name of a listening socket.
@@ -156,11 +140,6 @@ void test_getsockname_listening_socket(int domain,
 
     ret = close(sockfd);
     assert(ret == 0);
-
-    if (addr->sa_family == AF_UNIX) {
-        ret = unlink(((struct sockaddr_un *)addr)->sun_path);
-        assert(ret == 0);
-    }
 }
 
 // Tests if we succeed to get the name of a socket.

--- a/src/tests/integration/test-c-network/common.h
+++ b/src/tests/integration/test-c-network/common.h
@@ -51,7 +51,11 @@ extern void test_get_sockname(int domain,
                               const struct sockaddr *sockaddr,
                               socklen_t addrlen);
 
-extern void test_unix_sockets(const char sun_path[], const char unlink_path[]);
+// Tests host pathname sockets, with cleanup through the guest filesystem.
+extern void test_unix_pathname_sockets(const char sun_path[], const char unlink_path[]);
+
+// Tests unnamed Unix socket pairs without requiring hostfs.
+extern void test_unix_socket_pairs(void);
 extern void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr);
 
 // Tests poll() routing through hostfsd, networkd, VFSD, and all three services together.

--- a/src/tests/integration/test-c-network/common.h
+++ b/src/tests/integration/test-c-network/common.h
@@ -51,7 +51,7 @@ extern void test_get_sockname(int domain,
                               const struct sockaddr *sockaddr,
                               socklen_t addrlen);
 
-extern void test_unix_sockets(char sun_path[]);
+extern void test_unix_sockets(const char sun_path[], const char unlink_path[]);
 extern void test_inet_sockets(in_port_t sin_port, struct in_addr sin_addr);
 
 // Tests poll() routing through hostfsd, networkd, VFSD, and all three services together.

--- a/src/tests/integration/test-c-network/main.c
+++ b/src/tests/integration/test-c-network/main.c
@@ -10,6 +10,7 @@
 #include "common.h"
 #include <arpa/inet.h>
 #include <assert.h>
+#include <limits.h>
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <string.h>
@@ -140,6 +141,19 @@ int main(int argc, const char *argv[])
 
     test_inet_sockets(sin_port, sin_addr);
     test_poll_services(sin_addr);
+
+    if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
+        char cwd[PATH_MAX];
+        assert(getcwd(cwd, sizeof(cwd)) != NULL);
+        assert(chdir("/mnt") == 0);
+        char sun_path[UNIX_SOCKET_NAME_LEN];
+        for (int i = 0; i < UNIX_SOCKET_NAME_LEN - 1; i++) {
+            sun_path[i] = 'a' + (rand() % 26);
+        }
+        sun_path[UNIX_SOCKET_NAME_LEN - 1] = '\0';
+        test_unix_sockets(sun_path);
+        assert(chdir(cwd) == 0);
+    }
 
     // The network service supports only AF_INET sockets.
 #ifndef __NANVIX_STANDALONE__

--- a/src/tests/integration/test-c-network/main.c
+++ b/src/tests/integration/test-c-network/main.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <netinet/in.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -66,9 +67,10 @@
 #define SEED 42
 #endif
 
-// Length of the UNIX socket name (including the null terminator).
-// We set this so it fits on socaddr.sa_data.
-#define UNIX_SOCKET_NAME_LEN 9
+// Keep the host-relative socket path within `sockaddr_un.sun_path`.
+#define UNIX_SOCKET_HOST_DIRECTORY "bin/n/"
+#define UNIX_SOCKET_NAME_LEN 6
+#define UNIX_SOCKET_PATH_LEN (sizeof(UNIX_SOCKET_HOST_DIRECTORY) + UNIX_SOCKET_NAME_LEN - 1)
 
 //==================================================================================================
 // Standalone Functions
@@ -146,12 +148,16 @@ int main(int argc, const char *argv[])
         char cwd[PATH_MAX];
         assert(getcwd(cwd, sizeof(cwd)) != NULL);
         assert(chdir("/mnt") == 0);
-        char sun_path[UNIX_SOCKET_NAME_LEN];
+        char sun_name[UNIX_SOCKET_NAME_LEN];
         for (int i = 0; i < UNIX_SOCKET_NAME_LEN - 1; i++) {
-            sun_path[i] = 'a' + (rand() % 26);
+            sun_name[i] = 'a' + (rand() % 26);
         }
-        sun_path[UNIX_SOCKET_NAME_LEN - 1] = '\0';
-        test_unix_sockets(sun_path);
+        sun_name[UNIX_SOCKET_NAME_LEN - 1] = '\0';
+        char sun_path[UNIX_SOCKET_PATH_LEN];
+        int length = snprintf(sun_path, sizeof(sun_path), "%s%s", UNIX_SOCKET_HOST_DIRECTORY,
+                              sun_name);
+        assert(length > 0 && (size_t)length < sizeof(sun_path));
+        test_unix_sockets(sun_path, sun_name);
         assert(chdir(cwd) == 0);
     }
 
@@ -163,7 +169,7 @@ int main(int argc, const char *argv[])
             sun_path[i] = 'a' + (rand() % 26);
         }
         sun_path[UNIX_SOCKET_NAME_LEN - 1] = '\0';
-        test_unix_sockets(sun_path);
+        test_unix_sockets(sun_path, sun_path);
     }
 #endif
 

--- a/src/tests/integration/test-c-network/main.c
+++ b/src/tests/integration/test-c-network/main.c
@@ -144,6 +144,8 @@ int main(int argc, const char *argv[])
     test_inet_sockets(sin_port, sin_addr);
     test_poll_services(sin_addr);
 
+    test_unix_socket_pairs();
+
     if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
         char cwd[PATH_MAX];
         assert(getcwd(cwd, sizeof(cwd)) != NULL);
@@ -157,21 +159,20 @@ int main(int argc, const char *argv[])
         int length = snprintf(sun_path, sizeof(sun_path), "%s%s", UNIX_SOCKET_HOST_DIRECTORY,
                               sun_name);
         assert(length > 0 && (size_t)length < sizeof(sun_path));
-        test_unix_sockets(sun_path, sun_name);
+        test_unix_pathname_sockets(sun_path, sun_name);
         assert(chdir(cwd) == 0);
-    }
-
-    // The network service supports only AF_INET sockets.
-#ifndef __NANVIX_STANDALONE__
-    {
+    } else {
+#ifdef __NANVIX_STANDALONE__
+        fprintf(stderr, "skipping UNIX pathname sockets (hostfs not enabled)\n");
+#else
         char sun_path[UNIX_SOCKET_NAME_LEN];
         for (int i = 0; i < UNIX_SOCKET_NAME_LEN - 1; i++) {
             sun_path[i] = 'a' + (rand() % 26);
         }
         sun_path[UNIX_SOCKET_NAME_LEN - 1] = '\0';
-        test_unix_sockets(sun_path, sun_path);
-    }
+        test_unix_pathname_sockets(sun_path, sun_path);
 #endif
+    }
 
     // Write magic string to signal that the test passed.
     {

--- a/src/tests/integration/test-c-network/unix.c
+++ b/src/tests/integration/test-c-network/unix.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include "common.h"
+#include <arpa/inet.h>
+#include <assert.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests if we succeed to create a pair of connected sockets.
+static void test_create_socket_pair(int domain, int type, int protocol)
+{
+    int sockfds[2];
+    new_socket_pair(domain, type, protocol, sockfds);
+
+    int ret = close(sockfds[0]);
+    assert(ret == 0);
+
+    ret = close(sockfds[1]);
+    assert(ret == 0);
+}
+
+// Tests if we succeed to get the name of a pair of connected sockets.
+static void test_getpeername(int domain, int type, int protocol)
+{
+    int sockfds[2] = {-1, -1};
+    new_socket_pair(domain, type, protocol, sockfds);
+
+    struct sockaddr sockaddr_self = {0};
+    socklen_t addrlen_self = sizeof(sockaddr_self);
+    int ret = getsockname(sockfds[0], &sockaddr_self, &addrlen_self);
+    assert(ret == 0);
+
+    struct sockaddr sockaddr_peer = {0};
+    socklen_t addrlen_peer = sizeof(sockaddr_peer);
+    ret = getpeername(sockfds[0], &sockaddr_peer, &addrlen_peer);
+    assert(ret == 0);
+
+    // Check if the address family and the port are what we expect.
+    assert(memcmp(&sockaddr_self.sa_len, &sockaddr_peer.sa_len, sizeof(sockaddr_self.sa_len)) == 0);
+    assert(memcmp(&sockaddr_self.sa_family,
+                  &sockaddr_peer.sa_family,
+                  sizeof(sockaddr_self.sa_family)) == 0);
+    assert(memcmp(&sockaddr_self.sa_data, &sockaddr_peer.sa_data, sizeof(sockaddr_self.sa_data)) ==
+           0);
+
+    ret = close(sockfds[0]);
+    assert(ret == 0);
+
+    ret = close(sockfds[1]);
+    assert(ret == 0);
+}
+
+// Tests if we succeed to send and receive data through a pair of connected sockets.
+static void test_send_recv(int domain, int type, int protocol)
+{
+    int sockfds[2] = {-1, -1};
+    new_socket_pair(domain, type, protocol, sockfds);
+
+    const char *msg = "hello";
+    int ret = send(sockfds[0], msg, strlen(msg), 0);
+    assert(ret == (int)strlen(msg));
+
+    char buf[6] = {0};
+    ret = recv(sockfds[1], buf, 6, 0);
+    assert(ret == (int)strlen(msg));
+    assert(memcmp(msg, buf, strlen(msg)) == 0);
+
+    ret = close(sockfds[0]);
+    assert(ret == 0);
+
+    ret = close(sockfds[1]);
+    assert(ret == 0);
+}
+
+// Tests if we succeed to shutdown a pair of connected sockets.
+static void test_shutdown(int domain, int type, int protocol)
+{
+    int sockfds[2] = {-1, -1};
+    new_socket_pair(domain, type, protocol, sockfds);
+
+    int ret = shutdown(sockfds[0], SHUT_RDWR);
+    assert(ret == 0);
+
+    ret = shutdown(sockfds[1], SHUT_RDWR);
+    assert(ret == 0);
+
+    ret = close(sockfds[0]);
+    assert(ret == 0);
+
+    ret = close(sockfds[1]);
+    assert(ret == 0);
+}
+
+// Tests operations on UNIX sockets.
+void test_unix_sockets(char sun_path[])
+{
+    int domain = AF_UNIX;
+    int type = SOCK_STREAM;
+    int protocol = IPPROTO_IP;
+
+    struct sockaddr_un sockaddr = {
+        .sun_len = sizeof(struct sockaddr),
+        .sun_family = domain,
+    };
+    strncpy(sockaddr.sun_path, sun_path, sizeof(sockaddr.sun_path) - 1);
+    sockaddr.sun_path[sizeof(sockaddr.sun_path) - 1] = '\0';
+
+    // Clean up any leftover socket file from a previous run.
+    unlink(sun_path);
+
+    test_create_socket(domain, type, protocol);
+    test_bind_socket(domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    test_listen_socket(
+        domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    test_get_sockname(domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+
+    test_create_socket_pair(domain, type, protocol);
+    test_getpeername(domain, type, protocol);
+    test_send_recv(domain, type, protocol);
+    test_shutdown(domain, type, protocol);
+}

--- a/src/tests/integration/test-c-network/unix.c
+++ b/src/tests/integration/test-c-network/unix.c
@@ -10,6 +10,7 @@
 #include "common.h"
 #include <arpa/inet.h>
 #include <assert.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -19,6 +20,7 @@
 // Standalone Functions
 //==================================================================================================
 
+#ifndef NANVIX_HOST_WINDOWS
 // Tests if we succeed to create a pair of connected sockets.
 static void test_create_socket_pair(int domain, int type, int protocol)
 {
@@ -103,10 +105,13 @@ static void test_shutdown(int domain, int type, int protocol)
     ret = close(sockfds[1]);
     assert(ret == 0);
 }
+#endif
 
-// Tests operations on UNIX sockets.
-void test_unix_sockets(const char sun_path[], const char unlink_path[])
+// Tests operations on pathname UNIX sockets.
+void test_unix_pathname_sockets(const char sun_path[], const char unlink_path[])
 {
+    fprintf(stderr, "testing UNIX pathname sockets ... ");
+
     int domain = AF_UNIX;
     int type = SOCK_STREAM;
     int protocol = IPPROTO_IP;
@@ -138,8 +143,26 @@ void test_unix_sockets(const char sun_path[], const char unlink_path[])
         domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
     assert(unlink(unlink_path) == 0);
 
+    fprintf(stderr, "passed\n");
+}
+
+// Tests operations on unnamed UNIX socket pairs independently of hostfs.
+void test_unix_socket_pairs(void)
+{
+#ifdef NANVIX_HOST_WINDOWS
+    fprintf(stderr, "skipping UNIX socket pairs (socketpair is unsupported on Windows)\n");
+#else
+    fprintf(stderr, "testing UNIX socket pairs ... ");
+
+    int domain = AF_UNIX;
+    int type = SOCK_STREAM;
+    int protocol = IPPROTO_IP;
+
     test_create_socket_pair(domain, type, protocol);
     test_getpeername(domain, type, protocol);
     test_send_recv(domain, type, protocol);
     test_shutdown(domain, type, protocol);
+
+    fprintf(stderr, "passed\n");
+#endif
 }

--- a/src/tests/integration/test-c-network/unix.c
+++ b/src/tests/integration/test-c-network/unix.c
@@ -105,27 +105,38 @@ static void test_shutdown(int domain, int type, int protocol)
 }
 
 // Tests operations on UNIX sockets.
-void test_unix_sockets(char sun_path[])
+void test_unix_sockets(const char sun_path[], const char unlink_path[])
 {
     int domain = AF_UNIX;
     int type = SOCK_STREAM;
     int protocol = IPPROTO_IP;
 
     struct sockaddr_un sockaddr = {
-        .sun_len = sizeof(struct sockaddr),
+        .sun_len = sizeof(struct sockaddr_un),
         .sun_family = domain,
     };
     strncpy(sockaddr.sun_path, sun_path, sizeof(sockaddr.sun_path) - 1);
     sockaddr.sun_path[sizeof(sockaddr.sun_path) - 1] = '\0';
 
     // Clean up any leftover socket file from a previous run.
-    unlink(sun_path);
+    unlink(unlink_path);
 
     test_create_socket(domain, type, protocol);
+
     test_bind_socket(domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    assert(unlink(unlink_path) == 0);
+
     test_listen_socket(
         domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
-    test_get_sockname(domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    assert(unlink(unlink_path) == 0);
+
+    test_getsockname_bound_socket(
+        domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    assert(unlink(unlink_path) == 0);
+
+    test_getsockname_listening_socket(
+        domain, type, protocol, (const struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    assert(unlink(unlink_path) == 0);
 
     test_create_socket_pair(domain, type, protocol);
     test_getpeername(domain, type, protocol);

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -340,7 +340,7 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 name = "posix/test-c-network"
 program = "./bin/test-c-network.initrd"
-extra_nanvixd_args = "-allow-host-networking -mount ./bin/posix-tests-ramfs-seed"
+extra_nanvixd_args = "-allow-host-networking -mount ."
 expected_exit_code = 0
 
 [[tests]]

--- a/test/test-posix.toml
+++ b/test/test-posix.toml
@@ -340,7 +340,7 @@ build_modes = ["debug", "release"]
 executor = "terminal"
 name = "posix/test-c-network"
 program = "./bin/test-c-network.initrd"
-extra_nanvixd_args = "-allow-host-networking -mount ."
+extra_nanvixd_args = "-allow-host-networking -mount ./bin/n"
 expected_exit_code = 0
 
 [[tests]]


### PR DESCRIPTION
## Summary

- Restore the missing Unix-domain socket C tests.
- Run pathname-based socket coverage through hostfs on supported hosts.
- Use routed socket I/O for connected socket pairs.

## Testing

Verified against the full Linux and Windows lifecycles.

## Related

Part of #3121.

Stacked on #3135.
