### PR TITLE
[tests] E: Remove Standalone C Guard

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -61,10 +61,10 @@ POSIX_TEST_CRT_OBJ := $(POSIX_TESTS_OBJDIR)/common/crt0-stubs.o
 
 # Compile flags: the freestanding guest C flags, plus the upstream suite defines
 # (mirroring nanvix/posix-tests' src/Makefile) so the ported sources behave the
-# same as upstream — standalone build, microvm platform, and the system/node
-# name strings that misc-c compares against.
+# same as upstream on the microvm platform and use the system/node name strings
+# that misc-c compares against.
 POSIX_TEST_CFLAGS := $(GUEST_C_APP_CFLAGS)
-POSIX_TEST_CFLAGS += -D__NANVIX_STANDALONE__ -D__microvm__
+POSIX_TEST_CFLAGS += -D__microvm__
 POSIX_TEST_CFLAGS += -D__NANVIX_SYSNAME__=\"nanvix\" -D__NANVIX_NODENAME__=\"localhost\"
 
 #---------------------------------------------------------------------------------------------------
@@ -106,22 +106,6 @@ $(POSIX_TESTS_OBJDIR)/%.o: $(POSIX_TESTS_STRESS_SRCDIR)/%.c
 # win over pattern rules), so the standalone-images machinery bundles the
 # resulting ELF into `<suite>.initrd` without any custom mkimage recipe.
 #
-# A suite may restrict the compiled set via POSIX_TEST_FILES_<suite> (a list of
-# file names under the suite directory) — used by file-c, whose link-only and
-# guarded sub-tests need features absent from the standalone VFS (FAT32 has no
-# links/permissions; select has no standalone backend).
-
-# file-c: only the sub-tests that main.c runs under __NANVIX_STANDALONE__. The
-# remaining files exercise links, permissions/ownership, and timestamps, which
-# the standalone FAT32 VFS does not support.
-POSIX_TEST_FILES_test-c-file := \
-	main.c open_close.c create_unlink.c write_read.c poll.c select.c posix_fadvise.c lseek.c \
-	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
-	fdatasync.c stat.c device_namespace.c ftruncate.c truncate.c link.c linkat.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
-	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c terminal_devices.c getcwd.c chdir.c fchdir.c \
-	utimensat.c utimes.c utime.c futimens.c chown.c fchown.c fchownat.c lchown.c \
-	chmod.c fchmodat.c fchmod.c lchmod.c faccessat.c access.c
-
 # Extra link flags for position-independent executables. The dlfcn PIE variants
 # build as PIE so the linker emits .dynsym/.dynstr/.dynamic and the executable's
 # own symbols are resolvable via dlopen(NULL)/RTLD_DEFAULT. Mirrors the proven
@@ -283,7 +267,7 @@ POSIX_TEST_EXTRA_LDLIBS_test-c-dlfcn-hello := -L$(LIBRARIES_DIR) -l:libc.so -l:l
 
 define POSIX_TEST_RULE
 POSIX_TEST_SRCROOT_$(1) := $$(if $$(POSIX_TEST_STRESS_$(1)),$$(POSIX_TESTS_STRESS_SRCDIR),$$(POSIX_TESTS_SRCDIR))
