### PR TITLE
[vfs] F: Add Console Device

### DIFF
--- a/build/make/posix-tests.mk
+++ b/build/make/posix-tests.mk
@@ -118,7 +118,7 @@ POSIX_TEST_FILES_test-c-file := \
 	main.c open_close.c create_unlink.c write_read.c poll.c select.c posix_fadvise.c lseek.c \
 	posix_fallocate.c readv.c preadv.c writev.c pwritev.c pread.c pwrite.c \
 	fdatasync.c stat.c device_namespace.c ftruncate.c truncate.c link.c linkat.c renameat.c renameat_subdir.c unlinkat.c mkdirat.c mkdir.c \
-	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c getcwd.c chdir.c fchdir.c \
+	path_errno.c mkfifo.c mknod.c umask_ramfs.c umask.c dirent.c terminal_devices.c getcwd.c chdir.c fchdir.c \
 	utimensat.c utimes.c utime.c futimens.c chown.c fchown.c fchownat.c lchown.c \
 	chmod.c fchmodat.c fchmod.c lchmod.c faccessat.c access.c
 

--- a/src/daemons/vfsd/src/handler/hostfs_handlers.rs
+++ b/src/daemons/vfsd/src/handler/hostfs_handlers.rs
@@ -695,11 +695,11 @@ pub(crate) fn handle_read_with_hostfs(
     let req: ReadRequest = ReadRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
 
-    if let Ok(stream) = ::vfs::fd::vfs_console_stream(fd) {
+    if let Ok((readable, _)) = ::vfs::fd::vfs_terminal_access(fd) {
         return super::readwrite::handle_console_read(
             response_context,
             fd,
-            stream,
+            readable,
             req.count as usize,
             console_wait,
         );
@@ -760,6 +760,12 @@ pub(crate) fn handle_write_with_hostfs(
     let source_tid: ThreadIdentifier = response_context.source_tid();
     let req: WriteRequest = WriteRequest::from_bytes(msg.payload);
     let fd: i32 = req.fd;
+
+    if let Ok((_, writable)) = ::vfs::fd::vfs_terminal_access(fd) {
+        return Some(super::readwrite::handle_terminal_write(
+            source_pid, source_tid, msg, writable,
+        ));
+    }
 
     // Pipe write end: served by the pipe handler (which may park the caller).
     if let Some((pipe_id, is_write)) = ::vfs::fd::vfs_pipe_id(fd) {

--- a/src/daemons/vfsd/src/handler/long.rs
+++ b/src/daemons/vfsd/src/handler/long.rs
@@ -140,9 +140,14 @@ pub(crate) fn handle_openat(
     match ::vfs::fd::vfs_open_resolved(path, flags) {
         Ok(fd) => {
             let epoch: u64 = ::vfs::fd::vfs_current_generation();
+            let route: u32 = match ::vfs::fd::vfs_resolve(fd) {
+                Some((::vfs::fd::VfsRoute::Terminal, _)) => OpenAtResponse::ROUTE_TERMINAL,
+                _ => OpenAtResponse::ROUTE_VFS,
+            };
             vec![OpenAtResponse::build(
                 source,
                 fd,
+                route,
                 epoch,
                 ProcessIdentifier::VFSD,
                 MessageType::Ipc,

--- a/src/daemons/vfsd/src/handler/poll.rs
+++ b/src/daemons/vfsd/src/handler/poll.rs
@@ -41,10 +41,7 @@ use ::syscall::{
         PollResponse,
     },
 };
-use ::vfs::{
-    fd::ConsoleStream,
-    Fat32Error,
-};
+use ::vfs::Fat32Error;
 
 //==================================================================================================
 // Standalone Functions
@@ -111,7 +108,7 @@ fn console_probe(request: &PollRequest) -> Option<(i32, i16)> {
             if events & READ_EVENTS == 0 {
                 return None;
             }
-            if !matches!(::vfs::fd::vfs_console_stream(fd), Ok(ConsoleStream::Stdin)) {
+            if !matches!(::vfs::fd::vfs_terminal_access(fd), Ok((true, _))) {
                 return None;
             }
             match ::vfs::fd::vfs_poll(fd, events) {

--- a/src/daemons/vfsd/src/handler/readwrite.rs
+++ b/src/daemons/vfsd/src/handler/readwrite.rs
@@ -74,10 +74,7 @@ use ::syscall::{
     SystemCallMessage,
 };
 use ::vfs::{
-    fd::{
-        ConsoleStream,
-        TtyError,
-    },
+    fd::TtyError,
     line_discipline::{
         ConsoleReadOutcome,
         TerminalSignal,
@@ -173,13 +170,13 @@ pub(crate) fn handle_read(
 pub(crate) fn handle_console_read(
     response_context: ResponseContext,
     fd: i32,
-    stream: ConsoleStream,
+    readable: bool,
     count: usize,
     console_wait: &mut ConsoleWaitTable,
 ) -> Option<Message> {
     let source_pid: ProcessIdentifier = response_context.source_pid();
     let source_tid: ThreadIdentifier = response_context.source_tid();
-    if stream != ConsoleStream::Stdin {
+    if !readable {
         console_wait.park(BlockedConsoleReader {
             response_context,
             source_pid,
@@ -213,6 +210,46 @@ pub(crate) fn handle_console_read(
         wake_console_readers(console_wait);
     }
     None
+}
+
+/// Handles a write to an opened terminal device.
+pub(crate) fn handle_terminal_write(
+    source_pid: ProcessIdentifier,
+    source_tid: ThreadIdentifier,
+    msg: SystemCallMessage,
+    writable: bool,
+) -> Message {
+    let req: WriteRequest = WriteRequest::from_bytes(msg.payload);
+    let count: usize = req.count as usize;
+    let buf_size: usize = count.min(MAX_BULK_TRANSFER_SIZE);
+    // Safety: vfsd is single-threaded; no concurrent access to BULK_BUFFER.
+    let buf: &mut [u8] = unsafe { &mut BULK_BUFFER[..buf_size] };
+
+    match ::sys::kcall::ipc::__kcall_pull(source_pid, source_tid, buf) {
+        Ok(pulled) => {
+            if !writable {
+                return build_error(source_tid, ErrorCode::BadFile);
+            }
+            let write_len: usize = pulled.min(count);
+            if write_len > 0 {
+                notify_terminal_access(source_pid, true);
+                if let Err(error) = kernel_write_console(STDOUT_FILENO, &buf[..write_len]) {
+                    ::syslog::error!("terminal write failed (error={:?})", error);
+                    return build_error(source_tid, ErrorCode::IoErr);
+                }
+            }
+            WriteResponse::build(
+                source_tid,
+                write_len as i32,
+                ProcessIdentifier::VFSD,
+                MessageType::Ipc,
+            )
+        },
+        Err(error) => {
+            ::syslog::error!("terminal write pull failed (error={:?})", error);
+            build_error(source_tid, ErrorCode::IoErr)
+        },
+    }
 }
 
 pub(crate) fn handle_write(

--- a/src/daemons/vfsd/src/handler/short.rs
+++ b/src/daemons/vfsd/src/handler/short.rs
@@ -90,6 +90,7 @@ pub(crate) fn handle_resolve_fd(source: ThreadIdentifier, msg: SystemCallMessage
         Some((route, backend_fd)) => {
             let wire_route: u32 = match route {
                 VfsRoute::Console => ResolveFdResponse::ROUTE_CONSOLE,
+                VfsRoute::Terminal => ResolveFdResponse::ROUTE_TERMINAL,
                 VfsRoute::Vfs => ResolveFdResponse::ROUTE_VFS,
                 VfsRoute::Socket => ResolveFdResponse::ROUTE_SOCKET,
             };

--- a/src/daemons/vfsd/src/pending.rs
+++ b/src/daemons/vfsd/src/pending.rs
@@ -1055,6 +1055,7 @@ fn complete_open(
             let msg: Message = OpenAtResponse::build(
                 source_tid,
                 local_fd,
+                OpenAtResponse::ROUTE_VFS,
                 epoch,
                 ProcessIdentifier::VFSD,
                 MessageType::Ipc,

--- a/src/libs/syscall/src/close_route.rs
+++ b/src/libs/syscall/src/close_route.rs
@@ -41,7 +41,7 @@ pub(crate) struct CloseTarget {
 pub(crate) fn close_target(fd: i32, resolution: Resolution) -> CloseTarget {
     match resolution.route {
         // VFS-backed descriptors are closed by vfsd using the backend descriptor it reported.
-        Route::Vfs => CloseTarget {
+        Route::Vfs | Route::Terminal => CloseTarget {
             fd: resolution.backend_fd,
             destination: crate::VFS_DESTINATION,
             message_type: crate::VFS_MESSAGE_TYPE,

--- a/src/libs/syscall/src/fcntl/message/openat.rs
+++ b/src/libs/syscall/src/fcntl/message/openat.rs
@@ -239,6 +239,8 @@ impl MessagePartitioner for OpenAtRequest {
 #[repr(C, packed)]
 pub struct OpenAtResponse {
     pub ret: i32,
+    /// Descriptor backend route, using the `ROUTE_*` constants.
+    pub route: u32,
     /// The `vfsd` descriptor-table generation at the time this descriptor was returned.
     ///
     /// libposix stamps the resolution-cache entry for `ret` with this epoch so that a later plan
@@ -249,12 +251,20 @@ pub struct OpenAtResponse {
 ::static_assert::assert_eq_size!(OpenAtResponse, SystemCallMessage::PAYLOAD_SIZE);
 
 impl OpenAtResponse {
-    pub const PADDING_SIZE: usize =
-        SystemCallMessage::PAYLOAD_SIZE - mem::size_of::<i32>() - mem::size_of::<u64>();
+    /// Wire value for a vfsd-served descriptor.
+    pub const ROUTE_VFS: u32 = 0;
+    /// Wire value for a terminal descriptor served by vfsd.
+    pub const ROUTE_TERMINAL: u32 = 1;
 
-    pub fn new(ret: i32, epoch: u64) -> Self {
+    pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
+        - mem::size_of::<i32>()
+        - mem::size_of::<u32>()
+        - mem::size_of::<u64>();
+
+    pub fn new(ret: i32, route: u32, epoch: u64) -> Self {
         Self {
             ret,
+            route,
             epoch,
             _padding: [0; Self::PADDING_SIZE],
         }
@@ -271,11 +281,12 @@ impl OpenAtResponse {
     pub fn build(
         tid: ThreadIdentifier,
         ret: i32,
+        route: u32,
         epoch: u64,
         source: ProcessIdentifier,
         message_type: MessageType,
     ) -> Message {
-        let message: OpenAtResponse = OpenAtResponse::new(ret, epoch);
+        let message: OpenAtResponse = OpenAtResponse::new(ret, route, epoch);
         let message: SystemCallMessage =
             SystemCallMessage::new(SystemCallMessageKind::OpenAtResponse, message.into_bytes());
         let message: Message = Message::new(

--- a/src/libs/syscall/src/fcntl/syscall/openat.rs
+++ b/src/libs/syscall/src/fcntl/syscall/openat.rs
@@ -102,9 +102,21 @@ pub fn openat(dirfd: i32, pathname: &str, flags: c_int, mode: mode_t) -> Result<
                         // be aligned. Read it through a raw pointer to avoid forming an unaligned
                         // reference, which is undefined behavior on targets that fault on misaligned
                         // loads.
+                        let route: u32 =
+                            unsafe { ::core::ptr::addr_of!(response.route).read_unaligned() };
                         let epoch: u64 =
                             unsafe { ::core::ptr::addr_of!(response.epoch).read_unaligned() };
-                        crate::fdtable::record(fd, crate::fdtable::Route::Vfs, fd, epoch);
+                        let route: crate::fdtable::Route = match route {
+                            OpenAtResponse::ROUTE_VFS => crate::fdtable::Route::Vfs,
+                            OpenAtResponse::ROUTE_TERMINAL => crate::fdtable::Route::Terminal,
+                            _ => {
+                                return Err(Error::new(
+                                    ErrorCode::InvalidMessage,
+                                    "openat(): invalid descriptor route",
+                                ));
+                            },
+                        };
+                        crate::fdtable::record(fd, route, fd, epoch);
                     }
 
                     // Return file descriptor.

--- a/src/libs/syscall/src/fd_route.rs
+++ b/src/libs/syscall/src/fd_route.rs
@@ -1,0 +1,21 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Descriptor backend classification, independent of the resolution cache.
+
+//==================================================================================================
+// Enumerations
+//==================================================================================================
+
+/// The backend that serves a descriptor's operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Route {
+    /// A console stream (`stdin`/`stdout`/`stderr`); I/O flows directly to the kernel.
+    Console,
+    /// A terminal device whose I/O is served by vfsd.
+    Terminal,
+    /// A `vfsd`-managed object: regular file, directory, host file, or pipe end.
+    Vfs,
+    /// A `networkd`-managed socket.
+    Socket,
+}

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -44,6 +44,8 @@ use ::sysapi::unistd::{
 pub(crate) enum Route {
     /// A console stream (`stdin`/`stdout`/`stderr`); I/O flows directly to the kernel.
     Console,
+    /// A terminal device whose I/O is served by vfsd.
+    Terminal,
     /// A `vfsd`-managed object: regular file, directory, host file, or pipe end.
     Vfs,
     /// A `networkd`-managed socket.
@@ -239,7 +241,9 @@ pub(crate) fn resolve_vfs(fd: i32, syscall_name: &str) -> Result<i32, Error> {
     use ::sys::error::ErrorCode;
 
     match resolve_result(fd)? {
-        Some(resolution) if resolution.route == Route::Vfs => Ok(resolution.backend_fd),
+        Some(resolution) if matches!(resolution.route, Route::Vfs | Route::Terminal) => {
+            Ok(resolution.backend_fd)
+        },
         _ => {
             ::syslog::warn!("{syscall_name}(): bad file descriptor fd={fd}");
             Err(Error::new(ErrorCode::BadFile, "fd is not a VFS fd"))
@@ -279,7 +283,11 @@ pub(crate) fn resolve_table_op(fd: i32, syscall_name: &str) -> Result<i32, Error
     use ::sys::error::ErrorCode;
 
     match resolve_result(fd)? {
-        Some(resolution) if matches!(resolution.route, Route::Vfs | Route::Console) => Ok(fd),
+        Some(resolution)
+            if matches!(resolution.route, Route::Vfs | Route::Console | Route::Terminal) =>
+        {
+            Ok(fd)
+        },
         _ => {
             ::syslog::warn!("{syscall_name}(): bad file descriptor fd={fd}");
             Err(Error::new(ErrorCode::BadFile, "fd is not a vfsd table descriptor"))
@@ -290,16 +298,16 @@ pub(crate) fn resolve_table_op(fd: i32, syscall_name: &str) -> Result<i32, Error
 /// Resolves `fd` for a terminal-control `ioctl` request (`TCGETS`/`TCSETS`/`TIOCGWINSZ`/
 /// `TIOCSWINSZ`) and returns the flat descriptor `vfsd` expects.
 ///
-/// A descriptor is a terminal only when it resolves to the console backend. A console descriptor is
-/// accepted and returned unchanged (vfsd owns the terminal state keyed by the flat number); a valid
-/// non-console descriptor is rejected with `ENOTTY`; an unknown descriptor is rejected with `EBADF`.
+/// A descriptor is a terminal when it resolves to a direct console or vfsd terminal route. It is
+/// returned unchanged because vfsd owns terminal state keyed by the flat number; a valid
+/// non-terminal descriptor is rejected with `ENOTTY`, and an unknown descriptor with `EBADF`.
 /// This is the ioctl counterpart of [`resolve_socket`] and [`resolve_vfs`], the "new resolver arm"
 /// for terminal probing.
 pub(crate) fn resolve_tty(fd: i32, syscall_name: &str) -> Result<i32, Error> {
     use ::sys::error::ErrorCode;
 
     match resolve_result(fd)? {
-        Some(resolution) if resolution.route == Route::Console => Ok(fd),
+        Some(resolution) if matches!(resolution.route, Route::Console | Route::Terminal) => Ok(fd),
         Some(_) => {
             ::syslog::warn!("{syscall_name}(): fd is not a terminal fd={fd}");
             Err(Error::new(ErrorCode::NotTerminal, "fd is not a terminal"))
@@ -414,6 +422,7 @@ fn resolve_via_vfsd(fd: i32) -> Result<VfsdResolution, Error> {
         ResolveFdResponse::ROUTE_CONSOLE => Route::Console,
         ResolveFdResponse::ROUTE_VFS => Route::Vfs,
         ResolveFdResponse::ROUTE_SOCKET => Route::Socket,
+        ResolveFdResponse::ROUTE_TERMINAL => Route::Terminal,
         other => {
             ::syslog::warn!("resolve_via_vfsd(): unknown route tag {other} (fd={fd})");
             return Ok(VfsdResolution::BadFile);
@@ -520,6 +529,20 @@ mod tests {
         for fd in [0, 1, 2, 5] {
             assert_eq!(resolve(fd), None, "an unknown flat descriptor must be unroutable");
         }
+
+        clear();
+    }
+
+    /// Tests that a vfsd-served terminal supports both terminal control and VFS data routing.
+    #[test]
+    fn terminal_route_supports_control_and_io() {
+        let _guard = CACHE_TEST_GUARD.lock();
+        clear();
+
+        mock_vfsd(4, Route::Terminal, 4, 1);
+        assert_eq!(resolve_tty(4, "ioctl").expect("resolve terminal control"), 4);
+        assert_eq!(resolve_vfs(4, "read").expect("resolve terminal I/O"), 4);
+        assert!(matches!(resolve_console(4), Ok(ConsoleLookup::Other)));
 
         clear();
     }

--- a/src/libs/syscall/src/fdtable.rs
+++ b/src/libs/syscall/src/fdtable.rs
@@ -20,6 +20,7 @@
 //! `vfsd`. An entry older than that ([`is_coherent`]) is treated as stale and re-resolved, so a
 //! number reused for a different backend can never be answered from an outdated entry.
 
+pub(crate) use crate::fd_route::Route;
 use ::alloc::collections::BTreeMap;
 #[cfg(test)]
 use ::core::sync::atomic::AtomicBool;
@@ -38,19 +39,6 @@ use ::sysapi::unistd::{
 //==================================================================================================
 // Structures
 //==================================================================================================
-
-/// The backend that serves a descriptor's operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Route {
-    /// A console stream (`stdin`/`stdout`/`stderr`); I/O flows directly to the kernel.
-    Console,
-    /// A terminal device whose I/O is served by vfsd.
-    Terminal,
-    /// A `vfsd`-managed object: regular file, directory, host file, or pipe end.
-    Vfs,
-    /// A `networkd`-managed socket.
-    Socket,
-}
 
 /// A resolved routing decision: which backend serves a descriptor and the descriptor number that
 /// backend expects.

--- a/src/libs/syscall/src/lib.rs
+++ b/src/libs/syscall/src/lib.rs
@@ -91,6 +91,10 @@ pub mod stdlib;
 #[cfg(feature = "syscall")]
 pub(crate) mod path;
 
+/// Descriptor backend classification.
+#[cfg(any(feature = "syscall", test))]
+mod fd_route;
+
 /// Client-side file-descriptor resolution cache.
 #[cfg(feature = "syscall")]
 pub(crate) mod fdtable;

--- a/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fchmod.rs
@@ -52,7 +52,7 @@ pub fn fchmod(fd: RawFileDescriptor, mode: mode_t) -> Result<(), Error> {
             Route,
         };
         match resolve_result(fd)? {
-            Some(res) if res.route == Route::Vfs => res.backend_fd,
+            Some(res) if matches!(res.route, Route::Vfs | Route::Terminal) => res.backend_fd,
             _ => {
                 ::syslog::warn!("fchmod(): bad file descriptor fd={fd}");
                 return Err(Error::new(ErrorCode::BadFile, "fchmod: fd is not a VFS fd"));

--- a/src/libs/syscall/src/sys/stat/syscall/fstat.rs
+++ b/src/libs/syscall/src/sys/stat/syscall/fstat.rs
@@ -54,7 +54,7 @@ pub fn fstat(fd: i32, buf: &mut sys_stat::stat) -> Result<(), Error> {
             // it owns, addressed by the caller-facing flat descriptor. For a console this is the
             // slot number, not the stream number used to route I/O — the slot is the operand,
             // so a `dup`'d console descriptor shares its source's character-device identity.
-            Some(res) if matches!(res.route, Route::Vfs | Route::Console) => fd,
+            Some(res) if matches!(res.route, Route::Vfs | Route::Console | Route::Terminal) => fd,
             // Sockets and unroutable descriptors have no stat here.
             _ => {
                 ::syslog::warn!("fstat(): bad file descriptor fd={fd}");

--- a/src/libs/syscall/src/unistd/message/resolve_fd.rs
+++ b/src/libs/syscall/src/unistd/message/resolve_fd.rs
@@ -107,12 +107,13 @@ impl fmt::Debug for ResolveFdRequest {
 /// at (its coherence epoch).
 ///
 /// The route is carried as a small integer rather than an enum so the wire layout is fixed: `0` is
-/// the console (kernel), `1` is vfsd, and `2` is a `networkd` socket. A descriptor with no slot in
+/// the console (kernel), `1` is vfsd, `2` is a `networkd` socket, and `3` is a terminal served by
+/// vfsd. A descriptor with no slot in
 /// the process is reported by an error response (non-zero status), not by this message.
 ///
 #[repr(C, packed)]
 pub struct ResolveFdResponse {
-    /// The backend route: `0` = console, `1` = vfsd, `2` = socket.
+    /// The backend route: `0` = console, `1` = vfsd, `2` = socket, `3` = vfsd terminal.
     pub route: u32,
     /// The descriptor number the backend expects.
     pub backend_fd: i32,
@@ -129,6 +130,8 @@ impl ResolveFdResponse {
     pub const ROUTE_VFS: u32 = 1;
     /// Wire value for a `networkd` socket descriptor.
     pub const ROUTE_SOCKET: u32 = 2;
+    /// Wire value for a terminal descriptor served by vfsd.
+    pub const ROUTE_TERMINAL: u32 = 3;
 
     pub const PADDING_SIZE: usize = SystemCallMessage::PAYLOAD_SIZE
         - mem::size_of::<u32>()

--- a/src/libs/syscall/src/unistd/mod.rs
+++ b/src/libs/syscall/src/unistd/mod.rs
@@ -13,6 +13,9 @@
 
 pub mod message;
 
+#[cfg(any(feature = "syscall", test))]
+mod read_backend;
+
 //==================================================================================================
 
 // The getopt back-end and its C ABI binding are host-testable, so the `syscall` and `bindings`

--- a/src/libs/syscall/src/unistd/read_backend.rs
+++ b/src/libs/syscall/src/unistd/read_backend.rs
@@ -1,0 +1,83 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Read-backend classification without guest runtime dependencies.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use crate::fd_route::Route;
+use ::sys::error::{
+    Error,
+    ErrorCode,
+};
+
+//==================================================================================================
+// Enumerations
+//==================================================================================================
+
+/// Read backend; transport and cancellation follow from the variant.
+#[derive(Clone, Copy)]
+pub(super) enum ReadBackend {
+    /// Direct console input without VFSD.
+    #[cfg_attr(
+        not(feature = "syscall"),
+        expect(
+            dead_code,
+            reason = "Constructed only by the guest read implementation."
+        )
+    )]
+    KernelConsole,
+    /// Terminal input parked in VFSD's console wait table.
+    VfsConsole,
+    /// File or pipe input served by VFSD.
+    Vfs,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl TryFrom<Route> for ReadBackend {
+    type Error = Error;
+
+    fn try_from(route: Route) -> Result<Self, Self::Error> {
+        match route {
+            Route::Console | Route::Terminal => Ok(Self::VfsConsole),
+            Route::Vfs => Ok(Self::Vfs),
+            Route::Socket => Err(Error::new(ErrorCode::BadFile, "read: unsupported socket route")),
+        }
+    }
+}
+
+//==================================================================================================
+// Tests
+//==================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::ReadBackend;
+    use crate::fd_route::Route;
+    use ::sys::error::ErrorCode;
+
+    #[test]
+    fn terminal_reads_use_console_backend() {
+        for route in [Route::Console, Route::Terminal] {
+            assert!(matches!(ReadBackend::try_from(route), Ok(ReadBackend::VfsConsole)));
+        }
+    }
+
+    #[test]
+    fn other_vfs_reads_use_vfs_backend() {
+        assert!(matches!(ReadBackend::try_from(Route::Vfs), Ok(ReadBackend::Vfs)));
+    }
+
+    #[test]
+    fn sockets_are_not_read_backends() {
+        assert!(matches!(
+            ReadBackend::try_from(Route::Socket),
+            Err(error) if error.code == ErrorCode::BadFile
+        ));
+    }
+}

--- a/src/libs/syscall/src/unistd/syscall/fchown.rs
+++ b/src/libs/syscall/src/unistd/syscall/fchown.rs
@@ -56,7 +56,7 @@ pub fn fchown(fd: RawFileDescriptor, owner: uid_t, group: gid_t) -> Result<(), E
             Route,
         };
         match resolve_result(fd)? {
-            Some(res) if res.route == Route::Vfs => res.backend_fd,
+            Some(res) if matches!(res.route, Route::Vfs | Route::Terminal) => res.backend_fd,
             _ => {
                 ::syslog::warn!("fchown(): bad file descriptor fd={fd}");
                 return Err(Error::new(ErrorCode::BadFile, "fchown: fd is not a VFS fd"));

--- a/src/libs/syscall/src/unistd/syscall/isatty.rs
+++ b/src/libs/syscall/src/unistd/syscall/isatty.rs
@@ -33,7 +33,7 @@ pub fn isatty(fd: RawFileDescriptor) -> Result<bool, Error> {
     ::syslog::trace!("isatty(): fd={}", fd);
 
     // vfsd's flat slot table is authoritative: a descriptor is a terminal if and
-    // only if it resolves to the console backend, so a duplicated or redirected console descriptor
+    // only if it resolves to a terminal route, so a duplicated or redirected terminal descriptor
     // answers correctly rather than being judged by its number. An unresolvable descriptor is
     // rejected with `EBADF`.
     use crate::fdtable::{
@@ -41,7 +41,9 @@ pub fn isatty(fd: RawFileDescriptor) -> Result<bool, Error> {
         Route,
     };
     match resolve_result(fd)? {
-        Some(resolution) if resolution.route == Route::Console => Ok(true),
+        Some(resolution) if matches!(resolution.route, Route::Console | Route::Terminal) => {
+            Ok(true)
+        },
         Some(_) => {
             ::syslog::trace!("isatty(): file descriptor is not a terminal (fd={})", fd);
             Ok(false)

--- a/src/libs/syscall/src/unistd/syscall/lseek.rs
+++ b/src/libs/syscall/src/unistd/syscall/lseek.rs
@@ -47,7 +47,7 @@ pub fn lseek(fd: RawFileDescriptor, offset: off_t, whence: c_int) -> Result<off_
             // VFS-backed descriptors fall through to the vfsd seek path below.
             Some(res) if res.route == Route::Vfs => res.backend_fd,
             // Seeking the console (stdin/stdout/stderr) is an illegal seek.
-            Some(res) if res.route == Route::Console => {
+            Some(res) if matches!(res.route, Route::Console | Route::Terminal) => {
                 ::syslog::warn!(
                     "lseek(): illegal seek on stdio (fd={fd:?}, offset={offset}, whence={whence})",
                 );

--- a/src/libs/syscall/src/unistd/syscall/pread.rs
+++ b/src/libs/syscall/src/unistd/syscall/pread.rs
@@ -64,7 +64,7 @@ pub fn pread(fd: RawFileDescriptor, buffer: &mut [u8], offset: off_t) -> Result<
             // VFS-backed descriptors fall through to the vfsd read path below.
             Some(res) if res.route == Route::Vfs => res.backend_fd,
             // The console (stdin/stdout/stderr) is not seekable.
-            Some(res) if res.route == Route::Console => {
+            Some(res) if matches!(res.route, Route::Console | Route::Terminal) => {
                 ::syslog::warn!(
                     "pread(): illegal seek on stdio (fd={fd}, buffer={buffer:?}, offset={offset})",
                 );

--- a/src/libs/syscall/src/unistd/syscall/pwrite.rs
+++ b/src/libs/syscall/src/unistd/syscall/pwrite.rs
@@ -64,7 +64,7 @@ pub fn pwrite(fd: RawFileDescriptor, buffer: &[u8], offset: off_t) -> Result<c_s
             // VFS-backed descriptors fall through to the vfsd write path below.
             Some(res) if res.route == Route::Vfs => res.backend_fd,
             // The console (stdin/stdout/stderr) is not seekable.
-            Some(res) if res.route == Route::Console => {
+            Some(res) if matches!(res.route, Route::Console | Route::Terminal) => {
                 ::syslog::warn!(
                     "pwrite(): illegal seek on stdio (fd={fd:?}, buffer={buffer:?}, \
                      offset={offset})",

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -10,6 +10,7 @@ use super::{
     util::page_chunk_size,
 };
 use crate::{
+    fdtable::Route,
     poll::input_message::{
         ConsoleReadCancel,
         PipeOperation,
@@ -46,22 +47,27 @@ use ::sysapi::{
 // Standalone Functions
 //==================================================================================================
 
-/// Backend routing and interruption policy for one read operation.
+/// Read backend; transport and cancellation follow from the variant.
 #[derive(Clone, Copy)]
-struct ReadBackend {
-    destination: ProcessIdentifier,
-    message_type: MessageType,
-    pull_pid: ProcessIdentifier,
-    pull_tid: ThreadIdentifier,
-    cancellation: ReadCancellation,
+enum ReadBackend {
+    /// Direct console input without VFSD.
+    KernelConsole,
+    /// Terminal input parked in VFSD's console wait table.
+    VfsConsole,
+    /// File or pipe input served by VFSD.
+    Vfs,
 }
 
-/// Cancellation protocol to run when a read's bulk pull is interrupted.
-#[derive(Clone, Copy)]
-enum ReadCancellation {
-    None,
-    Console,
-    Pipe,
+impl TryFrom<Route> for ReadBackend {
+    type Error = Error;
+
+    fn try_from(route: Route) -> Result<Self, Self::Error> {
+        match route {
+            Route::Console | Route::Terminal => Ok(Self::VfsConsole),
+            Route::Vfs => Ok(Self::Vfs),
+            Route::Socket => Err(Error::new(ErrorCode::BadFile, "read: unsupported socket route")),
+        }
+    }
 }
 
 ///
@@ -87,26 +93,38 @@ fn read_chunk(
     chunk: &mut [u8],
     backend: ReadBackend,
 ) -> Result<c_size_t, Error> {
+    let (destination, message_type, pull_pid, pull_tid): (
+        ProcessIdentifier,
+        MessageType,
+        ProcessIdentifier,
+        ThreadIdentifier,
+    ) = match backend {
+        ReadBackend::KernelConsole => {
+            (crate::HOST_IO, MessageType::Ikc, ProcessIdentifier::KERNEL, ThreadIdentifier::KERNEL)
+        },
+        ReadBackend::VfsConsole | ReadBackend::Vfs => (
+            crate::VFS_DESTINATION,
+            crate::VFS_MESSAGE_TYPE,
+            crate::VFS_PUSH_PULL_PID,
+            crate::VFS_PUSH_PULL_TID,
+        ),
+    };
+
     // Send metadata-only ReadRequest via IPC message.
-    let mut request: Message = ReadRequest::build(
-        tid,
-        fd,
-        chunk.len() as c_size_t,
-        backend.destination,
-        backend.message_type,
-    );
+    let mut request: Message =
+        ReadRequest::build(tid, fd, chunk.len() as c_size_t, destination, message_type);
     let token: RequestToken = crate::rpc::send_request(&mut request)?;
 
     // Pull data via data chunk transfer.
     let mut interrupted: Option<Error> = None;
     let bytes_pulled: Option<usize> =
-        match ::sys::kcall::ipc::__kcall_pull(backend.pull_pid, backend.pull_tid, chunk) {
+        match ::sys::kcall::ipc::__kcall_pull(pull_pid, pull_tid, chunk) {
             Ok(bytes_pulled) => Some(bytes_pulled),
             Err(error) if error.code == ErrorCode::Interrupted => {
-                let cancelled: bool = match backend.cancellation {
-                    ReadCancellation::None => return Err(error),
-                    ReadCancellation::Console => cancel_console_read(tid, token.identifier())?,
-                    ReadCancellation::Pipe => {
+                let cancelled: bool = match backend {
+                    ReadBackend::KernelConsole => return Err(error),
+                    ReadBackend::VfsConsole => cancel_console_read(tid, token.identifier())?,
+                    ReadBackend::Vfs => {
                         cancel_pipe_operation(tid, fd, PipeOperation::Read, token.identifier())?
                             .is_some()
                     },
@@ -293,7 +311,6 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         resolve_console,
         resolve_result,
         ConsoleLookup,
-        Route,
     };
     match resolve_console(fd)? {
         // When vfsd owns the console slot, use the flat descriptor so vfsd can apply the shared
@@ -304,29 +321,9 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
             via_vfsd,
         } => {
             if via_vfsd {
-                read_ipc(
-                    fd,
-                    buffer,
-                    ReadBackend {
-                        destination: crate::VFS_DESTINATION,
-                        message_type: crate::VFS_MESSAGE_TYPE,
-                        pull_pid: crate::VFS_PUSH_PULL_PID,
-                        pull_tid: crate::VFS_PUSH_PULL_TID,
-                        cancellation: ReadCancellation::Console,
-                    },
-                )
+                read_ipc(fd, buffer, ReadBackend::VfsConsole)
             } else {
-                read_ipc(
-                    STDIN_FILENO,
-                    buffer,
-                    ReadBackend {
-                        destination: crate::HOST_IO,
-                        message_type: MessageType::Ikc,
-                        pull_pid: ProcessIdentifier::KERNEL,
-                        pull_tid: ThreadIdentifier::KERNEL,
-                        cancellation: ReadCancellation::None,
-                    },
-                )
+                read_ipc(STDIN_FILENO, buffer, ReadBackend::KernelConsole)
             }
         },
         ConsoleLookup::Console { .. } | ConsoleLookup::BadFile => {
@@ -335,17 +332,9 @@ pub fn read(fd: RawFileDescriptor, buffer: &mut [u8]) -> Result<c_size_t, Error>
         },
         ConsoleLookup::Other => match resolve_result(fd)? {
             // VFS-backed descriptors go to vfsd.
-            Some(res) if res.route == Route::Vfs => read_ipc(
-                res.backend_fd,
-                buffer,
-                ReadBackend {
-                    destination: crate::VFS_DESTINATION,
-                    message_type: crate::VFS_MESSAGE_TYPE,
-                    pull_pid: crate::VFS_PUSH_PULL_PID,
-                    pull_tid: crate::VFS_PUSH_PULL_TID,
-                    cancellation: ReadCancellation::Pipe,
-                },
-            ),
+            Some(res) if matches!(res.route, Route::Vfs | Route::Terminal) => {
+                read_ipc(res.backend_fd, buffer, ReadBackend::try_from(res.route)?)
+            },
             // stdout/stderr, sockets, and unroutable descriptors are not readable here.
             _ => {
                 ::syslog::warn!("read(): bad file descriptor fd={fd}");
@@ -394,4 +383,31 @@ fn read_ipc(
     }
 
     Ok(total_read)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReadBackend;
+    use crate::fdtable::Route;
+    use ::sys::error::ErrorCode;
+
+    #[test]
+    fn terminal_reads_use_console_backend() {
+        for route in [Route::Console, Route::Terminal] {
+            assert!(matches!(ReadBackend::try_from(route), Ok(ReadBackend::VfsConsole)));
+        }
+    }
+
+    #[test]
+    fn other_vfs_reads_use_vfs_backend() {
+        assert!(matches!(ReadBackend::try_from(Route::Vfs), Ok(ReadBackend::Vfs)));
+    }
+
+    #[test]
+    fn sockets_are_not_read_backends() {
+        assert!(matches!(
+            ReadBackend::try_from(Route::Socket),
+            Err(error) if error.code == ErrorCode::BadFile
+        ));
+    }
 }

--- a/src/libs/syscall/src/unistd/syscall/read.rs
+++ b/src/libs/syscall/src/unistd/syscall/read.rs
@@ -16,9 +16,12 @@ use crate::{
         PipeOperation,
     },
     safe::RawFileDescriptor,
-    unistd::message::{
-        ReadRequest,
-        ReadResponse,
+    unistd::{
+        message::{
+            ReadRequest,
+            ReadResponse,
+        },
+        read_backend::ReadBackend,
     },
     SystemCallMessage,
     SystemCallMessageKind,
@@ -46,29 +49,6 @@ use ::sysapi::{
 //==================================================================================================
 // Standalone Functions
 //==================================================================================================
-
-/// Read backend; transport and cancellation follow from the variant.
-#[derive(Clone, Copy)]
-enum ReadBackend {
-    /// Direct console input without VFSD.
-    KernelConsole,
-    /// Terminal input parked in VFSD's console wait table.
-    VfsConsole,
-    /// File or pipe input served by VFSD.
-    Vfs,
-}
-
-impl TryFrom<Route> for ReadBackend {
-    type Error = Error;
-
-    fn try_from(route: Route) -> Result<Self, Self::Error> {
-        match route {
-            Route::Console | Route::Terminal => Ok(Self::VfsConsole),
-            Route::Vfs => Ok(Self::Vfs),
-            Route::Socket => Err(Error::new(ErrorCode::BadFile, "read: unsupported socket route")),
-        }
-    }
-}
 
 ///
 /// # Description
@@ -383,31 +363,4 @@ fn read_ipc(
     }
 
     Ok(total_read)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::ReadBackend;
-    use crate::fdtable::Route;
-    use ::sys::error::ErrorCode;
-
-    #[test]
-    fn terminal_reads_use_console_backend() {
-        for route in [Route::Console, Route::Terminal] {
-            assert!(matches!(ReadBackend::try_from(route), Ok(ReadBackend::VfsConsole)));
-        }
-    }
-
-    #[test]
-    fn other_vfs_reads_use_vfs_backend() {
-        assert!(matches!(ReadBackend::try_from(Route::Vfs), Ok(ReadBackend::Vfs)));
-    }
-
-    #[test]
-    fn sockets_are_not_read_backends() {
-        assert!(matches!(
-            ReadBackend::try_from(Route::Socket),
-            Err(error) if error.code == ErrorCode::BadFile
-        ));
-    }
 }

--- a/src/libs/syscall/src/unistd/syscall/write.rs
+++ b/src/libs/syscall/src/unistd/syscall/write.rs
@@ -220,7 +220,7 @@ pub fn write(fd: RawFileDescriptor, buffer: &[u8]) -> Result<c_size_t, Error> {
             )
         },
         // VFS-backed descriptors go to vfsd.
-        Some(res) if res.route == Route::Vfs => write_ipc(
+        Some(res) if matches!(res.route, Route::Vfs | Route::Terminal) => write_ipc(
             res.backend_fd,
             buffer,
             WriteBackend {

--- a/src/libs/vfs/src/descriptor.rs
+++ b/src/libs/vfs/src/descriptor.rs
@@ -18,6 +18,7 @@ mod null_handle;
 mod pipe_closure;
 mod process_exit_reclaim;
 mod socket_handle;
+mod terminal_handle;
 mod tty_error;
 mod vfs_file_handle;
 mod vfs_route;
@@ -38,6 +39,10 @@ pub use self::{
     pipe_closure::PipeClosure,
     process_exit_reclaim::ProcessExitReclaim,
     socket_handle::SocketHandle,
+    terminal_handle::{
+        TerminalDevice,
+        TerminalHandle,
+    },
     tty_error::TtyError,
     vfs_file_handle::VfsFileHandle,
     vfs_route::VfsRoute,

--- a/src/libs/vfs/src/descriptor/terminal_handle.rs
+++ b/src/libs/vfs/src/descriptor/terminal_handle.rs
@@ -1,0 +1,77 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+//! Opened terminal-device handle.
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+use super::AccessMode;
+use crate::line_discipline::LineDiscipline;
+use ::alloc::sync::Arc;
+use ::spin::Mutex;
+
+//==================================================================================================
+// Enumerations
+//==================================================================================================
+
+/// Identity of a named terminal device.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TerminalDevice {
+    /// The system console.
+    Console,
+}
+
+//==================================================================================================
+// Structures
+//==================================================================================================
+
+/// An open description of a named terminal device.
+pub struct TerminalHandle {
+    /// Named device opened by the caller.
+    device: TerminalDevice,
+    /// Access permitted by this open description.
+    access_mode: AccessMode,
+    /// Shared console line discipline.
+    terminal: Arc<Mutex<LineDiscipline>>,
+}
+
+//==================================================================================================
+// Implementations
+//==================================================================================================
+
+impl TerminalHandle {
+    /// Creates an opened terminal handle.
+    pub fn new(
+        device: TerminalDevice,
+        access_mode: AccessMode,
+        terminal: Arc<Mutex<LineDiscipline>>,
+    ) -> Self {
+        Self {
+            device,
+            access_mode,
+            terminal,
+        }
+    }
+
+    /// Returns the named terminal device.
+    pub fn device(&self) -> TerminalDevice {
+        self.device
+    }
+
+    /// Returns whether reads are permitted.
+    pub fn readable(&self) -> bool {
+        self.access_mode.readable()
+    }
+
+    /// Returns whether writes are permitted.
+    pub fn writable(&self) -> bool {
+        self.access_mode.writable()
+    }
+
+    /// Returns the shared line discipline.
+    pub fn terminal(&self) -> &Arc<Mutex<LineDiscipline>> {
+        &self.terminal
+    }
+}

--- a/src/libs/vfs/src/descriptor/vfs_file_handle.rs
+++ b/src/libs/vfs/src/descriptor/vfs_file_handle.rs
@@ -14,6 +14,7 @@ use super::{
     HostFsHandle,
     NullHandle,
     SocketHandle,
+    TerminalHandle,
 };
 use crate::{
     filesystem::File,
@@ -51,6 +52,8 @@ pub enum VfsFileHandle {
     Pipe(PipeEnd),
     /// Routing token for a console stream (stdin/stdout/stderr).
     Console(ConsoleHandle),
+    /// An opened named terminal device.
+    Terminal(TerminalHandle),
     /// Routing token for a socket, holding the descriptor assigned by `networkd`.
     Socket(SocketHandle),
 }
@@ -69,7 +72,9 @@ impl VfsFileHandle {
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::Null(handle) => handle.read(),
             VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
-            VfsFileHandle::Console(_) | VfsFileHandle::Socket(_) => Err(Fat32Error::NotSupported),
+            VfsFileHandle::Console(_) | VfsFileHandle::Terminal(_) | VfsFileHandle::Socket(_) => {
+                Err(Fat32Error::NotSupported)
+            },
         }
     }
 
@@ -82,7 +87,9 @@ impl VfsFileHandle {
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::Null(handle) => handle.write(buf),
             VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
-            VfsFileHandle::Console(_) | VfsFileHandle::Socket(_) => Err(Fat32Error::NotSupported),
+            VfsFileHandle::Console(_) | VfsFileHandle::Terminal(_) | VfsFileHandle::Socket(_) => {
+                Err(Fat32Error::NotSupported)
+            },
         }
     }
 
@@ -98,7 +105,9 @@ impl VfsFileHandle {
             VfsFileHandle::HostFs(_) => Err(Fat32Error::NotSupported),
             VfsFileHandle::Null(handle) => handle.seek(whence),
             VfsFileHandle::Pipe(_) => Err(Fat32Error::NotSupported),
-            VfsFileHandle::Console(_) | VfsFileHandle::Socket(_) => Err(Fat32Error::NotSupported),
+            VfsFileHandle::Console(_) | VfsFileHandle::Terminal(_) | VfsFileHandle::Socket(_) => {
+                Err(Fat32Error::NotSupported)
+            },
         }
     }
 
@@ -111,7 +120,9 @@ impl VfsFileHandle {
             VfsFileHandle::HostFs(_) => Ok(0),
             VfsFileHandle::Null(_) => Ok(0),
             VfsFileHandle::Pipe(_) => Ok(0),
-            VfsFileHandle::Console(_) | VfsFileHandle::Socket(_) => Ok(0),
+            VfsFileHandle::Console(_) | VfsFileHandle::Terminal(_) | VfsFileHandle::Socket(_) => {
+                Ok(0)
+            },
         }
     }
 

--- a/src/libs/vfs/src/descriptor/vfs_route.rs
+++ b/src/libs/vfs/src/descriptor/vfs_route.rs
@@ -10,8 +10,10 @@
 /// The backend a descriptor's slot is bound to.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum VfsRoute {
-    /// A console stream.
+    /// A console stream served directly by the kernel.
     Console,
+    /// A terminal device served by vfsd.
+    Terminal,
     /// An object served by vfsd.
     Vfs,
     /// A socket served by networkd.

--- a/src/libs/vfs/src/devfs.rs
+++ b/src/libs/vfs/src/devfs.rs
@@ -80,6 +80,17 @@ const NULL_INODE: u64 = 2;
 /// Character-device identifier reported for `/dev/null`.
 const NULL_SPECIAL_DEVICE_ID: u64 = 1;
 
+/// Name of the console device.
+const CONSOLE_NAME: &str = "console";
+/// Absolute path of the console device.
+const CONSOLE_PATH: &str = "/dev/console";
+
+/// Stable inode identifier for `/dev/console`.
+const CONSOLE_INODE: u64 = 3;
+
+/// Character-device identifier reported for `/dev/console`.
+const CONSOLE_SPECIAL_DEVICE_ID: u64 = 2;
+
 //==================================================================================================
 // Structures
 //==================================================================================================
@@ -108,6 +119,8 @@ pub(crate) enum DevicePath {
     Directory,
     /// The null device.
     Null,
+    /// The system console.
+    Console,
     /// An unknown entry below `/dev`.
     Missing,
 }
@@ -130,6 +143,12 @@ impl DevicePath {
                 device: DEVICE_NAMESPACE_ID,
                 inode: NULL_INODE,
                 special_device: NULL_SPECIAL_DEVICE_ID,
+                is_directory: false,
+            }),
+            DevicePath::Console => Some(DeviceMetadata {
+                device: DEVICE_NAMESPACE_ID,
+                inode: CONSOLE_INODE,
+                special_device: CONSOLE_SPECIAL_DEVICE_ID,
                 is_directory: false,
             }),
             DevicePath::Missing => None,
@@ -195,7 +214,20 @@ pub(crate) fn posix_stat(cwd: &str, path: &str) -> Result<Option<PosixStat>, Fat
 
 /// Synthesizes POSIX metadata for `/dev/null`.
 pub(crate) fn null_posix_stat() -> PosixStat {
-    build_posix_stat(DevicePath::Null.metadata().expect("null device has metadata"))
+    build_posix_stat(
+        DevicePath::Null
+            .metadata()
+            .expect("null device has metadata"),
+    )
+}
+
+/// Synthesizes POSIX metadata for `/dev/console`.
+pub(crate) fn console_posix_stat() -> PosixStat {
+    build_posix_stat(
+        DevicePath::Console
+            .metadata()
+            .expect("console device has metadata"),
+    )
 }
 
 /// Builds POSIX metadata for a devfs entry.
@@ -233,11 +265,11 @@ pub(crate) fn directory_entry() -> DirEntry {
 /// Reads a directory owned by devfs.
 pub(crate) fn read_dir(cwd: &str, path: &str) -> Result<Option<Vec<DirEntry>>, Fat32Error> {
     match resolve(cwd, path)? {
-        Some(DevicePath::Directory) => Ok(Some(alloc::vec![DirEntry::new_character_device(
-            String::from(NULL_NAME),
-            NULL_INODE,
-        )])),
-        Some(DevicePath::Null) => Err(Fat32Error::NotADirectory),
+        Some(DevicePath::Directory) => Ok(Some(alloc::vec![
+            DirEntry::new_character_device(String::from(NULL_NAME), NULL_INODE),
+            DirEntry::new_character_device(String::from(CONSOLE_NAME), CONSOLE_INODE),
+        ])),
+        Some(DevicePath::Null | DevicePath::Console) => Err(Fat32Error::NotADirectory),
         Some(DevicePath::Missing) => Err(Fat32Error::NotFound),
         None => Ok(None),
     }
@@ -249,7 +281,7 @@ fn validate_components(path: &str) -> Result<(), Fat32Error> {
     for component in path.split('/').filter(|component| !component.is_empty()) {
         if components.len() >= 2 && components[0] == DIRECTORY_NAME {
             return match components[1] {
-                NULL_NAME => Err(Fat32Error::NotADirectory),
+                NULL_NAME | CONSOLE_NAME => Err(Fat32Error::NotADirectory),
                 _ => Err(Fat32Error::NotFound),
             };
         }
@@ -269,6 +301,7 @@ fn resolve_normalized(path: &str) -> Option<DevicePath> {
     match path {
         DIRECTORY_PATH => Some(DevicePath::Directory),
         NULL_PATH => Some(DevicePath::Null),
+        CONSOLE_PATH => Some(DevicePath::Console),
         path if path.starts_with(DIRECTORY_PREFIX) => Some(DevicePath::Missing),
         _ => None,
     }
@@ -293,20 +326,17 @@ mod tests {
 
     #[test]
     fn synthesizes_stat() {
-        let stat: Stat = stat("/", "/dev").expect("valid path").expect("existing path");
+        let stat: Stat = stat("/", "/dev")
+            .expect("valid path")
+            .expect("existing path");
         assert_eq!(
             stat,
-            Stat::new(
-                0,
-                true,
-                STAT_TIMESTAMP_SECS,
-                STAT_TIMESTAMP_SECS,
-                STAT_TIMESTAMP_SECS,
-            )
+            Stat::new(0, true, STAT_TIMESTAMP_SECS, STAT_TIMESTAMP_SECS, STAT_TIMESTAMP_SECS,)
         );
 
-        let stat: PosixStat =
-            posix_stat("/", "/dev").expect("valid path").expect("existing path");
+        let stat: PosixStat = posix_stat("/", "/dev")
+            .expect("valid path")
+            .expect("existing path");
         assert_eq!(stat.st_dev, DEVICE_NAMESPACE_ID);
         assert_eq!(stat.st_ino, DIRECTORY_INODE);
         assert_eq!(stat.st_blksize, ::arch::mem::PAGE_SIZE as i64);

--- a/src/libs/vfs/src/fd/mod.rs
+++ b/src/libs/vfs/src/fd/mod.rs
@@ -160,12 +160,25 @@ fn console_device() -> Arc<Mutex<LineDiscipline>> {
         .clone()
 }
 
+/// Access and line-discipline state of a terminal descriptor.
+struct TerminalState {
+    /// Standard stream identity, if this is a seeded console descriptor.
+    stream: Option<ConsoleStream>,
+    /// Shared console line discipline.
+    terminal: Arc<Mutex<LineDiscipline>>,
+    /// Whether reads are permitted.
+    readable: bool,
+    /// Whether writes are permitted.
+    writable: bool,
+}
+
 //==================================================================================================
 // Public Re-Exports
 //==================================================================================================
 
 pub use crate::{
     descriptor::{
+        AccessMode,
         ConsoleHandle,
         ConsoleStream,
         DirectReadHandle,
@@ -176,6 +189,8 @@ pub use crate::{
         PipeClosure,
         ProcessExitReclaim,
         SocketHandle,
+        TerminalDevice,
+        TerminalHandle,
         TtyError,
         VfsFileHandle,
         VfsRoute,
@@ -955,6 +970,7 @@ pub fn vfs_resolve(fd: c_int) -> Option<(VfsRoute, c_int)> {
             },
         ),
         VfsFileHandle::Socket(h) => (VfsRoute::Socket, h.remote_fd()),
+        VfsFileHandle::Terminal(_) => (VfsRoute::Terminal, fd),
         // Every other handle is served by vfsd, addressed by the raw descriptor.
         VfsFileHandle::Fat32(_)
         | VfsFileHandle::DirectRead(_)
@@ -980,6 +996,19 @@ pub fn vfs_poll(fd: c_int, events: c_short) -> Result<c_short, Fat32Error> {
                 return Ok(events & (READ_EVENTS | WRITE_EVENTS))
             },
             VfsFileHandle::Null(handle) => return Ok(handle.poll(events)),
+            VfsFileHandle::Terminal(handle) => {
+                let mut ready: c_short = 0;
+                if handle.readable()
+                    && events & READ_EVENTS != 0
+                    && handle.terminal().lock().is_readable()
+                {
+                    ready |= events & READ_EVENTS;
+                }
+                if handle.writable() {
+                    ready |= events & WRITE_EVENTS;
+                }
+                return Ok(ready);
+            },
             VfsFileHandle::Directory(_) => return Ok(events & READ_EVENTS),
             VfsFileHandle::Pipe(end) => return Ok(end.poll(events)),
             VfsFileHandle::Socket(_) => return Err(Fat32Error::NotSupported),
@@ -1013,8 +1042,8 @@ pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
             return Err(Fat32Error::NotAFile);
         }
     }
-    // If O_DIRECTORY is set, verify the path is a directory before opening.
-    if flags & file_creation_flags::O_DIRECTORY != 0 {
+    // O_DIRECTORY and trailing slashes require a directory.
+    if flags & file_creation_flags::O_DIRECTORY != 0 || path.ends_with('/') {
         let info: filesystem::Stat = filesystem::stat(&cwd, path)?;
         if !info.is_dir() {
             return Err(Fat32Error::NotADirectory);
@@ -1025,6 +1054,30 @@ pub fn vfs_open(path: &str, flags: c_int) -> Result<c_int, Fat32Error> {
             flags & (file_access_mode::O_ACCMODE | file_status_flags::O_NONBLOCK);
         return alloc_fd_with_status(handle, status_flags);
     }
+
+    if matches!(devfs::resolve(&cwd, path)?, Some(DevicePath::Console)) {
+        if flags & file_creation_flags::O_CREAT != 0 && flags & file_creation_flags::O_EXCL != 0 {
+            return Err(Fat32Error::AlreadyExists);
+        }
+        if flags & file_access_mode::O_EXEC != 0 {
+            return Err(Fat32Error::PermissionDenied);
+        }
+        let access_mode: AccessMode = match flags & file_access_mode::O_ACCMODE {
+            file_access_mode::O_RDONLY => AccessMode::ReadOnly,
+            file_access_mode::O_WRONLY => AccessMode::WriteOnly,
+            file_access_mode::O_RDWR => AccessMode::ReadWrite,
+            _ => return Err(Fat32Error::InvalidArgument),
+        };
+        let handle: VfsFileHandle = VfsFileHandle::Terminal(TerminalHandle::new(
+            TerminalDevice::Console,
+            access_mode,
+            console_device(),
+        ));
+        let status_flags: c_int =
+            flags & (file_access_mode::O_ACCMODE | file_status_flags::O_NONBLOCK);
+        return alloc_fd_with_status(handle, status_flags);
+    }
+
     let handle: VfsFileHandle = open_adapter::open(&cwd, path, flags)?;
     let status_flags: c_int = flags & (file_access_mode::O_ACCMODE | file_status_flags::O_NONBLOCK);
     alloc_fd_with_status(handle, status_flags)
@@ -1305,6 +1358,9 @@ pub fn vfs_fstat(fd: c_int, buf: &mut ::sysapi::sys_stat::stat) -> Result<(), Fa
         },
         VfsFileHandle::Console(handle) => {
             populate_console_stat_fields(buf, handle.stream(), handle.created());
+        },
+        VfsFileHandle::Terminal(handle) => match handle.device() {
+            TerminalDevice::Console => *buf = devfs::console_posix_stat(),
         },
         VfsFileHandle::Socket(_) => {
             // TODO: Report socket metadata instead of treating the descriptor as a regular file.
@@ -1645,7 +1701,7 @@ pub fn vfs_ftruncate(fd: c_int, length: off_t) -> Result<(), Fat32Error> {
             }
         },
         VfsFileHandle::DirectRead(_) => Err(Fat32Error::ReadOnly),
-        VfsFileHandle::Null(_) => Err(Fat32Error::InvalidArgument),
+        VfsFileHandle::Null(_) | VfsFileHandle::Terminal(_) => Err(Fat32Error::InvalidArgument),
         VfsFileHandle::Directory(_)
         | VfsFileHandle::HostFs(_)
         | VfsFileHandle::Pipe(_)
@@ -1697,6 +1753,7 @@ pub fn vfs_fallocate(fd: c_int, offset: off_t, len: off_t) -> Result<(), Fat32Er
         | VfsFileHandle::Null(_)
         | VfsFileHandle::Pipe(_)
         | VfsFileHandle::Console(_)
+        | VfsFileHandle::Terminal(_)
         | VfsFileHandle::Socket(_) => Err(Fat32Error::NotSupported),
     }
 }
@@ -1710,7 +1767,7 @@ pub fn vfs_fsync(fd: c_int) -> Result<(), Fat32Error> {
     let entry: &mut VfsEntry = &mut guard;
     match &mut entry.handle {
         VfsFileHandle::Fat32(file) => file.flush(),
-        VfsFileHandle::Null(_) => Err(Fat32Error::InvalidArgument),
+        VfsFileHandle::Null(_) | VfsFileHandle::Terminal(_) => Err(Fat32Error::InvalidArgument),
         VfsFileHandle::DirectRead(_)
         | VfsFileHandle::Directory(_)
         | VfsFileHandle::HostFs(_)
@@ -1722,21 +1779,26 @@ pub fn vfs_fsync(fd: c_int) -> Result<(), Fat32Error> {
 
 /// Checks if a descriptor refers to a terminal.
 ///
-/// A descriptor is a terminal if and only if its slot in the current process resolves to the
-/// console backend. This makes `isatty` authoritative against the flat slot table: a duplicate of a
-/// console descriptor answers `true`, while a regular file, pipe, or socket answers `false`. A
-/// descriptor with no slot answers `false` (the caller maps the absent slot to `EBADF`).
+/// A descriptor is a terminal when its slot contains a seeded console stream or an opened named
+/// terminal. This makes `isatty` authoritative against the flat slot table: duplicates remain
+/// terminals, while regular files, pipes, and sockets do not. A descriptor with no slot answers
+/// `false` (the caller maps the absent slot to `EBADF`).
 pub fn vfs_isatty(fd: c_int) -> bool {
-    matches!(vfs_resolve(fd), Some((VfsRoute::Console, _)))
+    let Ok(file) = entry_arc(fd) else {
+        return false;
+    };
+    let is_terminal: bool =
+        matches!(&file.lock().handle, VfsFileHandle::Console(_) | VfsFileHandle::Terminal(_));
+    is_terminal
 }
 
-/// Returns the shared terminal device state of `fd` when it is a console descriptor.
+/// Returns the shared terminal device state of a seeded console or opened named terminal.
 ///
 /// The shared [`Arc`] is cloned out from under the registry lock and the per-entry lock is released
 /// before it is returned, so the caller may lock the terminal without nesting registry or entry
-/// locks. A descriptor with no slot yields [`TtyError::BadFd`]; a non-console descriptor yields
+/// locks. A descriptor with no slot yields [`TtyError::BadFd`]; a non-terminal descriptor yields
 /// [`TtyError::NotTty`].
-fn console_handle(fd: c_int) -> Result<(ConsoleStream, Arc<Mutex<LineDiscipline>>), TtyError> {
+fn terminal_handle(fd: c_int) -> Result<TerminalState, TtyError> {
     let file: OpenFile = {
         let procs: spin::MutexGuard<'_, BTreeMap<ProcessIdentifier, ProcessState>> =
             PROCESSES.lock();
@@ -1751,18 +1813,37 @@ fn console_handle(fd: c_int) -> Result<(ConsoleStream, Arc<Mutex<LineDiscipline>
     };
     let guard = file.lock();
     match &guard.handle {
-        VfsFileHandle::Console(h) => Ok((h.stream(), h.terminal().clone())),
+        VfsFileHandle::Console(handle) => {
+            let stream: ConsoleStream = handle.stream();
+            Ok(TerminalState {
+                stream: Some(stream),
+                terminal: handle.terminal().clone(),
+                readable: stream == ConsoleStream::Stdin,
+                writable: matches!(stream, ConsoleStream::Stdout | ConsoleStream::Stderr),
+            })
+        },
+        VfsFileHandle::Terminal(handle) => Ok(TerminalState {
+            stream: None,
+            terminal: handle.terminal().clone(),
+            readable: handle.readable(),
+            writable: handle.writable(),
+        }),
         _ => Err(TtyError::NotTty),
     }
 }
 
 /// Returns the console stream represented by descriptor `fd`.
 pub fn vfs_console_stream(fd: c_int) -> Result<ConsoleStream, TtyError> {
-    console_handle(fd).map(|(stream, _)| stream)
+    terminal_handle(fd).and_then(|state| state.stream.ok_or(TtyError::NotTty))
+}
+
+/// Returns the read and write access permitted by a terminal descriptor.
+pub fn vfs_terminal_access(fd: c_int) -> Result<(bool, bool), TtyError> {
+    terminal_handle(fd).map(|state| (state.readable, state.writable))
 }
 
 fn console_terminal(fd: c_int) -> Result<Arc<Mutex<LineDiscipline>>, TtyError> {
-    console_handle(fd).map(|(_, terminal)| terminal)
+    terminal_handle(fd).map(|state| state.terminal)
 }
 
 /// Reads the terminal attributes of the console descriptor `fd` (`TCGETS`/`tcgetattr`).
@@ -2370,8 +2451,8 @@ mod tests {
         let dev: Vec<filesystem::DirEntry> = vfs_readdir("/dev").expect("read /dev");
         assert_eq!(root.iter().map(|entry| entry.name()).collect::<Vec<_>>(), ["dev"]);
         assert_eq!(root[0].inode(), directory.st_ino);
-        assert_eq!(dev.iter().map(|entry| entry.name()).collect::<Vec<_>>(), ["null"]);
-        assert!(dev[0].is_character_device());
+        assert_eq!(dev.iter().map(|entry| entry.name()).collect::<Vec<_>>(), ["null", "console"]);
+        assert!(dev.iter().all(|entry| entry.is_character_device()));
 
         let fd: c_int = vfs_open("/dev", file_access_mode::O_RDONLY).expect("open /dev");
         let mut opened: ::sysapi::sys_stat::stat = ::sysapi::sys_stat::stat::default();
@@ -2524,6 +2605,67 @@ mod tests {
             vfs_open("/dev/null/", file_access_mode::O_RDONLY),
             Err(Fat32Error::NotADirectory)
         );
+        forget_processes(&[pid]);
+    }
+
+    /// Tests an opened console device independently of the standard descriptor slots.
+    #[test]
+    fn console_device_open_modes() {
+        let _guard = FORK_TEST_GUARD.lock();
+        if !crate::state::is_initialized() {
+            crate::state::init().expect("initialize VFS");
+        }
+        let pid: ProcessIdentifier = root_process_identifier();
+        vfs_seed_root_console(pid);
+        set_current_process(pid);
+
+        let redirected: c_int = vfs_alloc_hostfs(10, false, None).expect("open redirected file");
+        for fd in [STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO] {
+            vfs_dup2(redirected, fd).expect("redirect standard descriptor");
+        }
+        vfs_close(redirected).expect("close redirected file");
+        assert!(!vfs_isatty(STDIN_FILENO));
+        assert!(!vfs_isatty(STDOUT_FILENO));
+        assert!(!vfs_isatty(STDERR_FILENO));
+
+        assert_eq!(
+            vfs_open("/dev/console", file_access_mode::O_EXEC),
+            Err(Fat32Error::PermissionDenied)
+        );
+        let console_flags: c_int =
+            file_access_mode::O_RDWR | file_creation_flags::O_CREAT | file_creation_flags::O_TRUNC;
+        let directory: c_int = vfs_open("/dev/", file_access_mode::O_RDONLY).expect("open /dev/");
+        for flags in [file_access_mode::O_RDONLY, console_flags] {
+            assert_eq!(vfs_open("/dev/console/", flags), Err(Fat32Error::NotADirectory));
+            assert_eq!(vfs_openat(directory, "console/", flags), Err(Fat32Error::NotADirectory));
+        }
+        vfs_close(directory).expect("close /dev/");
+
+        let console: c_int = vfs_open("/dev/console", console_flags).expect("open console");
+        assert!(vfs_isatty(console));
+        assert_eq!(vfs_resolve(console), Some((VfsRoute::Terminal, console)));
+        assert_eq!(vfs_terminal_access(console), Ok((true, true)));
+
+        let resized: Winsize = Winsize {
+            ws_row: 40,
+            ws_col: 100,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        vfs_tty_set_winsize(console, resized).expect("set console winsize");
+        assert_eq!(vfs_tty_get_winsize(console), Ok(resized));
+
+        let mut path: ::sysapi::sys_stat::stat = ::sysapi::sys_stat::stat::default();
+        let mut descriptor: ::sysapi::sys_stat::stat = ::sysapi::sys_stat::stat::default();
+        vfs_stat("/dev/console", &mut path).expect("stat console");
+        vfs_fstat(console, &mut descriptor).expect("fstat console");
+        assert_eq!(descriptor.st_ino, path.st_ino);
+
+        let exclusive_flags: c_int =
+            file_access_mode::O_WRONLY | file_creation_flags::O_CREAT | file_creation_flags::O_EXCL;
+        assert_eq!(vfs_open("/dev/console", exclusive_flags), Err(Fat32Error::AlreadyExists));
+
+        vfs_close(console).expect("close console");
         forget_processes(&[pid]);
     }
 

--- a/src/libs/vfs/src/fd/open.rs
+++ b/src/libs/vfs/src/fd/open.rs
@@ -143,7 +143,7 @@ pub fn open(cwd: &str, path: &str, flags: c_int) -> Result<VfsFileHandle, Fat32E
             return Err(Fat32Error::NotFound);
         },
         Some(DevicePath::Directory) => return Err(Fat32Error::NotAFile),
-        None => {},
+        Some(DevicePath::Console) | None => {},
     }
 
     // Try zero-copy direct read for read-only opens of contiguous files.

--- a/src/libs/vfs/src/filesystem.rs
+++ b/src/libs/vfs/src/filesystem.rs
@@ -200,7 +200,7 @@ pub(crate) fn set_times(
 /// - [POSIX mkdir()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/mkdir.html)
 pub(crate) fn mkdir(cwd: &str, path: &str) -> Result<(), Fat32Error> {
     match devfs::resolve(cwd, path)? {
-        Some(DevicePath::Directory | DevicePath::Null) => {
+        Some(DevicePath::Directory | DevicePath::Null | DevicePath::Console) => {
             return Err(Fat32Error::AlreadyExists);
         },
         Some(DevicePath::Missing) => return Err(Fat32Error::PermissionDenied),
@@ -477,7 +477,9 @@ pub(crate) fn normalize(cwd: &str, path: &str) -> Result<String, Fat32Error> {
 /// Rejects mutation of an existing synthetic device-namespace entry.
 fn reject_device_mutation(cwd: &str, path: &str) -> Result<(), Fat32Error> {
     match devfs::resolve(cwd, path)? {
-        Some(DevicePath::Directory | DevicePath::Null) => Err(Fat32Error::PermissionDenied),
+        Some(DevicePath::Directory | DevicePath::Null | DevicePath::Console) => {
+            Err(Fat32Error::PermissionDenied)
+        },
         Some(DevicePath::Missing) => Err(Fat32Error::NotFound),
         None => Ok(()),
     }
@@ -486,9 +488,9 @@ fn reject_device_mutation(cwd: &str, path: &str) -> Result<(), Fat32Error> {
 /// Rejects a valid rename destination in the synthetic device namespace.
 fn reject_device_destination(cwd: &str, path: &str) -> Result<(), Fat32Error> {
     match devfs::resolve(cwd, path)? {
-        Some(DevicePath::Directory | DevicePath::Null | DevicePath::Missing) => {
-            Err(Fat32Error::PermissionDenied)
-        },
+        Some(
+            DevicePath::Directory | DevicePath::Null | DevicePath::Console | DevicePath::Missing,
+        ) => Err(Fat32Error::PermissionDenied),
         None => Ok(()),
     }
 }
@@ -555,7 +557,9 @@ pub(crate) fn open_with_options(
     }
 
     match devfs::resolve(cwd, path)? {
-        Some(DevicePath::Directory | DevicePath::Null) => return Err(Fat32Error::NotAFile),
+        Some(DevicePath::Directory | DevicePath::Null | DevicePath::Console) => {
+            return Err(Fat32Error::NotAFile);
+        },
         Some(DevicePath::Missing) if create || create_new => {
             return Err(Fat32Error::PermissionDenied);
         },

--- a/src/tests/integration/test-c-file/common.h
+++ b/src/tests/integration/test-c-file/common.h
@@ -128,6 +128,7 @@ extern void test_renameat_subdir(void);
 
 // Tests whether we can get file status information.
 extern void test_stat(void);
+extern void test_terminal_devices(void);
 
 // Tests whether we can create a symbolic link to a file.
 extern void test_symlinkat(void);

--- a/src/tests/integration/test-c-file/device_namespace.c
+++ b/src/tests/integration/test-c-file/device_namespace.c
@@ -3,6 +3,10 @@
  * Licensed under the MIT License.
  */
 
+//==================================================================================================
+// Imports
+//==================================================================================================
+
 #include <assert.h>
 #include <dirent.h>
 #include <errno.h>
@@ -14,20 +18,30 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-// Tests the synthetic namespace and null device.
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests pathname, metadata, enumeration, null I/O, and mutation behavior for /dev.
 void test_device_namespace(void)
 {
     struct stat directory = {0};
-    struct stat null = {0};
+    struct stat devices[2] = {{0}};
+    const char *paths[2] = {"/dev/null", "/dev/console"};
+
     assert(stat("/dev", &directory) == 0);
     assert(S_ISDIR(directory.st_mode));
-    assert(stat("/dev/null", &null) == 0);
-    assert(S_ISCHR(null.st_mode));
-    assert(null.st_dev == directory.st_dev);
-    assert(null.st_ino != directory.st_ino);
-    assert(null.st_rdev != 0);
-    assert(null.st_size == 0);
-    assert(null.st_blocks == 0);
+    for (int i = 0; i < 2; i++) {
+        assert(stat(paths[i], &devices[i]) == 0);
+        assert(S_ISCHR(devices[i].st_mode));
+        assert(devices[i].st_dev == directory.st_dev);
+        assert(devices[i].st_ino != directory.st_ino);
+        assert(devices[i].st_rdev != 0);
+        assert(devices[i].st_size == 0);
+        assert(devices[i].st_blocks == 0);
+    }
+    assert(devices[0].st_ino != devices[1].st_ino);
+    assert(devices[0].st_rdev != devices[1].st_rdev);
 
     struct stat missing = {0};
     errno = 0;
@@ -49,11 +63,17 @@ void test_device_namespace(void)
 
     DIR *dev = opendir("/dev");
     assert(dev != NULL);
-    entry = readdir(dev);
-    assert(entry != NULL);
-    assert(strcmp(entry->d_name, "null") == 0);
-    assert(entry->d_ino == null.st_ino);
-    assert(readdir(dev) == NULL);
+    bool found[2] = {false, false};
+    while ((entry = readdir(dev)) != NULL) {
+        for (int i = 0; i < 2; i++) {
+            const char *name = paths[i] + strlen("/dev/");
+            if (strcmp(entry->d_name, name) == 0) {
+                found[i] = true;
+                assert(entry->d_ino == devices[i].st_ino);
+            }
+        }
+    }
+    assert(found[0] && found[1]);
     assert(closedir(dev) == 0);
 
     int nullfd = open("/dev/null", O_RDWR);
@@ -71,17 +91,15 @@ void test_device_namespace(void)
     assert(read(nullfd, buffer, sizeof(buffer)) == 0);
     struct stat opened = {0};
     assert(fstat(nullfd, &opened) == 0);
-    assert(opened.st_dev == null.st_dev);
-    assert(opened.st_ino == null.st_ino);
-    assert(opened.st_rdev == null.st_rdev);
+    assert(opened.st_dev == devices[0].st_dev);
+    assert(opened.st_ino == devices[0].st_ino);
+    assert(opened.st_rdev == devices[0].st_rdev);
     assert(close(nullfd) == 0);
 
-    nullfd = open("/dev/null", O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    int flags = O_WRONLY | O_CREAT | O_TRUNC;
+    nullfd = open("/dev/null", flags, 0600);
     assert(nullfd >= 0);
     assert(write(nullfd, "discarded", 9) == 9);
-    errno = 0;
-    assert(read(nullfd, buffer, sizeof(buffer)) == -1);
-    assert(errno == EBADF);
     assert(close(nullfd) == 0);
 
     errno = 0;
@@ -100,6 +118,13 @@ void test_device_namespace(void)
     };
     assert(poll(&pollfd, 1, 0) == 1);
     assert((pollfd.revents & (POLLIN | POLLOUT)) == (POLLIN | POLLOUT));
+    assert(close(nullfd) == 0);
+
+    nullfd = open("/dev/null", O_WRONLY);
+    assert(nullfd >= 0);
+    errno = 0;
+    assert(read(nullfd, buffer, sizeof(buffer)) == -1);
+    assert(errno == EBADF);
     assert(close(nullfd) == 0);
 
     errno = 0;

--- a/src/tests/integration/test-c-file/main.c
+++ b/src/tests/integration/test-c-file/main.c
@@ -130,6 +130,7 @@ int main(int argc, const char *argv[])
     test_fdatasync();       // requires open(), close(), read(), write(), and unlink().
     test_stat();
     test_device_namespace();
+    test_terminal_devices();
     test_ftruncate(); // requires open(), close(), fstat() and unlink().
     test_truncate();  // requires open(), close(), stat() and unlinkat().
 #ifndef __NANVIX_STANDALONE__

--- a/src/tests/integration/test-c-file/terminal_devices.c
+++ b/src/tests/integration/test-c-file/terminal_devices.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright(c) The Maintainers of Nanvix.
+ * Licensed under the MIT License.
+ */
+
+//==================================================================================================
+// Imports
+//==================================================================================================
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <termios.h>
+#include <unistd.h>
+
+//==================================================================================================
+// Standalone Functions
+//==================================================================================================
+
+// Tests the system console independently of the standard descriptor slots.
+void test_terminal_devices(void)
+{
+    int dev = open("/dev/", O_RDONLY | O_DIRECTORY);
+    assert(dev >= 0);
+    const int modes[] = {O_RDONLY, O_WRONLY, O_RDWR, O_WRONLY | O_CREAT | O_TRUNC};
+    for (unsigned int i = 0; i < sizeof(modes) / sizeof(modes[0]); i++) {
+        errno = 0;
+        assert(open("/dev/console/", modes[i], 0) == -1);
+        assert(errno == ENOTDIR);
+        errno = 0;
+        assert(openat(dev, "console/", modes[i], 0) == -1);
+        assert(errno == ENOTDIR);
+    }
+    assert(close(dev) == 0);
+
+    int saved[3] = {dup(STDIN_FILENO), dup(STDOUT_FILENO), dup(STDERR_FILENO)};
+    assert(saved[0] >= 0);
+    assert(saved[1] >= 0);
+    assert(saved[2] >= 0);
+
+    int redirected = open("terminal-redirection.tmp", O_CREAT | O_RDWR, 0600);
+    assert(redirected >= 0);
+    assert(dup2(redirected, STDIN_FILENO) == STDIN_FILENO);
+    assert(dup2(redirected, STDOUT_FILENO) == STDOUT_FILENO);
+    assert(dup2(redirected, STDERR_FILENO) == STDERR_FILENO);
+
+    int console = open("/dev/console", O_WRONLY | O_CREAT | O_TRUNC, 0);
+    assert(console >= 0);
+    assert(isatty(console) == 1);
+
+    struct termios attrs;
+    assert(tcgetattr(console, &attrs) == 0);
+
+    struct pollfd output = {
+        .fd = console,
+        .events = POLLOUT,
+        .revents = 0,
+    };
+    assert(poll(&output, 1, 0) == 1);
+    assert(output.revents & POLLOUT);
+    assert(write(console, ".", 1) == 1);
+
+    assert(close(console) == 0);
+    assert(dup2(saved[0], STDIN_FILENO) == STDIN_FILENO);
+    assert(dup2(saved[1], STDOUT_FILENO) == STDOUT_FILENO);
+    assert(dup2(saved[2], STDERR_FILENO) == STDERR_FILENO);
+    assert(close(saved[0]) == 0);
+    assert(close(saved[1]) == 0);
+    assert(close(saved[2]) == 0);
+    assert(close(redirected) == 0);
+    assert(unlink("terminal-redirection.tmp") == 0);
+}


### PR DESCRIPTION
## Summary

Adds `/dev/console` as a synthetic character device backed by the existing console line discipline, independent of standard-descriptor redirection.

- Supports terminal I/O, controls, polling, and character-device metadata.
- Preserves access modes, trailing-slash validation, and interrupted-read cancellation.
- Models read backends explicitly and separates pure routing logic from guest runtime dependencies, allowing its tests to run in normal host CI.

Part of #3122. Builds on merged #3149; `/dev/tty` follows separately.

## Validation

- Debug build, formatting, lint, and spellcheck passed.
- 87 syscall host tests, including all three routing tests, and 177 VFS unit tests passed.
- `test-c-file`, `test-c-termios`, and `test-c-signal-rpc` guest suites passed under Linux/KVM.
- An ad hoc guest probe verified interrupted console reads return `EINTR` and leave subsequent reads usable.