-POSIX_TEST_SRCS_$(1) := $$(if $$(POSIX_TEST_FILES_$(1)),$$(addprefix $$(POSIX_TEST_SRCROOT_$(1))/$(1)/,$$(POSIX_TEST_FILES_$(1))),$$(wildcard $$(POSIX_TEST_SRCROOT_$(1))/$(1)/*.c))
+POSIX_TEST_SRCS_$(1) := $$(wildcard $$(POSIX_TEST_SRCROOT_$(1))/$(1)/*.c)
 POSIX_TEST_OBJS_$(1) := $$(patsubst $$(POSIX_TEST_SRCROOT_$(1))/%.c,$$(POSIX_TESTS_OBJDIR)/%.o,$$(POSIX_TEST_SRCS_$(1)))
 # PIE suites compile their objects with -fPIE and use the architecture's PIC
 # crt0/libc/libm archives.
@@ -310,6 +294,7 @@ $(foreach suite,$(ALL_POSIX_TESTS),$(eval $(call POSIX_TEST_RULE,$(suite))))
 
 # The guest compiler targets Nanvix, so pass the host OS explicitly to the Unix socket tests.
 ifeq ($(IS_WINDOWS),yes)
+$(POSIX_TESTS_OBJDIR)/test-c-network/main.o \
 $(POSIX_TESTS_OBJDIR)/test-c-network/unix.o: POSIX_TEST_EXTRA_CFLAGS += -DNANVIX_HOST_WINDOWS
 endif
 

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -6,6 +6,8 @@
 #ifndef _COMMON_H_
 #define _COMMON_H_
 
+#include <stdbool.h>
+
 // Tests whether we can check access permissions of a file using access().
 extern void test_access(void);
 
@@ -143,7 +145,7 @@ extern void test_umask(void);
 extern void test_umask_ramfs(void);
 
 // Tests whether we can change file access and modification times.
-extern void test_utimensat(void);
+extern void test_utimensat(bool update_access_time);
 extern void test_utimensat_now(void);
 
 // Tests whether we can update file timestamps with `utimes()`.

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -133,15 +133,7 @@ int main(int argc, const char *argv[])
     test_terminal_devices();
     test_ftruncate(); // requires open(), close(), fstat() and unlink().
     test_truncate();  // requires open(), close(), stat() and unlinkat().
-#ifndef __NANVIX_STANDALONE__
-    // FAT32 does not support hard links or symbolic links.
-    test_linkat();     // requires open(), stat() and unlinkat().
-    test_link();       // requires open(), stat() and unlinkat().
-    test_symlinkat();  // requires open(), stat() and unlinkat().
-    test_readlinkat(); // requires symlinkat() and unlinkat().
-    test_readlink();   // requires symlinkat() and unlink().
-#endif                 // __NANVIX_STANDALONE__
-    test_renameat();   // requires open(), close() and unlink().
+    test_renameat();  // requires open(), close() and unlink().
     test_renameat_subdir(); // subdir rename + replace-existing.
     test_unlinkat();   // requires open() and close().
     test_mkdirat();    // requires stat() and unlinkat().
@@ -156,8 +148,12 @@ int main(int argc, const char *argv[])
         int cwd = open(".", O_RDONLY | O_DIRECTORY);
         assert(cwd != -1);
         assert(chdir("/mnt") == 0);
-        test_linkat(); // requires open(), stat() and unlinkat().
-        test_link();   // requires open(), stat() and unlinkat().
+        test_select();     // requires open(), close(), write(), read(), and unlink().
+        test_linkat();     // requires open(), stat() and unlinkat().
+        test_link();       // requires open(), stat() and unlinkat().
+        test_symlinkat();  // requires open(), stat() and unlinkat().
+        test_readlinkat(); // requires symlinkat() and unlinkat().
+        test_readlink();   // requires symlinkat() and unlink().
         test_fchownat();
         test_chown();
         test_fchown();
@@ -178,38 +174,20 @@ int main(int argc, const char *argv[])
     test_getcwd();
     test_chdir(); // requires getcwd().
     test_fchdir();
-    test_utimensat();
+    test_utimensat(false);
     test_utimensat_now();
     test_utime_preserve_imported_timestamps();
     if (getenv("NANVIX_TEST_HOSTFS") != NULL) {
         char cwd[PATH_MAX];
         assert(getcwd(cwd, sizeof(cwd)) != NULL);
         assert(chdir("/mnt") == 0);
-        test_utimensat();
+        test_utimensat(true);
         test_utimensat_now();
         test_utimes();
         test_utime();
         test_futimens();
         assert(chdir(cwd) == 0);
     }
-#ifndef __NANVIX_STANDALONE__
-    // FAT32 timestamps, permissions, and ownership are no-ops that fail assertions.
-    test_utimensat();
-    test_utimes(); // requires open(), close(), stat() and unlinkat().
-    test_utime();  // requires open(), close(), stat() and unlinkat().
-    test_chmod();     // requires open(), close(), stat() and unlinkat().
-    test_fchmodat();  // requires open(), close(), stat() and unlinkat().
-    test_fchmod();    // requires open(), close(), fstat() and unlink().
-    test_lchmod();    // requires open(), close(), stat(), link() and unlinkat().
-    test_fchownat();  // requires open(), close() and unlinkat().
-    test_faccessat(); // requires open(), close(), chmodat() and unlinkat().
-    test_access();    // requires open(), close(), chmodat() and unlinkat().
-    test_chown();     // requires open(), close(), and unlinkat().
-    test_fchown();    // requires open(), close() and unlink().
-    test_lchown();    // requires open(), close() and unlinkat().
-    test_futimens();  // Requires open(), fstat(), close() and unlink().
-#endif                // __NANVIX_STANDALONE__
-
     // Write magic string to signal that the test passed.
     {
         const char *magic_string = "ok";

--- a/src/tests/integration/test-c-file/utimensat.c
+++ b/src/tests/integration/test-c-file/utimensat.c
@@ -30,7 +30,7 @@
 //==================================================================================================
 
 // Tests whether we can update file timestamps with `utimensat()`.
-void test_utimensat(void)
+void test_utimensat(bool update_access_time)
 {
     fprintf(stderr, "testing utimensat() ... ");
 
@@ -47,11 +47,7 @@ void test_utimensat(void)
     assert(fstat(fd, &st) == 0);
 
     // Set new timestamps.
-#ifdef __NANVIX_STANDALONE__
-    times[0].tv_sec = st.st_atime; // Access time is date-only on FAT.
-#else
-    times[0].tv_sec = st.st_atime + 20; // Access time.
-#endif
+    times[0].tv_sec = update_access_time ? st.st_atime + 20 : st.st_atime;
     times[0].tv_nsec = 0;
     times[1].tv_sec = st.st_mtime + 10; // Modification time.
     times[1].tv_nsec = 0;
@@ -112,7 +108,7 @@ void test_utimensat(void)
 }
 
 // Tests whether the time-setting calls accept a NULL `times` (set to current
-// time). NULL returns success even on FAT32, where timestamps are ignored.
+// time). FAT timestamp resolution makes resulting values unobservable here.
 void test_utimensat_now(void)
 {
     fprintf(stderr, "testing NULL times (set to now) ... ");

--- a/src/tests/integration/test-c-network/main.c
+++ b/src/tests/integration/test-c-network/main.c
@@ -16,9 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
-#ifndef __NANVIX_STANDALONE__
 #include <sys/un.h>
-#endif
 #include <time.h>
 #include <unistd.h>
 
@@ -126,7 +124,6 @@ int main(int argc, const char *argv[])
     );
     STATIC_ASSERT_SIZE(struct sockaddr_in, sizeof(struct sockaddr_storage));
 
-#ifndef __NANVIX_STANDALONE__
     // Sanity check size of `sockaddr_un` structure.
     STATIC_ASSERT_SIZE(struct sockaddr_un,
                        sizeof(unsigned char) +       // sun_len
@@ -134,7 +131,6 @@ int main(int argc, const char *argv[])
                            SUNPATHLEN * sizeof(char) // sun_path
     );
     STATIC_ASSERT_SIZE(struct sockaddr_un, sizeof(struct sockaddr_storage));
-#endif
 
     srand(SEED);
 
@@ -162,7 +158,7 @@ int main(int argc, const char *argv[])
         test_unix_pathname_sockets(sun_path, sun_name);
         assert(chdir(cwd) == 0);
     } else {
-#ifdef __NANVIX_STANDALONE__
+#ifdef NANVIX_HOST_WINDOWS
         fprintf(stderr, "skipping UNIX pathname sockets (hostfs not enabled)\n");
 #else
         char sun_path[UNIX_SOCKET_NAME_LEN];


### PR DESCRIPTION
## Summary

- Remove the obsolete `__NANVIX_STANDALONE__` POSIX-test define and guards.
- Compile all file-test sources and run Unix filesystem semantics through hostfs.
- Preserve native FAT and stronger hostfs timestamp coverage.

## Testing

Verified against the full Linux and Windows lifecycles.

## Related

Fixes #3121.

Stacked on the Unix-socket test restoration.
